### PR TITLE
docs: document view() factory in the Lenses notebook

### DIFF
--- a/docs/notebooks/lens.ipynb
+++ b/docs/notebooks/lens.ipynb
@@ -20,7 +20,7 @@
     "import jax.numpy as jnp\n",
     "from jax import Array\n",
     "\n",
-    "from kups.core.lens import LambdaLens, Lens, bind, lens\n",
+    "from kups.core.lens import LambdaLens, Lens, bind, lens, view\n",
     "from kups.core.utils.jax import dataclass"
    ]
   },
@@ -139,6 +139,35 @@
     "```\n",
     "\n",
     "In practice, you rarely need this. When a lens is passed into a typed context — for example, as a function argument annotated `Lens[State, Array]` — the type is inferred automatically from the call site. The `cls=` argument exists for the cases where you define a lens at module level without such context."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read-only views: `view()`\n",
+    "\n",
+    "Sometimes a component only needs to *read* a field, not write it. The [view()][kups.core.lens.view] factory returns a plain [View][kups.core.lens.View], which is callable on the state but has no setter:\n",
+    "\n",
+    "- `lens(where, cls=...)` returns a [Lens[S, R]][kups.core.lens.Lens]. Satisfies both [View][kups.core.lens.View] and [Update][kups.core.lens.Update]; the setter is inferred from the getter. Read via `lens.get(state)`; write via `lens.set(state, value)`.\n",
+    "- `view(where, cls=...)` returns a [View[S, R]][kups.core.lens.View]. Read-only; no setter is generated. Read by calling it directly: `v(state)`.\n",
+    "\n",
+    "Use `view()` when a function advertises (via its type signature) that it will only read. Use `lens()` when it may also need to write back."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pos_view = view(lambda s: s.atoms.positions, cls=State)\n",
+    "\n",
+    "# A View is callable directly on the state (no `.get`):\n",
+    "print(pos_view(state))\n",
+    "\n",
+    "# It has no `.set`, so misuse is a type error at the call site,\n",
+    "# not a silent failure at runtime."
    ]
   },
   {


### PR DESCRIPTION
Fixes #24.

Adds a 'Read-only views: `view()`' section to `docs/notebooks/lens.ipynb` contrasting `view(where, cls=...)` with `lens(where, cls=...)` and showing the call-on-state form. The `view` factory was previously used in the Logging notebook without ever being introduced in the handbook.

## Test plan

- [x] `JAX_PLATFORMS=cpu uv run jupyter nbconvert --execute --to notebook docs/notebooks/lens.ipynb` executes end-to-end.
- [x] `uv run pre-commit run --all-files` clean.