### PR TITLE
chore: Bump version to 1.0.0 and add PyPI metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kups"
-version = "0.1.1"
+version = "1.0.0"
 description = "A toolkit for building high-performance molecular simulations on JAX."
 readme = "README.md"
 authors = [
@@ -8,7 +8,38 @@ authors = [
     { name = "Jonas Köhler", email = "jonas@cusp.ai" },
     { name = "CuspAI OpenSource Team", email = "opensource@cusp.ai" },
 ]
-license = { file = "LICENSE" }
+maintainers = [
+    { name = "Nicholas Gao", email = "nicholas@cusp.ai" },
+    { name = "Jonas Köhler", email = "jonas@cusp.ai" },
+    { name = "CuspAI OpenSource Team", email = "opensource@cusp.ai" },
+]
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+keywords = [
+    "jax",
+    "molecular-dynamics",
+    "molecular-simulation",
+    "mlff",
+    "machine-learning-force-field",
+    "computational-chemistry",
+    "computational-physics",
+    "monte-carlo",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Typing :: Typed",
+]
 requires-python = ">=3.12, <3.15"
 dependencies = [
     "ase>=3.24.0",
@@ -27,6 +58,17 @@ dependencies = [
     "nanoargs>=0.1.1",
     "slub>=0.1.1",
 ]
+
+[project.optional-dependencies]
+cuda = ["jax[cuda]>=0.7.2; sys_platform == 'linux'"]
+hf = ["huggingface-hub>=1.11.0"]
+
+[project.urls]
+homepage = "https://github.com/cusp-ai-oss/kups"
+source = "https://github.com/cusp-ai-oss/kups"
+issues = "https://github.com/cusp-ai-oss/kups/issues"
+documentation = "https://cusp-ai-oss.github.io/kups/"
+
 [project.scripts]
 kups_md_mlff = "kups.application.simulations.md_mlff:main"
 kups_relax_mlff = "kups.application.simulations.relax_mlff:main"
@@ -37,6 +79,17 @@ kups_relax_lj = "kups.application.simulations.relax_lj:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/kups"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/LICENSE",
+    "/README.md",
+    "/pyproject.toml",
+]
 
 [dependency-groups]
 cuda = ["jax[cuda]>=0.7.2; sys_platform == 'linux'"]
@@ -70,11 +123,6 @@ hf = ["huggingface-hub>=1.11.0"]
 
 [tool.uv]
 default-groups = "all"
-
-[tool.uv.sources]
-tinyargs = { workspace = true, editable = true }
-weft = { workspace = true, editable = true }
-
 
 [tool.pytest_env]
 JAX_PLATFORMS = "cpu"

--- a/src/kups/__init__.py
+++ b/src/kups/__init__.py
@@ -1,2 +1,3 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
+__version__ = "1.0.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ wheels = [
 
 [[package]]
 name = "kups"
-version = "0.1.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "ase" },
@@ -1537,6 +1537,14 @@ dependencies = [
     { name = "rich" },
     { name = "slub" },
     { name = "tqdm" },
+]
+
+[package.optional-dependencies]
+cuda = [
+    { name = "jax", extra = ["cuda"], marker = "sys_platform == 'linux'" },
+]
+hf = [
+    { name = "huggingface-hub" },
 ]
 
 [package.dev-dependencies]
@@ -1580,7 +1588,9 @@ requires-dist = [
     { name = "etils", specifier = ">=1.13.0" },
     { name = "flatbuffers", specifier = ">=25.2.10" },
     { name = "h5py", specifier = ">=3.15.0" },
+    { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=1.11.0" },
     { name = "jax", specifier = ">=0.7.2" },
+    { name = "jax", extras = ["cuda"], marker = "sys_platform == 'linux' and extra == 'cuda'", specifier = ">=0.7.2" },
     { name = "jsonargparse", specifier = ">=4.41.0" },
     { name = "msgpack", specifier = ">=1.1.2" },
     { name = "nanoargs", specifier = ">=0.1.1" },
@@ -1591,6 +1601,7 @@ requires-dist = [
     { name = "slub", specifier = ">=0.1.1" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
+provides-extras = ["cuda", "hf"]
 
 [package.metadata.requires-dev]
 cuda = [{ name = "jax", extras = ["cuda"], marker = "sys_platform == 'linux'", specifier = ">=0.7.2" }]


### PR DESCRIPTION
Bumps the package version to `1.0.0` and prepares it for public PyPI distribution. This includes adding PyPI classifiers, keywords, maintainer metadata, and project URLs (homepage, source, issues, documentation). The license field is updated to use the SPDX identifier format alongside an explicit license file declaration.

Optional dependency extras (`cuda`, `hf`) are introduced so users can install GPU support or Hugging Face Hub integration without requiring them by default. Hatch build targets are explicitly configured to package the `src/kups` directory for both wheel and sdist distributions.

The `__version__` attribute is added to the package's `__init__.py`, and local workspace source overrides for `tinyargs` and `weft` are removed, indicating those dependencies are now consumed from their published releases rather than local editable installs.