### PR TITLE
docs: remove empty trailing code cell in conventions notebook

### DIFF
--- a/docs/notebooks/conventions.ipynb
+++ b/docs/notebooks/conventions.ipynb
@@ -293,13 +293,6 @@
     "print(\"full control:\", pot_a(s))\n",
     "print(\"from_state:  \", pot_b(s))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixes #55.

`conventions.ipynb` ended with an empty code cell that rendered as an empty code block at the bottom of the chapter. Cosmetic but looked like an unfinished thought.

## Test plan

- [x] `JAX_PLATFORMS=cpu uv run jupyter nbconvert --execute --to notebook docs/notebooks/conventions.ipynb` still executes cleanly.
- [x] `uv run pre-commit run --all-files` clean.