### PR TITLE
chore: Remove `.gitmodules` submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "packages/weft"]
-	path = packages/weft
-	url = ../weft
-[submodule "packages/tinyargs"]
-	path = packages/tinyargs
-  url = ../tinyargs


### PR DESCRIPTION
Removes the `.gitmodules` file, detaching the `weft` and `tinyargs` packages as git submodules from the repository.