### PR TITLE
chore: make lens value covariant

### DIFF
--- a/src/kups/core/lens.py
+++ b/src/kups/core/lens.py
@@ -126,8 +126,8 @@ _NOT_SET = _NOT_SET_TYPE.OBJ
 
 
 S = TypeVar("S", covariant=True)
-R = TypeVar("R")
-R2 = TypeVar("R2")
+R = TypeVar("R", covariant=True)
+R2 = TypeVar("R2", covariant=True)
 
 
 @runtime_checkable
@@ -151,14 +151,14 @@ class Lens(Protocol[S, R]):
     """
 
     @overload
-    def __call__[S2](self: Lens[S2, R], state: S2, /, value: R) -> S2: ...
+    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /, value: R2) -> S2: ...
 
     @overload
-    def __call__[S2](self: Lens[S2, R], state: S2, /) -> R: ...
+    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /) -> R2: ...
 
-    def __call__[S2](
-        self: Lens[S2, R], state: S2, /, value: R | _NOT_SET_TYPE = _NOT_SET
-    ) -> S2 | R:
+    def __call__[S2, R2](
+        self: Lens[S2, R2], state: S2, /, value: R2 | _NOT_SET_TYPE = _NOT_SET
+    ) -> S2 | R2:
         """Get or set the focused value, satisfying View and Update protocols.
 
         When called with one argument, acts as a View and returns the focused value.
@@ -195,7 +195,7 @@ class Lens(Protocol[S, R]):
         """
         ...
 
-    def set[S2](self: Lens[S2, R], state: S2, /, value: R) -> S2:
+    def set[S2, R2](self: Lens[S2, R2], state: S2, /, value: R2) -> S2:
         """Set the focused value in the data structure.
 
         Args:
@@ -207,7 +207,7 @@ class Lens(Protocol[S, R]):
         """
         ...
 
-    def apply[S2](self: Lens[S2, R], state: S2, /, modifier: Modifier[R]) -> S2:
+    def apply[S2, R2](self: Lens[S2, R2], state: S2, /, modifier: Modifier[R2]) -> S2:
         """Apply a modifier function to the focused value.
 
         Args:
@@ -256,7 +256,7 @@ class Lens(Protocol[S, R]):
         """
         ...
 
-    def nest[U](self, other: Lens[R, U]) -> Lens[S, U]:
+    def nest[U, S2, R2](self: Lens[S2, R2], other: Lens[R2, U]) -> Lens[S2, U]:
         """Nest another lens or view within this lens.
 
         This provides an alternative to focus() that works with both lenses and views.
@@ -290,12 +290,14 @@ class BoundLens(Protocol[S, R]):
     """
 
     @overload
-    def __call__(self, value: R) -> S: ...
+    def __call__[R2](self: BoundLens[S, R2], value: R2) -> S: ...
 
     @overload
     def __call__(self) -> R: ...
 
-    def __call__(self, value: R | _NOT_SET_TYPE = _NOT_SET) -> S | R:
+    def __call__[R2](
+        self: BoundLens[S, R2], value: R2 | _NOT_SET_TYPE = _NOT_SET
+    ) -> S | R2:
         """Get or set the focused value in the bound state.
 
         When called with no arguments, returns the focused value.
@@ -309,7 +311,9 @@ class BoundLens(Protocol[S, R]):
         """
         ...
 
-    def focus[B](self, where: Callable[[R], B]) -> BoundLens[S, B]:
+    def focus[B, R2](
+        self: BoundLens[S, R2], where: Callable[[R2], B]
+    ) -> BoundLens[S, B]:
         """Focus this bound lens on a deeper part of the data structure.
 
         Args:
@@ -328,7 +332,7 @@ class BoundLens(Protocol[S, R]):
         """
         ...
 
-    def set(self, value: R) -> S:
+    def set[R2](self: BoundLens[S, R2], value: R2) -> S:
         """Set the focused value in the bound data structure.
 
         Args:
@@ -339,7 +343,7 @@ class BoundLens(Protocol[S, R]):
         """
         ...
 
-    def apply(self, modifier: Modifier[R]) -> S:
+    def apply[R2](self: BoundLens[S, R2], modifier: Modifier[R2]) -> S:
         """Apply a modifier function to the focused value in the bound data structure.
 
         Args:
@@ -366,9 +370,9 @@ class BoundLens(Protocol[S, R]):
         """
         ...
 
-    def merge[S2, R2](
-        self: BoundLens[S2, R], other: Lens[S2, R2]
-    ) -> BoundLens[S2, tuple[R, R2]]:
+    def merge[S2, R2, R3](
+        self: BoundLens[S2, R2], other: Lens[S2, R3]
+    ) -> BoundLens[S2, tuple[R2, R3]]:
         """Merge this lens with another lens to access multiple values.
 
         Args:
@@ -379,7 +383,7 @@ class BoundLens(Protocol[S, R]):
         """
         ...
 
-    def nest[U](self, other: Lens[R, U]) -> BoundLens[S, U]:
+    def nest[U, R2](self: BoundLens[S, R2], other: Lens[R2, U]) -> BoundLens[S, U]:
         """Nest another lens or view within this bound lens.
 
         This provides an alternative to focus() that works with both lenses and views.
@@ -395,7 +399,7 @@ class BoundLens(Protocol[S, R]):
         ...
 
 
-class BaseLens(Lens[S, R]):
+class BaseLens(Lens[S, R], abc.ABC):
     """Base class for lens implementations."""
 
     def focus[B](self, where: Callable[[R], B]) -> Lens[S, B]:
@@ -418,21 +422,21 @@ class BaseLens(Lens[S, R]):
     ) -> Lens[S2, tuple[R, R2]]:
         return MergedLens(self, other)
 
-    def nest[U](self, other: Lens[R, U]) -> Lens[S, U]:
+    def nest[U, R2](self: Lens[S, R2], other: Lens[R2, U]) -> Lens[S, U]:
         view_func = other.get if isinstance(other, Lens) else other
         return self.focus(view_func)
 
     @overload
-    def __call__[S2](self: Lens[S2, R], state: S2, /, value: R) -> S2: ...
+    def __call__[S2, R2](self: Lens[S2, R2], state: S2, /, value: R2) -> S2: ...
 
     @overload
-    def __call__[S2](
-        self: Lens[S2, R], state: S2, /, value: _NOT_SET_TYPE = _NOT_SET
-    ) -> R: ...
+    def __call__[S2, R2](
+        self: Lens[S2, R2], state: S2, /, value: _NOT_SET_TYPE = _NOT_SET
+    ) -> R2: ...
 
-    def __call__[S2](
-        self: Lens[S2, R], state: S2, /, value: R | _NOT_SET_TYPE = _NOT_SET
-    ) -> S2 | R:
+    def __call__[S2, R2](
+        self: Lens[S2, R2], state: S2, /, value: R2 | _NOT_SET_TYPE = _NOT_SET
+    ) -> S2 | R2:
         if value is _NOT_SET:
             return self.get(state)
         else:
@@ -458,7 +462,7 @@ class SimpleLens(BaseLens[S, R]):
         """Get the focused value using the provided view function."""
         return self._get(state)
 
-    def set[S2](self: SimpleLens[S2, R], state: S2, value: R) -> S2:
+    def set[S2, R2](self: SimpleLens[S2, R2], state: S2, value: R2) -> S2:
         """Set the focused value using traversal lens."""
         try:
             return _traversal_lens(self.get, cls=type(state)).set(state, value)
@@ -479,7 +483,7 @@ class ConstLens(BaseLens[S, R]):
     def get[S2](self: ConstLens[S2, R], state: S2) -> R:
         return self.value
 
-    def set[S2](self: ConstLens[S2, R], state: S2, value: R) -> S2:
+    def set[S2, R2](self: ConstLens[S2, R2], state: S2, value: R2) -> S2:
         return state
 
 
@@ -502,7 +506,11 @@ class MergedLens(BaseLens[S, tuple[R, R2]]):
     def get[S2](self: MergedLens[S2, R, R2], state: S2) -> tuple[R, R2]:
         return self.left.get(state), self.right.get(state)
 
-    def set[S2](self: MergedLens[S2, R, R2], state: S2, value: tuple[R, R2]) -> S2:
+    # pyright throws: "object*" is not assignable to "tuple[R3@set, R4@set]"
+    # It sounds like an inference issue as I cannot follow where object* is inferred.
+    def set[S2, R3, R4](  # type: ignore[reportIncompatibleMethodOverride]
+        self: MergedLens[S2, R3, R4], state: S2, /, value: tuple[R3, R4]
+    ) -> S2:
         state = self.left.set(state, value[0])
         return self.right.set(state, value[1])
 
@@ -523,7 +531,7 @@ class NestedLens(BaseLens[S, R2], Generic[S, R, R2]):
         """Get value by applying outer lens then inner lens."""
         return self.inner.get(self.outer.get(state))
 
-    def set[S2](self: NestedLens[S2, R, R2], state: S2, value: R2) -> S2:
+    def set[S2, R3](self: NestedLens[S2, R, R3], state: S2, value: R3) -> S2:
         """Set value by getting outer value, setting inner value, then setting outer."""
         inner = self.inner.set(self.outer.get(state), value)
         return self.outer.set(state, inner)
@@ -548,7 +556,7 @@ class SimpleBoundLens(BoundLens[S, R]):
         """Get the focused value from the bound target."""
         return self.lens.get(self.target)
 
-    def set(self, value: R) -> S:
+    def set[R2](self: SimpleBoundLens[S, R2], value: R2) -> S:
         """Set the focused value in the bound target."""
         return self.lens.set(self.target, value)
 
@@ -566,17 +574,21 @@ class SimpleBoundLens(BoundLens[S, R]):
         """Merge this bound lens with another lens to access multiple values."""
         return self.lens.merge(other).bind(self.target)
 
-    def nest[U](self, other: Lens[R, U]) -> BoundLens[S, U]:
+    def nest[U, R2](
+        self: SimpleBoundLens[S, R2], other: Lens[R2, U]
+    ) -> BoundLens[S, U]:
         """Nest another lens or view within this bound lens."""
         return self.lens.nest(other).bind(self.target)
 
     @overload
-    def __call__(self, value: R) -> S: ...
+    def __call__[R2](self: SimpleBoundLens[S, R2], value: R2) -> S: ...
 
     @overload
     def __call__(self, value: _NOT_SET_TYPE = _NOT_SET) -> R: ...
 
-    def __call__(self, value: R | _NOT_SET_TYPE = _NOT_SET) -> S | R:
+    def __call__[R2](
+        self: SimpleBoundLens[S, R2], value: R2 | _NOT_SET_TYPE = _NOT_SET
+    ) -> S | R2:
         if value is _NOT_SET:
             return self.get()
         else:
@@ -598,7 +610,7 @@ class LambdaLens(BaseLens[S, R]):
         """Get the focused value using the custom getter function."""
         return self._get(state)
 
-    def set[S2](self: LambdaLens[S2, R], state: S2, value: R) -> S2:
+    def set[S2, R2](self: LambdaLens[S2, R2], state: S2, value: R2) -> S2:
         """Set the focused value using the custom setter function."""
         return self._set(state, value)
 
@@ -640,7 +652,7 @@ class IndexLens(BaseLens[S, R]):
             is_leaf=lambda x: isinstance(x, (Array, HasScatterArgs)),
         )
 
-    def set[S2](self: IndexLens[S2, R], state: S2, value: R) -> S2:
+    def set[S2, R2](self: IndexLens[S2, R2], state: S2, value: R2) -> S2:
         """Set values by applying array indexing to the focused data."""
         return self.lens.set(
             state, tree_scatter_set(self.lens.get(state), value, self.idxs, self.args)

--- a/src/kups/core/neighborlist.py
+++ b/src/kups/core/neighborlist.py
@@ -952,8 +952,8 @@ class DenseNearestNeighborList:
         )
 
     @classmethod
-    def from_state[P: IsDenseNeighborlistParams](
-        cls, state: IsNeighborListState[P]
+    def from_state(
+        cls, state: IsNeighborListState[IsDenseNeighborlistParams]
     ) -> DenseNearestNeighborList:
         return cls.new(state, lens(lambda s: s.neighborlist_params))
 

--- a/src/kups/core/typing.py
+++ b/src/kups/core/typing.py
@@ -401,6 +401,9 @@ class HasCache[Data, Cache](Protocol):
     def cache(self) -> Cache: ...
 
 
+type MaybeCached[P, C] = P | HasCache[P, C]
+
+
 @runtime_checkable
 class HasMotifAndSystemIndex(HasMotifIndex, HasSystemIndex, Protocol):
     """Protocol for entities with both motif and system indices."""

--- a/src/kups/mcmc/moves.py
+++ b/src/kups/mcmc/moves.py
@@ -913,12 +913,8 @@ def _sched(params_lens: Lens) -> PropertyScheduler:
     return PropertyScheduler(params_lens, Table.transform(acceptance_target_schedule))
 
 
-def make_group_translation_mcmc_propagator[
-    State,
-    InState: IsTranslationState,
-    Move: Patch,
-](
-    state: Lens[State, InState],
+def make_group_translation_mcmc_propagator[State, Move: Patch](
+    state: Lens[State, IsTranslationState],
     patch_fn: PatchFn[State, ParticlePositionChanges, Move],
     probability_fn: LogProbabilityRatioFn[State, Move],
 ) -> MCMCPropagator[State, ParticlePositionChanges, Move]:
@@ -941,12 +937,8 @@ def make_group_translation_mcmc_propagator[
     )
 
 
-def make_group_rotation_mcmc_propagator[
-    State,
-    InState: IsRotationState,
-    Move: Patch,
-](
-    state: Lens[State, InState],
+def make_group_rotation_mcmc_propagator[State, Move: Patch](
+    state: Lens[State, IsRotationState],
     patch_fn: PatchFn[State, ParticlePositionChanges, Move],
     probability_fn: LogProbabilityRatioFn[State, Move],
 ) -> MCMCPropagator[State, ParticlePositionChanges, Move]:
@@ -968,12 +960,8 @@ def make_group_rotation_mcmc_propagator[
     )
 
 
-def make_reinsertion_mcmc_propagator[
-    State,
-    InState: IsReinsertionState,
-    Move: Patch,
-](
-    state: Lens[State, InState],
+def make_reinsertion_mcmc_propagator[State, Move: Patch](
+    state: Lens[State, IsReinsertionState],
     patch_fn: PatchFn[State, ParticlePositionChanges, Move],
     probability_fn: LogProbabilityRatioFn[State, Move],
 ) -> MCMCPropagator[State, ParticlePositionChanges, Move]:
@@ -992,12 +980,8 @@ def make_reinsertion_mcmc_propagator[
     )
 
 
-def make_displacement_mcmc_propagator[
-    State,
-    InState: IsDisplacementState,
-    Move: Patch,
-](
-    state: Lens[State, InState],
+def make_displacement_mcmc_propagator[State, Move: Patch](
+    state: Lens[State, IsDisplacementState],
     patch_fn: PatchFn[State, ParticlePositionChanges, Move],
     probability_fn: LogProbabilityRatioFn[State, Move],
     *,
@@ -1070,12 +1054,8 @@ def make_displacement_mcmc_propagator[
     )
 
 
-def make_exchange_mcmc_propagator[
-    State,
-    InState: IsExchangeState,
-    Move: Patch,
-](
-    state: Lens[State, InState],
+def make_exchange_mcmc_propagator[State, Move: Patch](
+    state: Lens[State, IsExchangeState],
     patch_fn: PatchFn[State, ExchangeChanges, Move],
     probability_fn: LogProbabilityRatioFn[State, Move],
 ) -> MCMCPropagator[State, ExchangeChanges, Move]:
@@ -1095,12 +1075,8 @@ def make_exchange_mcmc_propagator[
     )
 
 
-def make_gcmc_mcmc_propagator[
-    State,
-    InState: IsGCMCState,
-    Move: Patch,
-](
-    state: Lens[State, InState],
+def make_gcmc_mcmc_propagator[State, Move: Patch](
+    state: Lens[State, IsGCMCState],
     patch_fn: PatchFn[State, ExchangeChanges, Move],
     probability_fn: LogProbabilityRatioFn[State, Move],
     *,

--- a/src/kups/mcmc/probability.py
+++ b/src/kups/mcmc/probability.py
@@ -292,8 +292,8 @@ class IsMuVTState(Protocol):
     def systems(self) -> Table[SystemId, MuVTSystems]: ...
 
 
-def make_boltzmann_probability_ratio[State, InpState: IsBoltzmannState, Move: Patch](
-    state: Lens[State, InpState], potential: Potential[State, Any, Any, Move]
+def make_boltzmann_probability_ratio[State, Move: Patch](
+    state: Lens[State, IsBoltzmannState], potential: Potential[State, Any, Any, Move]
 ) -> tuple[
     CachedPotential[State, EmptyType, EmptyType, Move],
     BoltzmannLogProbabilityRatio[State, Move],
@@ -331,8 +331,8 @@ def make_boltzmann_probability_ratio[State, InpState: IsBoltzmannState, Move: Pa
     )
 
 
-def make_fugacity_probability_ratio[State, InpState: IsFugacityState, Move: Patch](
-    state: Lens[State, InpState],
+def make_fugacity_probability_ratio[State, Move: Patch](
+    state: Lens[State, IsFugacityState],
 ) -> LogFugacityRatio[State, Any]:
     """Build the fugacity (chemical potential) acceptance criterion for GCMC.
 
@@ -366,8 +366,8 @@ def make_fugacity_probability_ratio[State, InpState: IsFugacityState, Move: Patc
     )
 
 
-def make_muvt_probability_ratio[State, InpState: IsMuVTState, Move: Patch](
-    state: Lens[State, InpState], potential: Potential[State, Any, Any, Move]
+def make_muvt_probability_ratio[State, Move: Patch](
+    state: Lens[State, IsMuVTState], potential: Potential[State, Any, Any, Move]
 ) -> tuple[
     CachedPotential[State, EmptyType, EmptyType, Move],
     MuVTLogProbabilityRatio[State, Move],

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -160,7 +160,7 @@ class _PositionStepData(
 
 
 @dataclass
-class PositionStep[State, Data: _PositionStepData](Propagator[State]):
+class PositionStep[State](Propagator[State]):
     """Update positions using velocities in molecular dynamics.
 
     Implements the 'A' operator in splitting schemes, propagating positions
@@ -175,7 +175,6 @@ class PositionStep[State, Data: _PositionStepData](Propagator[State]):
 
     Type Parameters:
         State: Simulation state type
-        Data: Particle data type (must have momenta, positions, masses, system index)
 
     Attributes:
         particles: Lens to get/set indexed particle data (momenta $\\mathbf{p}$, positions $\\mathbf{r}$, masses $m$)
@@ -183,7 +182,7 @@ class PositionStep[State, Data: _PositionStepData](Propagator[State]):
         flow: Flow operator defining how positions evolve (handles boundary conditions)
     """
 
-    particles: Lens[State, Table[ParticleId, Data]] = field(static=True)
+    particles: Lens[State, Table[ParticleId, _PositionStepData]] = field(static=True)
     systems: View[State, Table[SystemId, HasTimeStep]] = field(static=True)
     flow: Flow[State, Array] = field(static=True)
 
@@ -216,7 +215,7 @@ class IsMomentumStepData(HasMomenta, HasForces, HasSystemIndex, Protocol): ...
 
 
 @dataclass
-class MomentumStep[State, Data: IsMomentumStepData](Propagator[State]):
+class MomentumStep[State](Propagator[State]):
     """Update momenta using forces according to Newton's second law.
 
     Implements the 'B' operator in splitting schemes, applying forces to
@@ -231,14 +230,13 @@ class MomentumStep[State, Data: IsMomentumStepData](Propagator[State]):
 
     Type Parameters:
         State: Simulation state type
-        Data: Particle data type (must have momenta, forces, system index)
 
     Attributes:
         particles: Lens to get/set indexed particle data (momenta $\\mathbf{p}$, forces $\\mathbf{F}$)
         systems: View to extract system data with time step $\\Delta t$
     """
 
-    particles: Lens[State, Table[ParticleId, Data]] = field(static=True)
+    particles: Lens[State, Table[ParticleId, IsMomentumStepData]] = field(static=True)
     systems: View[State, Table[SystemId, HasTimeStep]] = field(static=True)
 
     def __call__(self, key: Array, state: State) -> State:
@@ -272,8 +270,8 @@ class _MDParticleData(
     def position_gradients(self) -> Array: ...
 
 
-def make_velocity_verlet_step[State, Data: _MDParticleData](
-    particles: Lens[State, Table[ParticleId, Data]],
+def make_velocity_verlet_step[State](
+    particles: Lens[State, Table[ParticleId, _MDParticleData]],
     systems: View[State, Table[SystemId, HasTimeStep]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
@@ -330,7 +328,7 @@ class _StochasticSysData(
 
 
 @dataclass
-class StochasticStep[State, Data: IsStochasticParticleData](Propagator[State]):
+class StochasticStep[State](Propagator[State]):
     """Langevin thermostat stochastic step with exact Ornstein-Uhlenbeck solution.
 
     Implements the 'O' operator in the BAOAB splitting scheme. This step
@@ -347,7 +345,6 @@ class StochasticStep[State, Data: IsStochasticParticleData](Propagator[State]):
 
     Type Parameters:
         State: Simulation state type
-        Data: Particle data type (must have momenta, masses, system index)
 
     Attributes:
         particles: Lens to get/set indexed particle data (momenta $\\mathbf{p}$, masses $m$)
@@ -361,7 +358,9 @@ class StochasticStep[State, Data: IsStochasticParticleData](Propagator[State]):
         DOI: 10.1093/amrx/abs010
     """
 
-    particles: Lens[State, Table[ParticleId, Data]] = field(static=True)
+    particles: Lens[State, Table[ParticleId, IsStochasticParticleData]] = field(
+        static=True
+    )
     system: View[State, Table[SystemId, _StochasticSysData]] = field(static=True)
 
     def __call__(self, key: Array, state: State) -> State:
@@ -403,8 +402,8 @@ class StochasticStep[State, Data: IsStochasticParticleData](Propagator[State]):
         )
 
 
-def make_baoab_langevin_step[State, Data: _MDParticleData](
-    particles: Lens[State, Table[ParticleId, Data]],
+def make_baoab_langevin_step[State](
+    particles: Lens[State, Table[ParticleId, _MDParticleData]],
     systems: View[State, Table[SystemId, _StochasticSysData]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
@@ -468,10 +467,7 @@ class IsCSVRParticleData(HasMomenta, HasMasses, HasSystemIndex, Protocol): ...
 
 
 @dataclass
-class CSVRStep[
-    State,
-    Data: IsCSVRParticleData,
-](Propagator[State]):
+class CSVRStep[State](Propagator[State]):
     r"""Canonical Sampling through Velocity Rescaling (CSVR) thermostat step.
 
     Implements the Bussi-Donadio-Parrinello algorithm for canonical sampling
@@ -496,7 +492,6 @@ class CSVRStep[
 
     Type Parameters:
         State: Simulation state type
-        Data: Particle data type (must have momenta, masses, system index)
 
     Attributes:
         particles: Lens to get/set indexed particle data (momenta $\\mathbf{p}$, masses $m$)
@@ -509,7 +504,7 @@ class CSVRStep[
         DOI: 10.1063/1.2408420
     """
 
-    particles: Lens[State, Table[ParticleId, Data]] = field(static=True)
+    particles: Lens[State, Table[ParticleId, IsCSVRParticleData]] = field(static=True)
     systems: View[State, Table[SystemId, _CSVRSystemData]] = field(static=True)
 
     def __call__(self, key: Array, state: State) -> State:
@@ -590,8 +585,8 @@ class CSVRStep[
         )
 
 
-def make_csvr_step[State, Data: _MDParticleData](
-    particles: Lens[State, Table[ParticleId, Data]],
+def make_csvr_step[State](
+    particles: Lens[State, Table[ParticleId, _MDParticleData]],
     systems: View[State, Table[SystemId, _CSVRSystemData]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
@@ -659,11 +654,7 @@ class _BarostatParticleData(_MDParticleData, Protocol): ...
 
 
 @dataclass
-class StochasticCellRescalingStep[
-    State,
-    Data: _BarostatParticleData,
-    SData: _StochasticCellRescalingSystemData,
-](Propagator[State]):
+class StochasticCellRescalingStep[State](Propagator[State]):
     """Stochastic cell rescaling barostat for NPT ensemble sampling.
 
     Implements the isotropic stochastic cell rescaling algorithm (Bernetti & Bussi, 2020)
@@ -695,8 +686,6 @@ class StochasticCellRescalingStep[
 
     Type Parameters:
         State: Simulation state type
-        Data: Particle data type (must have positions, momenta, masses, system index)
-        SData: System data type with barostat parameters
 
     Attributes:
         particles: Lens to get/set indexed particle data (positions $\\mathbf{r}$, momenta $\\mathbf{p}$, masses $m$)
@@ -710,8 +699,12 @@ class StochasticCellRescalingStep[
         DOI: 10.1063/5.0020514
     """
 
-    particles: Lens[State, Table[ParticleId, Data]] = field(static=True)
-    systems: Lens[State, Table[SystemId, SData]] = field(static=True)
+    particles: Lens[State, Table[ParticleId, _BarostatParticleData]] = field(
+        static=True
+    )
+    systems: Lens[State, Table[SystemId, _StochasticCellRescalingSystemData]] = field(
+        static=True
+    )
 
     def __call__(self, key: Array, state: State) -> State:
         """Apply stochastic cell rescaling for pressure control.
@@ -833,13 +826,9 @@ class IsCSVRNPTSystemData(
     def unitcell_gradients(self) -> UnitCell: ...
 
 
-def make_csvr_npt_step[
-    State,
-    Data: _BarostatParticleData,
-    SData: IsCSVRNPTSystemData,
-](
-    particles: Lens[State, Table[ParticleId, Data]],
-    systems: Lens[State, Table[SystemId, SData]],
+def make_csvr_npt_step[State](
+    particles: Lens[State, Table[ParticleId, _BarostatParticleData]],
+    systems: Lens[State, Table[SystemId, IsCSVRNPTSystemData]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
 ) -> SequentialPropagator[State]:
@@ -882,8 +871,10 @@ def make_csvr_npt_step[
              stochastic cell rescaling. J. Chem. Phys., 153(11), 114107.
              DOI: 10.1063/5.0020514
     """
-    sys_view: View[State, Table[SystemId, SData]] = systems.get
-    sys_half_view: View[State, Table[SystemId, SData]] = pipe(systems.get, _half_time)
+    sys_view: View[State, Table[SystemId, IsCSVRNPTSystemData]] = systems.get
+    sys_half_view: View[State, Table[SystemId, IsCSVRNPTSystemData]] = pipe(
+        systems.get, _half_time
+    )
     return SequentialPropagator(
         (
             CSVRStep(particles, sys_view),
@@ -910,8 +901,8 @@ class IsMDState(Protocol):
     def systems(self) -> Table[SystemId, IsMDSystem]: ...
 
 
-def make_md_step_from_state[State, InpState: IsMDState](
-    state: Lens[State, InpState],
+def make_md_step_from_state[State](
+    state: Lens[State, IsMDState],
     derivative_computation: Propagator[State],
     integrator: Integrator,
 ) -> Propagator[State]:

--- a/src/kups/potential/classical/blocking.py
+++ b/src/kups/potential/classical/blocking.py
@@ -311,11 +311,8 @@ class IsBlockingSpheresState(Protocol):
 
 
 @overload
-def make_blocking_spheres_from_state[
-    State,
-    InState: IsBlockingSpheresState,
-](
-    state: Lens[State, InState],
+def make_blocking_spheres_from_state[State](
+    state: Lens[State, IsBlockingSpheresState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -323,11 +320,8 @@ def make_blocking_spheres_from_state[
 
 
 @overload
-def make_blocking_spheres_from_state[
-    State,
-    InState: IsBlockingSpheresState,
-](
-    state: Lens[State, InState],
+def make_blocking_spheres_from_state[State](
+    state: Lens[State, IsBlockingSpheresState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -335,12 +329,8 @@ def make_blocking_spheres_from_state[
 
 
 @overload
-def make_blocking_spheres_from_state[
-    State,
-    InState: IsBlockingSpheresState,
-    P: Patch,
-](
-    state: Lens[State, InState],
+def make_blocking_spheres_from_state[State, P: Patch](
+    state: Lens[State, IsBlockingSpheresState],
     probe: Probe[State, P, IsBlockingSpheresProbe],
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -348,12 +338,8 @@ def make_blocking_spheres_from_state[
 
 
 @overload
-def make_blocking_spheres_from_state[
-    State,
-    InState: IsBlockingSpheresState,
-    P: Patch,
-](
-    state: Lens[State, InState],
+def make_blocking_spheres_from_state[State, P: Patch](
+    state: Lens[State, IsBlockingSpheresState],
     probe: Probe[State, P, IsBlockingSpheresProbe],
     *,
     compute_position_and_unitcell_gradients: Literal[True],

--- a/src/kups/potential/classical/cosine_angle.py
+++ b/src/kups/potential/classical/cosine_angle.py
@@ -45,6 +45,7 @@ from kups.core.typing import (
     HasSystemIndex,
     HasUnitCell,
     Label,
+    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -288,13 +289,11 @@ class IsCosineAngleState[Params](Protocol):
 
 
 @overload
-def make_cosine_angle_from_state[
-    State,
-    InState: IsCosineAngleState[
-        CosineAngleParameters | HasCache[CosineAngleParameters, Any]
+def make_cosine_angle_from_state[State](
+    state: Lens[
+        State,
+        IsCosineAngleState[MaybeCached[CosineAngleParameters, Any]],
     ],
-](
-    state: Lens[State, InState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -302,13 +301,11 @@ def make_cosine_angle_from_state[
 
 
 @overload
-def make_cosine_angle_from_state[
-    State,
-    InState: IsCosineAngleState[
-        CosineAngleParameters | HasCache[CosineAngleParameters, Any]
+def make_cosine_angle_from_state[State](
+    state: Lens[
+        State,
+        IsCosineAngleState[MaybeCached[CosineAngleParameters, Any]],
     ],
-](
-    state: Lens[State, InState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -316,14 +313,13 @@ def make_cosine_angle_from_state[
 
 
 @overload
-def make_cosine_angle_from_state[
-    State,
-    InState: IsCosineAngleState[
-        HasCache[CosineAngleParameters, PotentialOut[EmptyType, EmptyType]]
+def make_cosine_angle_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsCosineAngleState[
+            HasCache[CosineAngleParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[
         State,
         P,
@@ -335,14 +331,15 @@ def make_cosine_angle_from_state[
 
 
 @overload
-def make_cosine_angle_from_state[
-    State,
-    InState: IsCosineAngleState[
-        HasCache[CosineAngleParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+def make_cosine_angle_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsCosineAngleState[
+            HasCache[
+                CosineAngleParameters, PotentialOut[PositionAndUnitCell, EmptyType]
+            ]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[
         State,
         P,

--- a/src/kups/potential/classical/coulomb.py
+++ b/src/kups/potential/classical/coulomb.py
@@ -159,11 +159,8 @@ class IsCoulombVacuumState(Protocol):
 
 
 @overload
-def make_coulomb_vacuum_from_state[
-    State,
-    InState: IsCoulombVacuumState,
-](
-    state: Lens[State, InState],
+def make_coulomb_vacuum_from_state[State](
+    state: Lens[State, IsCoulombVacuumState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -171,11 +168,8 @@ def make_coulomb_vacuum_from_state[
 
 
 @overload
-def make_coulomb_vacuum_from_state[
-    State,
-    InState: IsCoulombVacuumState,
-](
-    state: Lens[State, InState],
+def make_coulomb_vacuum_from_state[State](
+    state: Lens[State, IsCoulombVacuumState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -183,12 +177,8 @@ def make_coulomb_vacuum_from_state[
 
 
 @overload
-def make_coulomb_vacuum_from_state[
-    State,
-    InState: IsCoulombVacuumState,
-    P: Patch,
-](
-    state: Lens[State, InState],
+def make_coulomb_vacuum_from_state[State, P: Patch](
+    state: Lens[State, IsCoulombVacuumState],
     probe: Probe[State, P, IsRadiusGraphProbe[IsCoulombGraphParticles]],
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -196,12 +186,8 @@ def make_coulomb_vacuum_from_state[
 
 
 @overload
-def make_coulomb_vacuum_from_state[
-    State,
-    InState: IsCoulombVacuumState,
-    P: Patch,
-](
-    state: Lens[State, InState],
+def make_coulomb_vacuum_from_state[State, P: Patch](
+    state: Lens[State, IsCoulombVacuumState],
     probe: Probe[State, P, IsRadiusGraphProbe[IsCoulombGraphParticles]],
     *,
     compute_position_and_unitcell_gradients: Literal[True],

--- a/src/kups/potential/classical/dihedral.py
+++ b/src/kups/potential/classical/dihedral.py
@@ -43,6 +43,7 @@ from kups.core.typing import (
     HasSystemIndex,
     HasUnitCell,
     Label,
+    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -343,11 +344,8 @@ class IsDihedralState[Params](Protocol):
 
 
 @overload
-def make_dihedral_from_state[
-    State,
-    InState: IsDihedralState[DihedralParameters | HasCache[DihedralParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_dihedral_from_state[State](
+    state: Lens[State, IsDihedralState[MaybeCached[DihedralParameters, Any]]],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -355,11 +353,8 @@ def make_dihedral_from_state[
 
 
 @overload
-def make_dihedral_from_state[
-    State,
-    InState: IsDihedralState[DihedralParameters | HasCache[DihedralParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_dihedral_from_state[State](
+    state: Lens[State, IsDihedralState[MaybeCached[DihedralParameters, Any]]],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -367,14 +362,13 @@ def make_dihedral_from_state[
 
 
 @overload
-def make_dihedral_from_state[
-    State,
-    InState: IsDihedralState[
-        HasCache[DihedralParameters, PotentialOut[EmptyType, EmptyType]]
+def make_dihedral_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsDihedralState[
+            HasCache[DihedralParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[
         State,
         P,
@@ -386,14 +380,13 @@ def make_dihedral_from_state[
 
 
 @overload
-def make_dihedral_from_state[
-    State,
-    InState: IsDihedralState[
-        HasCache[DihedralParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+def make_dihedral_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsDihedralState[
+            HasCache[DihedralParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[
         State,
         P,

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -50,6 +50,7 @@ from kups.core.typing import (
     HasCharges,
     HasUnitCell,
     InclusionId,
+    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -1036,11 +1037,8 @@ class IsEwaldState[Params](Protocol):
 
 
 @overload
-def make_ewald_from_state[
-    State,
-    InState: IsEwaldState[EwaldParameters | HasCache[EwaldParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_ewald_from_state[State](
+    state: Lens[State, IsEwaldState[MaybeCached[EwaldParameters, Any]]],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -1049,11 +1047,8 @@ def make_ewald_from_state[
 
 
 @overload
-def make_ewald_from_state[
-    State,
-    InState: IsEwaldState[EwaldParameters | HasCache[EwaldParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_ewald_from_state[State](
+    state: Lens[State, IsEwaldState[MaybeCached[EwaldParameters, Any]]],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -1062,12 +1057,10 @@ def make_ewald_from_state[
 
 
 @overload
-def make_ewald_from_state[
-    State,
-    InState: IsEwaldState[HasCache[EwaldParameters, EwaldCache[EmptyType, EmptyType]]],
-    P: Patch,
-](
-    state: Lens[State, InState],
+def make_ewald_from_state[State, P: Patch](
+    state: Lens[
+        State, IsEwaldState[HasCache[EwaldParameters, EwaldCache[EmptyType, EmptyType]]]
+    ],
     probe: Probe[State, P, IsRadiusGraphProbe[IsEwaldPointData]],
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -1076,14 +1069,13 @@ def make_ewald_from_state[
 
 
 @overload
-def make_ewald_from_state[
-    State,
-    InState: IsEwaldState[
-        HasCache[EwaldParameters, EwaldCache[PositionAndUnitCell, EmptyType]]
+def make_ewald_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsEwaldState[
+            HasCache[EwaldParameters, EwaldCache[PositionAndUnitCell, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[State, P, IsRadiusGraphProbe[IsEwaldPointData]],
     *,
     compute_position_and_unitcell_gradients: Literal[True],

--- a/src/kups/potential/classical/harmonic.py
+++ b/src/kups/potential/classical/harmonic.py
@@ -34,6 +34,7 @@ from kups.core.typing import (
     HasSystemIndex,
     HasUnitCell,
     Label,
+    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -299,13 +300,11 @@ class IsHarmonicBondState[Params](HasBondedParticlesAndSystems, Protocol):
 
 
 @overload
-def make_harmonic_bond_from_state[
-    State,
-    InState: IsHarmonicBondState[
-        HarmonicBondParameters | HasCache[HarmonicBondParameters, Any]
+def make_harmonic_bond_from_state[State](
+    state: Lens[
+        State,
+        IsHarmonicBondState[MaybeCached[HarmonicBondParameters, Any]],
     ],
-](
-    state: Lens[State, InState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -313,13 +312,11 @@ def make_harmonic_bond_from_state[
 
 
 @overload
-def make_harmonic_bond_from_state[
-    State,
-    InState: IsHarmonicBondState[
-        HarmonicBondParameters | HasCache[HarmonicBondParameters, Any]
+def make_harmonic_bond_from_state[State](
+    state: Lens[
+        State,
+        IsHarmonicBondState[MaybeCached[HarmonicBondParameters, Any]],
     ],
-](
-    state: Lens[State, InState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -327,14 +324,13 @@ def make_harmonic_bond_from_state[
 
 
 @overload
-def make_harmonic_bond_from_state[
-    State,
-    InState: IsHarmonicBondState[
-        HasCache[HarmonicBondParameters, PotentialOut[EmptyType, EmptyType]]
+def make_harmonic_bond_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsHarmonicBondState[
+            HasCache[HarmonicBondParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[2]]],
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -342,14 +338,15 @@ def make_harmonic_bond_from_state[
 
 
 @overload
-def make_harmonic_bond_from_state[
-    State,
-    InState: IsHarmonicBondState[
-        HasCache[HarmonicBondParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+def make_harmonic_bond_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsHarmonicBondState[
+            HasCache[
+                HarmonicBondParameters, PotentialOut[PositionAndUnitCell, EmptyType]
+            ]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[2]]],
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -429,13 +426,11 @@ class IsHarmonicAngleState[Params](HasBondedParticlesAndSystems, Protocol):
 
 
 @overload
-def make_harmonic_angle_from_state[
-    State,
-    InState: IsHarmonicAngleState[
-        HarmonicAngleParameters | HasCache[HarmonicAngleParameters, Any]
+def make_harmonic_angle_from_state[State](
+    state: Lens[
+        State,
+        IsHarmonicAngleState[MaybeCached[HarmonicAngleParameters, Any]],
     ],
-](
-    state: Lens[State, InState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -443,13 +438,11 @@ def make_harmonic_angle_from_state[
 
 
 @overload
-def make_harmonic_angle_from_state[
-    State,
-    InState: IsHarmonicAngleState[
-        HarmonicAngleParameters | HasCache[HarmonicAngleParameters, Any]
+def make_harmonic_angle_from_state[State](
+    state: Lens[
+        State,
+        IsHarmonicAngleState[MaybeCached[HarmonicAngleParameters, Any]],
     ],
-](
-    state: Lens[State, InState],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -457,14 +450,13 @@ def make_harmonic_angle_from_state[
 
 
 @overload
-def make_harmonic_angle_from_state[
-    State,
-    InState: IsHarmonicAngleState[
-        HasCache[HarmonicAngleParameters, PotentialOut[EmptyType, EmptyType]]
+def make_harmonic_angle_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsHarmonicAngleState[
+            HasCache[HarmonicAngleParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[3]]],
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -472,14 +464,15 @@ def make_harmonic_angle_from_state[
 
 
 @overload
-def make_harmonic_angle_from_state[
-    State,
-    InState: IsHarmonicAngleState[
-        HasCache[HarmonicAngleParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+def make_harmonic_angle_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsHarmonicAngleState[
+            HasCache[
+                HarmonicAngleParameters, PotentialOut[PositionAndUnitCell, EmptyType]
+            ]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[3]]],
     *,
     compute_position_and_unitcell_gradients: Literal[True],

--- a/src/kups/potential/classical/inversion.py
+++ b/src/kups/potential/classical/inversion.py
@@ -56,6 +56,7 @@ from kups.core.typing import (
     HasSystemIndex,
     HasUnitCell,
     Label,
+    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -277,11 +278,11 @@ class IsInversionState[Params](Protocol):
 
 
 @overload
-def make_inversion_from_state[
-    State,
-    InState: IsInversionState[InversionParameters | HasCache[InversionParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_inversion_from_state[State](
+    state: Lens[
+        State,
+        IsInversionState[MaybeCached[InversionParameters, Any]],
+    ],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -289,11 +290,11 @@ def make_inversion_from_state[
 
 
 @overload
-def make_inversion_from_state[
-    State,
-    InState: IsInversionState[InversionParameters | HasCache[InversionParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_inversion_from_state[State](
+    state: Lens[
+        State,
+        IsInversionState[MaybeCached[InversionParameters, Any]],
+    ],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -301,14 +302,13 @@ def make_inversion_from_state[
 
 
 @overload
-def make_inversion_from_state[
-    State,
-    InState: IsInversionState[
-        HasCache[InversionParameters, PotentialOut[EmptyType, EmptyType]]
+def make_inversion_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsInversionState[
+            HasCache[InversionParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[
         State,
         P,
@@ -320,14 +320,13 @@ def make_inversion_from_state[
 
 
 @overload
-def make_inversion_from_state[
-    State,
-    InState: IsInversionState[
-        HasCache[InversionParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+def make_inversion_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsInversionState[
+            HasCache[InversionParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[
         State,
         P,

--- a/src/kups/potential/classical/lennard_jones.py
+++ b/src/kups/potential/classical/lennard_jones.py
@@ -51,6 +51,7 @@ from kups.core.typing import (
     HasSystemIndex,
     HasUnitCell,
     Label,
+    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -410,11 +411,8 @@ class IsLJState[Params](HasLJParticlesAndSystems, Protocol):
 
 
 @overload
-def make_lennard_jones_from_state[
-    State,
-    InState: IsLJState[LennardJonesParameters | HasCache[LennardJonesParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_lennard_jones_from_state[State](
+    state: Lens[State, IsLJState[MaybeCached[LennardJonesParameters, Any]]],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -422,11 +420,8 @@ def make_lennard_jones_from_state[
 
 
 @overload
-def make_lennard_jones_from_state[
-    State,
-    InState: IsLJState[LennardJonesParameters | HasCache[LennardJonesParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_lennard_jones_from_state[State](
+    state: Lens[State, IsLJState[MaybeCached[LennardJonesParameters, Any]]],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -434,12 +429,11 @@ def make_lennard_jones_from_state[
 
 
 @overload
-def make_lennard_jones_from_state[
-    State,
-    InState: IsLJState[HasCache[LennardJonesParameters, PotentialOut]],
-    P: Patch,
-](
-    state: Lens[State, InState],
+def make_lennard_jones_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsLJState[HasCache[LennardJonesParameters, PotentialOut[EmptyType, EmptyType]]],
+    ],
     probe: Probe[State, P, IsRadiusGraphProbe],
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -447,14 +441,15 @@ def make_lennard_jones_from_state[
 
 
 @overload
-def make_lennard_jones_from_state[
-    State,
-    InState: IsLJState[
-        HasCache[LennardJonesParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+def make_lennard_jones_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsLJState[
+            HasCache[
+                LennardJonesParameters, PotentialOut[PositionAndUnitCell, EmptyType]
+            ]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[State, P, IsRadiusGraphProbe],
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -600,8 +595,7 @@ def make_global_lennard_jones_tail_correction_potential[State, Gradients, Hessia
 
 
 type IsGlobalTailCorrectedIsLJState = IsLJState[
-    GlobalTailCorrectedLennardJonesParameters
-    | HasCache[GlobalTailCorrectedLennardJonesParameters, PotentialOut]
+    MaybeCached[GlobalTailCorrectedLennardJonesParameters, PotentialOut]
 ]
 
 

--- a/src/kups/potential/classical/morse.py
+++ b/src/kups/potential/classical/morse.py
@@ -40,6 +40,7 @@ from kups.core.typing import (
     HasSystemIndex,
     HasUnitCell,
     Label,
+    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -237,11 +238,8 @@ class IsMorseBondState[Params](Protocol):
 
 
 @overload
-def make_morse_bond_from_state[
-    State,
-    InState: IsMorseBondState[MorseBondParameters | HasCache[MorseBondParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_morse_bond_from_state[State](
+    state: Lens[State, IsMorseBondState[MaybeCached[MorseBondParameters, Any]]],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
@@ -249,11 +247,8 @@ def make_morse_bond_from_state[
 
 
 @overload
-def make_morse_bond_from_state[
-    State,
-    InState: IsMorseBondState[MorseBondParameters | HasCache[MorseBondParameters, Any]],
-](
-    state: Lens[State, InState],
+def make_morse_bond_from_state[State](
+    state: Lens[State, IsMorseBondState[MaybeCached[MorseBondParameters, Any]]],
     probe: None = None,
     *,
     compute_position_and_unitcell_gradients: Literal[True],
@@ -261,14 +256,13 @@ def make_morse_bond_from_state[
 
 
 @overload
-def make_morse_bond_from_state[
-    State,
-    InState: IsMorseBondState[
-        HasCache[MorseBondParameters, PotentialOut[EmptyType, EmptyType]]
+def make_morse_bond_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsMorseBondState[
+            HasCache[MorseBondParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[
         State,
         P,
@@ -280,14 +274,13 @@ def make_morse_bond_from_state[
 
 
 @overload
-def make_morse_bond_from_state[
-    State,
-    InState: IsMorseBondState[
-        HasCache[MorseBondParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+def make_morse_bond_from_state[State, P: Patch](
+    state: Lens[
+        State,
+        IsMorseBondState[
+            HasCache[MorseBondParameters, PotentialOut[PositionAndUnitCell, EmptyType]]
+        ],
     ],
-    P: Patch,
-](
-    state: Lens[State, InState],
     probe: Probe[
         State,
         P,

--- a/src/kups/potential/mliap/local.py
+++ b/src/kups/potential/mliap/local.py
@@ -57,6 +57,7 @@ from kups.core.typing import (
     HasPositionsAndAtomicNumbers,
     HasSystemIndex,
     HasUnitCell,
+    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -603,13 +604,8 @@ class IsLocalMLIAPState[Model](Protocol):
 
 
 @overload
-def make_local_mliap_from_state[
-    State,
-    InState: IsLocalMLIAPState[LocalMLIAPData],
-    Gradient,
-    Hessian,
-](
-    state: Lens[State, InState],
+def make_local_mliap_from_state[State, Gradient, Hessian](
+    state: Lens[State, IsLocalMLIAPState[MaybeCached[LocalMLIAPData, Any]]],
     probe: None = None,
     gradient_lens: Lens[LocalMLIAPInput, Gradient] = EMPTY_LENS,
     hessian_lens: Lens[Gradient, Hessian] = EMPTY_LENS,
@@ -619,30 +615,8 @@ def make_local_mliap_from_state[
 
 
 @overload
-def make_local_mliap_from_state[
-    State,
-    InState: IsLocalMLIAPState[HasCache[LocalMLIAPData, Any]],
-    Gradient,
-    Hessian,
-](
-    state: Lens[State, InState],
-    probe: None = None,
-    gradient_lens: Lens[LocalMLIAPInput, Gradient] = EMPTY_LENS,
-    hessian_lens: Lens[Gradient, Hessian] = EMPTY_LENS,
-    hessian_idx_view: Lens[State, Hessian] = EMPTY_LENS,
-    out_idx_view: None = None,
-) -> Potential[State, Gradient, Hessian, Patch]: ...
-
-
-@overload
-def make_local_mliap_from_state[
-    State,
-    InState: IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut]],
-    Ptch: Patch,
-    Gradient,
-    Hessian,
-](
-    state: Lens[State, InState],
+def make_local_mliap_from_state[State, Ptch: Patch, Gradient, Hessian](
+    state: Lens[State, IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut]]],
     probe: Probe[State, Ptch, IsRadiusGraphProbe[IsLocalMLIAPGraphParticles]],
     gradient_lens: Lens[LocalMLIAPInput, Gradient] = EMPTY_LENS,
     hessian_lens: Lens[Gradient, Hessian] = EMPTY_LENS,

--- a/src/kups/potential/mliap/tojax.py
+++ b/src/kups/potential/mliap/tojax.py
@@ -231,16 +231,16 @@ class IsTojaxedState(Protocol):
 
 
 @overload
-def make_tojaxed_from_state[State, InState: IsTojaxedState](
-    state: Lens[State, InState],
+def make_tojaxed_from_state[State](
+    state: Lens[State, IsTojaxedState],
     *,
     compute_position_and_unitcell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, Any]: ...
 
 
 @overload
-def make_tojaxed_from_state[State, InState: IsTojaxedState](
-    state: Lens[State, InState],
+def make_tojaxed_from_state[State](
+    state: Lens[State, IsTojaxedState],
     *,
     compute_position_and_unitcell_gradients: Literal[True],
 ) -> Potential[State, PositionAndUnitCell, EmptyType, Any]: ...


### PR DESCRIPTION
This PR makes R of Lens[S, R] covariant (it used to be invariant). This is hugely beneficial if we work with Protocols where we before had to do something like
```py
def foo[State, X: HasPositions](lens: Lens[State, X]): ...
```
now it simplifies to
```py
def foo[State](lens: Lens[State, HasPositions]): ...
```
Such simplifications are now allied throughout. 

For reviewing: most interesting changes happen in `lens.py`. Notably, there is a `type: ignore` in `MergedLens`, it is worth checking whether that could be simplified