### PR TITLE
docs: drop Flow from Conventions list

### DIFF
--- a/docs/notebooks/conventions.ipynb
+++ b/docs/notebooks/conventions.ipynb
@@ -73,7 +73,7 @@
     "- `Has*` for a single specific field or property: [HasPositions][kups.core.typing.HasPositions], [HasUnitCell][kups.core.typing.HasUnitCell], [HasSystemIndex][kups.core.typing.HasSystemIndex]. The most granular level, one protocol per field.\n",
     "- `Is*` for a multi-field role or identity: `IsState`, `IsMDState`. The object \"is\" conceptually that thing. Used when several fields always appear together.\n",
     "- `Supports*` for an operation capability: `SupportsAdd`, `SupportsDType`. Used for generic algorithms that need specific operators or methods.\n",
-    "- No verb for callables and framework abstractions defined by behavior: [Propagator][kups.core.propagator.Propagator], [Lens][kups.core.lens.Lens], `Flow`. These are already nouns that describe what the object does."
+    "- No verb for callables and framework abstractions defined by behavior: [Propagator][kups.core.propagator.Propagator], [Lens][kups.core.lens.Lens]. These are already nouns that describe what the object does."
    ]
   },
   {


### PR DESCRIPTION
Fixes #28.

Reviewer n-gao pointed out that adding a Flow section to the general Propagators chapter is too MD-specific. Takes option (b) from the issue: drop `Flow` from the callable-abstractions list in `docs/notebooks/conventions.ipynb`. `Flow` remains a first-class user-facing protocol; it just doesn't get advertised in the general-audience handbook until there is a dedicated MD chapter to host a worked example.

## Test plan

- [x] `JAX_PLATFORMS=cpu uv run jupyter nbconvert --execute --to notebook docs/notebooks/conventions.ipynb` executes end-to-end.
- [x] `uv run pre-commit run --all-files` clean.