### PR TITLE
docs: Add ML force fields section with Hugging Face model URIs

### DIFF
--- a/docs/simulations.md
+++ b/docs/simulations.md
@@ -70,3 +70,25 @@ kups_mcmc_rigid mcmc_rigid.yaml
 - **Exchange** — insert or delete a molecule based on the chemical potential (fugacity computed via the Peng-Robinson equation of state).
 
 Move probabilities and step sizes are configurable. The simulation supports multiple adsorbate species (CO₂, CH₄, H₂O, N₂, etc.) with pre-defined molecular geometries.
+
+# Machine-learning Force Fields
+
+CuspAI publishes JAX exports of MACE, UMA, and Orb on the Hugging Face Hub — one repository per model so each retains its upstream license:
+
+| Model | Hugging Face repository | License |
+|-------|-------------------------|---------|
+| [MACE](https://github.com/ACEsuit/mace-foundations) | [CuspAI/kUPS-mace-jax](https://huggingface.co/CuspAI/kUPS-mace-jax) | MIT |
+| [UMA](https://huggingface.co/facebook/UMA) | [CuspAI/kUPS-uma-jax](https://huggingface.co/CuspAI/kUPS-uma-jax) (gated) | FAIR Chemistry License v1 |
+| [Orb](https://github.com/orbital-materials/orb-models) | [CuspAI/kUPS-orb-jax](https://huggingface.co/CuspAI/kUPS-orb-jax) | Apache 2.0 |
+
+These are re-exports (via [Tojax](https://github.com/cusp-ai-oss/tojax)), not retrainings — weights and architectures are unchanged from upstream. UMA inherits Meta's gated distribution: request access on both the [upstream page](https://huggingface.co/facebook/UMA) and [CuspAI/kUPS-uma-jax](https://huggingface.co/CuspAI/kUPS-uma-jax), then `huggingface-cli login` before downloading.
+
+Any `model_path:` field accepts an `hf://<owner>/<repo>/<filename>` URI, which is fetched via `huggingface_hub.hf_hub_download` and cached on first use:
+
+```yaml
+model_path: hf://CuspAI/kUPS-mace-jax/mace-mpa-0-medium_32.zip
+model_path: hf://CuspAI/kUPS-uma-jax/uma-s-1p2_omat.zip        # heads: oc20, odac, omat, omc, omol
+model_path: hf://CuspAI/kUPS-orb-jax/orb_v3_conservative_inf_omat.zip
+```
+
+Requires the optional `huggingface_hub` dependency: `pip install kups[hf]`.


### PR DESCRIPTION
Adds documentation for using machine-learning force fields (MACE, UMA, and Orb) with kUPS. Covers the CuspAI JAX exports hosted on Hugging Face Hub, their respective licenses, and the gated access workflow required for UMA. Documents the `hf://` URI scheme for `model_path:` fields, including example values for each model, and notes the `kups[hf]` optional dependency needed to enable Hugging Face Hub downloads.