### PR TITLE
docs: Add custom color scheme and update theme configuration

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,19 @@
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: #C5F598;
+  --md-primary-fg-color--light: #DEFBC6;
+  --md-primary-fg-color--dark: #9FE066;
+  --md-accent-fg-color: #46D2E6;
+  --md-accent-fg-color--light: #7BE3F0;
+  --md-accent-fg-color--dark: #1FA8BC;
+  --md-accent-fg-color--transparent: rgba(70, 210, 230, 0.1);
+}
+
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #5FA03A;
+  --md-primary-fg-color--light: #7DB85A;
+  --md-primary-fg-color--dark: #3F7A20;
+  --md-accent-fg-color: #0E8A9E;
+  --md-accent-fg-color--light: #1FA8BC;
+  --md-accent-fg-color--dark: #085F6E;
+  --md-accent-fg-color--transparent: rgba(14, 138, 158, 0.1);
+}

--- a/docs/units.md
+++ b/docs/units.md
@@ -1,6 +1,6 @@
 # 📐 Units & Constants
 
-*k*UPS uses a consistent unit system optimized for molecular simulations:
+<em>k</em>UPS uses a consistent unit system optimized for molecular simulations:
 
 | Physical Quantity | Unit | Symbol |
 |-------------------|------|---------|

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,8 @@ theme:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
-      primary: indigo
-      accent: deep purple
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
@@ -24,8 +24,8 @@ theme:
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
-      primary: indigo
-      accent: deep purple
+      primary: custom
+      accent: custom
       toggle:
         icon: material/brightness-4
         name: Switch to system preference
@@ -111,7 +111,7 @@ extra:
       link: https://pypi.org/project/kups/
       name: kUPS on PyPI
 
-copyright: Copyright &copy; 2025 Cusp-AI
+copyright: Copyright &copy; 2024-2026 CuspAI
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
This PR updates the documentation site's visual theme to use custom brand colors instead of the default Material theme indigo/deep purple palette.

Custom CSS variables are introduced for both light (`default`) and dark (`slate`) color schemes, defining primary and accent colors with their light, dark, and transparent variants. The `mkdocs.yml` theme configuration is updated to reference these custom color definitions.

Additionally, the copyright notice is corrected to reflect the proper date range (2024-2026) and company name formatting (CuspAI), and an italic formatting fix is applied to the *k*UPS product name in the units documentation to use HTML `<em>` tags instead of Markdown italics for more reliable rendering.