### PR TITLE
docs: print valid_mask in the OOB Tables example

### DIFF
--- a/docs/notebooks/tables.ipynb
+++ b/docs/notebooks/tables.ipynb
@@ -110,6 +110,9 @@
    "source": [
     "# Mark the last entry as out-of-bounds\n",
     "system_index = Index(keys=(SystemId(0),), indices=jnp.array([0, 0, 0, 1, 1]))\n",
+    "\n",
+    "# Each entry is either in-bounds (True) or OOB (False).\n",
+    "print(\"valid_mask:\", system_index.valid_mask)\n",
     "system_index"
    ]
   },


### PR DESCRIPTION
Fixes #38.

The Tables chapter used to rely on the `Index` repr printing `'OOB'` markers to make the out-of-bounds story visible ("see the `'OOB'` sentinel appear in the repr"), but the repr has been shortened and that beat no longer lands. Add an explicit `print(system_index.valid_mask)` to the OOB cell so the True/False pattern stays visible regardless of repr formatting.

The separate concern about stale rendered outputs in `tables.md` on the deployed site resolves itself on the next docs build — `docs/scripts/build.sh` runs `jupyter nbconvert --execute` so the rendered outputs are regenerated from the current `.ipynb` on every build.

## Test plan

- [x] `JAX_PLATFORMS=cpu uv run jupyter nbconvert --execute --to notebook docs/notebooks/tables.ipynb` executes end-to-end.
- [x] `uv run pre-commit run --all-files` clean.