### PR TITLE
docs: fix README Quick Start yaml reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ uv sync
 
 ```bash
 cd examples
-kups_mcmc_rigid gcmc_co2_30box.yaml
+kups_mcmc_rigid mcmc_rigid.yaml
 ```
 
 </details>


### PR DESCRIPTION
Fixes #37.

README pointed at `examples/gcmc_co2_30box.yaml` which doesn't exist in the `examples/` directory. Update to `mcmc_rigid.yaml`, matching what ships in the repo and what `docs/simulations.md` already uses.

`docs/index.md` was already fixed by PR #31 but the README still carried the old filename.

## Test plan

- [x] `ls examples/ | grep mcmc_rigid` shows the file exists.
- [x] `uv run pre-commit run --all-files` clean.