### PR TITLE
docs: fix citation bibtex author list

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,17 @@ If you use *k*UPS in your research, please cite:
 
 ```bibtex
 @software{kups2026,
-  author = {{Cusp AI}},
-  title = {kUPS},
+  author = {Gao, Nicholas
+    and K{\"o}hler, Jonas
+    and Ramanan, Anita
+    and Hanke, Felix
+    and Moubarak, Elias
+    and Morrow, Joe
+    and de Haan, Pim
+    and Openshaw, Hannah
+    and Welling, Max
+    and CuspAI Team},
+  title = {kUPS - a universal particle simulation toolkit},
   year = {2026},
   url = {https://github.com/cusp-ai-oss/kups}
 }

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ If you use *k*UPS in your research, please cite:
 @software{kups2026,
   author = {Gao, Nicholas
     and K{\"o}hler, Jonas
-    and Ramanan, Anita
     and Hanke, Felix
+    and Ramanan, Anita
     and Moubarak, Elias
     and Morrow, Joe
     and de Haan, Pim


### PR DESCRIPTION
## Summary

Replaces the placeholder `{{Cusp AI}}` author entry in the README bibtex with the full contributor list (Gao, Köhler, Ramanan, Hanke, Moubarak, Morrow, de Haan, Openshaw, Welling, CuspAI Team) and expands the software title to *kUPS - a universal particle simulation toolkit*.

Same content as #13, which GitHub marked merged but whose merge commit landed on `graphite-base/13` rather than `main`; the author list never actually reached trunk. This PR reapplies the patch as a single commit off current `main`.

## Test plan

- [ ] `cat README.md | grep -A 15 kups2026` shows the full author list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)