### PR TITLE
docs: use kups[cuda] extra for GPU install in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,10 +12,10 @@
 pip install kups
 ```
 
-For GPU support, install JAX with CUDA separately:
+For GPU support (Linux only):
 
 ```sh
-pip install jax[cuda]
+pip install kups[cuda]
 ```
 
 ## Quick Start


### PR DESCRIPTION
Fixes #26.

README uses `pip install kups[cuda]`; `docs/index.md` gave two lines (plain `pip install kups` + a separate `pip install jax[cuda]`) with no Linux-only note. Align both to the real public extra and flag the Linux-only constraint that the extra already encodes in `pyproject.toml` (`jax[cuda]>=0.7.2; sys_platform == 'linux'`).

## Test plan

- [x] `uv run pre-commit run --all-files` clean.
- [x] Install snippet now matches README verbatim apart from the Linux-only parenthetical.