### PR TITLE
docs: updated config filename to reflect doc

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ The repository includes example applications built with <em>k</em>UPS. To try th
 
 ```sh
 cd examples
-kups_mcmc_rigid gcmc_co2_30box.yaml
+kups_mcmc_rigid mcmc_rigid.yaml
 ```
 
 ```sh


### PR DESCRIPTION
Previous quickstart example read `kups_mcmc_rigid gcmc_co2_30box.yaml` however the config file was renamed to `mcmc_rigid.yaml`