### PR TITLE
docs: point mkdocs site_url at the deployed GH Pages site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: kUPS Docs
-site_url: https://github.com/cusp-ai-oss/kUPS
+site_url: https://cusp-ai-oss.github.io/kUPS/
 repo_url: https://github.com/cusp-ai-oss/kUPS
 repo_name: cusp-ai-oss/kUPS
 edit_uri: edit/main/docs/


### PR DESCRIPTION
Fixes #44.

`site_url` in `mkdocs.yml` pointed at the GitHub repo URL (`https://github.com/cusp-ai-oss/kUPS`). `site_url` is what mkdocs writes into sitemaps and canonical-URL tags, so it should match the real deployed site (`https://cusp-ai-oss.github.io/kUPS/`) — otherwise search engines and canonical-URL consumers get pointed at the wrong place.

Leaves `repo_url` / `repo_name` as the GitHub URLs since those control the Edit-this-page / source-code links in the mkdocs-material theme.

## Test plan

- [x] `uv run pre-commit run --all-files` clean.