### PR TITLE
docs: add md_orb.yaml / relax_orb.yaml examples

### DIFF
--- a/docs/simulations.md
+++ b/docs/simulations.md
@@ -17,6 +17,7 @@ kups_md_lj md_lj_argon_nvt.yaml
 kups_md_lj md_lj_argon_nve.yaml
 kups_md_mlff md_mace.yaml
 kups_md_mlff md_uma.yaml
+kups_md_mlff md_orb.yaml
 ```
 
 **Ensembles and integrators:**
@@ -39,6 +40,7 @@ Relax atomic positions (and optionally lattice vectors) to a local energy minimu
 ```sh
 cd examples
 kups_relax_mlff relax_mace.yaml
+kups_relax_mlff relax_orb.yaml
 ```
 
 **Optimizers:**

--- a/examples/md_orb.yaml
+++ b/examples/md_orb.yaml
@@ -1,0 +1,18 @@
+inp_files:
+  - host/argon_fcc.cif
+model_path: hf://CuspAI/kUPS-orb-jax/orb_v3_conservative_inf_omat.zip
+md:
+  temperature: 400         # K
+  time_step: 0.1           # fs
+  friction_coefficient: 0.001      # 1/fs
+  thermostat_time_constant: 100.0  # fs
+  target_pressure: 0.0             # Pa
+  pressure_coupling_time: 1000.0   # fs
+  compressibility: 4.57e-10        # 1/Pa
+  minimum_scale_factor: 1.0
+  integrator: baoab_langevin
+run:
+  out_file: md_orb.h5
+  num_steps: 1000
+  num_warmup_steps: 0
+  seed: null

--- a/examples/relax_orb.yaml
+++ b/examples/relax_orb.yaml
@@ -1,0 +1,18 @@
+inp_files:
+  - host/RUBTAK.cif
+model_path: hf://CuspAI/kUPS-orb-jax/orb_v3_conservative_inf_omat.zip
+relax:
+  optimizer:
+    - transform: scale_by_ase_lbfgs
+      memory_size: 100
+      alpha: 70
+    - transform: max_step_size
+      max_step_size: 0.2
+    - transform: scale
+      step_size: -1
+  optimize_cell: false
+run:
+  out_file: relax_orb.h5
+  max_steps: 1000
+  force_tolerance: 0.001   # eV/Å
+  seed: null


### PR DESCRIPTION
Fixes #51.

`docs/simulations.md` advertised `kups_md_mlff` / `kups_relax_mlff` as supporting MACE, UMA, and ORB, and documented an `hf://CuspAI/kUPS-orb-jax/...` path in the MLFF table further down the page, but `examples/` had no `md_orb.yaml` / `relax_orb.yaml` for users to copy.

Add both, mirroring the MACE examples but pointing at the Orb v3 conservative inf-omat archive on HF. Quick Start code blocks in `simulations.md` updated to include `kups_md_mlff md_orb.yaml` and `kups_relax_mlff relax_orb.yaml`.

## Test plan

- [x] `uv run pre-commit run --all-files` clean.
- [x] `examples/md_orb.yaml` / `examples/relax_orb.yaml` exist and parse as YAML.