### PR TITLE
Fix: per-system optimizer states for batched relaxation of independent systems

### DIFF
--- a/examples/relax_mlff_vmapped.py
+++ b/examples/relax_mlff_vmapped.py
@@ -1,0 +1,445 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Batched MLFF relaxation with per-system vmapped LBFGS optimizer states.
+
+This is a standalone proof-of-concept demonstrating the fix for the
+shared-LBFGS convergence issue in batched relaxation. It uses kUPS's
+model loading and optimizer primitives but bypasses the Table/Lens
+propagator machinery to implement the split-vmap-scatter pattern
+directly.
+
+Architecture:
+  1. Batched model forward pass: one call over all concatenated atoms
+     (kUPS-native, no padding of model inputs)
+  2. Split per-atom gradients by system using static index arrays
+  3. Pad to (B, max_atoms, 3) for vmapped optimizer update
+  4. jax.vmap(optimizer.update) — independent LBFGS state per molecule
+  5. Unpad and scatter updates back to concatenated positions
+
+The entire step (gradient + split + pad + vmap LBFGS + unpad + scatter)
+is compiled into a single JIT'd JAX kernel.
+
+Usage:
+    python relax_mlff_vmapped.py config.yaml
+
+YAML config format (same as relax_mlff, plus optional per_system_optimizer):
+    inp_files:
+      - structure1.cif
+      - structure2.xyz
+    model_path: /path/to/model.zip  # or hf://...
+    relax:
+      optimizer:
+        - transform: scale_by_ase_lbfgs
+          memory_size: 20
+          alpha: 70
+        - transform: max_step_size
+          max_step_size: 0.2
+        - transform: scale
+          step_size: -1
+      optimize_cell: false
+    run:
+      out_file: relax_output.json
+      max_steps: 200
+      force_tolerance: 0.01
+      seed: 42
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import zipfile
+from pathlib import Path
+
+import ase.io
+import jax
+import jax.numpy as jnp
+import msgpack
+import numpy as np
+import optax
+import torch
+import yaml
+from jax import export as jax_export
+
+jax.config.update("jax_default_matmul_precision", "highest")
+jax.config.update("jax_enable_x64", True)
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+# Conditionally import kUPS components (graceful fallback for standalone use)
+try:
+    from kups.relaxation.optax import make_optimizer
+except ImportError:
+    make_optimizer = None
+
+try:
+    from fairchem.core.datasets.atomic_data import AtomicData
+
+    AtomicData.validate = lambda self: None
+except ImportError:
+    AtomicData = None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Model loading
+# ─────────────────────────────────────────────────────────────────────────
+def load_jaxified_model(model_path: str | Path):
+    """Load a jaxified MLFF model from a kUPS-format zip archive."""
+    model_path = Path(model_path)
+    if str(model_path).startswith("hf://"):
+        from huggingface_hub import hf_hub_download
+
+        parts = str(model_path)[5:].split("/", 2)
+        model_path = Path(
+            hf_hub_download(repo_id=f"{parts[0]}/{parts[1]}", filename=parts[2])
+        )
+
+    with zipfile.ZipFile(model_path) as zf:
+        exp = jax_export.deserialize(bytearray(zf.read("model.jax")))
+        raw = msgpack.unpackb(zf.read("params.msgpack"), raw=False)
+        params = [
+            jnp.array(
+                np.frombuffer(e["data"], dtype=np.dtype(e["dtype"]))
+                .reshape(e["shape"])
+                .copy()
+            )
+            for e in raw
+        ]
+        metadata = json.loads(zf.read("metadata.json"))
+    return exp, params, metadata
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Structure loading and graph construction
+# ─────────────────────────────────────────────────────────────────────────
+def load_molecules(inp_files, radius=6.0, max_neigh=300):
+    """Load structures and build per-molecule graph data."""
+    torch.set_default_device("cpu")
+    mol_data = []
+    for f in inp_files:
+        atoms = ase.io.read(str(f))
+        if not any(atoms.pbc):
+            atoms.center(vacuum=5.0)
+            atoms.pbc = True
+        atoms.info.setdefault("charge", 0)
+        atoms.info.setdefault("spin", 1)
+        data = AtomicData.from_ase(
+            atoms,
+            task_name="omol",
+            r_edges=True,
+            r_data_keys=["spin", "charge"],
+            max_neigh=max_neigh,
+            radius=radius,
+            target_dtype=torch.float32,
+        )
+        mol_data.append(
+            {
+                "name": Path(f).stem,
+                "n_atoms": len(atoms),
+                "pos": data.pos.numpy(),
+                "atomic_numbers": data.atomic_numbers.numpy(),
+                "cell": data.cell.numpy(),
+                "pbc": data.pbc.numpy(),
+                "edge_index": data.edge_index.numpy(),
+                "cell_offsets": data.cell_offsets.numpy(),
+                "batch": data.batch.numpy(),
+                "charge": data.charge.numpy(),
+                "spin": data.spin.numpy(),
+            }
+        )
+    return mol_data
+
+
+def build_batched_graph(mol_data):
+    """Concatenate per-molecule data into a single batched graph."""
+    B = len(mol_data)
+    system_counts = np.array([m["n_atoms"] for m in mol_data])
+    N_total = int(system_counts.sum())
+    max_atoms = int(system_counts.max())
+
+    all_pos = np.concatenate([m["pos"] for m in mol_data])
+    all_an = np.concatenate([m["atomic_numbers"] for m in mol_data])
+    all_cell = np.concatenate([m["cell"] for m in mol_data])
+    all_pbc = np.concatenate([m["pbc"] for m in mol_data])
+    all_charge = np.concatenate([m["charge"] for m in mol_data])
+    all_spin = np.concatenate([m["spin"] for m in mol_data])
+    batch_idx = np.concatenate(
+        [np.full(m["n_atoms"], i) for i, m in enumerate(mol_data)]
+    )
+
+    atom_offset = 0
+    ei_list, co_list = [], []
+    for m in mol_data:
+        ei_list.append(m["edge_index"] + atom_offset)
+        co_list.append(m["cell_offsets"])
+        atom_offset += m["n_atoms"]
+
+    static_graph = {
+        "atomic_numbers": jnp.array(all_an),
+        "cell": jnp.array(all_cell, dtype=jnp.float32),
+        "pbc": jnp.array(all_pbc),
+        "edge_index": jnp.array(np.concatenate(ei_list, axis=1)),
+        "cell_offsets": jnp.array(np.concatenate(co_list), dtype=jnp.float32),
+        "batch": jnp.array(batch_idx),
+        "charge": jnp.array(all_charge),
+        "spin": jnp.array(all_spin),
+    }
+    positions = jnp.array(all_pos, dtype=jnp.float32)
+
+    # Static index arrays for JIT-friendly split/pad/scatter
+    system_offsets = np.concatenate([[0], np.cumsum(system_counts[:-1])])
+    gather_indices = np.full((B, max_atoms), N_total, dtype=np.int32)
+    for i in range(B):
+        gather_indices[i, : system_counts[i]] = np.arange(
+            system_offsets[i], system_offsets[i] + system_counts[i]
+        )
+    grad_mask = np.zeros((B, max_atoms, 1))
+    for i in range(B):
+        grad_mask[i, : system_counts[i]] = 1.0
+    fmax_mask = np.zeros((B, max_atoms), dtype=bool)
+    for i in range(B):
+        fmax_mask[i, : system_counts[i]] = True
+
+    return (
+        static_graph,
+        positions,
+        B,
+        N_total,
+        max_atoms,
+        system_counts,
+        jnp.array(gather_indices),
+        jnp.array(grad_mask),
+        jnp.array(fmax_mask),
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# JIT'd optimization step
+# ─────────────────────────────────────────────────────────────────────────
+def make_full_step(energy_fn, static_graph, optimizer, gather_idx, grad_mask,
+                   fmax_mask, N_total):
+    """Build a fully JIT'd optimization step function.
+
+    The returned function compiles gradient computation, per-system
+    splitting, vmapped LBFGS update, and scatter-back into one kernel.
+    """
+    sg = static_graph
+    vmapped_update = jax.vmap(lambda g, s, p: optimizer.update(g, s, p))
+
+    @jax.jit
+    def step(positions, opt_states, freeze_mask):
+        def energy_sum(pos):
+            return jnp.sum(energy_fn({**sg, "pos": pos}))
+
+        _, grad = jax.value_and_grad(energy_sum)(positions)
+        per_sys_e = energy_fn({**sg, "pos": positions})
+
+        grad_ext = jnp.concatenate([grad, jnp.zeros((1, 3), dtype=grad.dtype)])
+        padded_grad = grad_ext[gather_idx] * grad_mask * freeze_mask
+
+        pos_ext = jnp.concatenate(
+            [positions, jnp.zeros((1, 3), dtype=positions.dtype)]
+        )
+        padded_pos = pos_ext[gather_idx]
+
+        force_norms = jnp.linalg.norm(-padded_grad, axis=-1)
+        force_norms = jnp.where(fmax_mask, force_norms, 0.0)
+        per_mol_fmax = jnp.max(force_norms, axis=-1)
+
+        padded_updates, new_opt_states = vmapped_update(
+            padded_grad, opt_states, padded_pos
+        )
+        padded_updates = padded_updates * freeze_mask
+
+        B_local, max_a, _ = padded_updates.shape
+        flat_updates = padded_updates.reshape(B_local * max_a, 3)
+        flat_indices = gather_idx.reshape(B_local * max_a)
+        real_mask = flat_indices < N_total
+        safe_idx = jnp.where(real_mask, flat_indices, 0)
+        new_positions = positions.at[safe_idx].add(flat_updates * real_mask[:, None])
+
+        return new_positions.astype(jnp.float32), new_opt_states, per_sys_e, per_mol_fmax
+
+    return step
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Main relaxation loop
+# ─────────────────────────────────────────────────────────────────────────
+def run_relaxation(config_path: str | Path):
+    """Run batched relaxation with per-molecule vmapped LBFGS."""
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    max_steps = config["run"]["max_steps"]
+    fmax_tol = config["run"]["force_tolerance"]
+    out_file = config["run"].get("out_file", "relax_results.json")
+
+    # Load model
+    logging.info("Loading model...")
+    exp, params, metadata = load_jaxified_model(config["model_path"])
+    cutoff = metadata.get("cutoff", 6.0)
+
+    def energy_fn(data):
+        return exp.call(params, data)
+
+    # Load structures and build batched graph
+    logging.info("Loading structures...")
+    mol_data = load_molecules(config["inp_files"], radius=cutoff)
+    (sg, positions, B, N_total, max_atoms, system_counts,
+     gather_idx, grad_mask, fmax_mask) = build_batched_graph(mol_data)
+
+    logging.info(
+        f"{B} molecules, {N_total} total atoms, max_atoms={max_atoms}"
+    )
+
+    # Build optimizer
+    if make_optimizer is not None:
+        optimizer = make_optimizer(config["relax"]["optimizer"])
+    else:
+        optimizer = optax.chain(
+            optax.scale_by_lbfgs(memory_size=20),
+            optax.scale(-1.0),
+        )
+
+    # Initialize per-molecule optimizer states
+    pos_ext = jnp.concatenate(
+        [positions, jnp.zeros((1, 3), dtype=positions.dtype)]
+    )
+    padded_pos_init = pos_ext[gather_idx]
+    all_opt_states = jax.vmap(optimizer.init)(padded_pos_init)
+
+    # Build JIT'd step function
+    full_step = make_full_step(
+        energy_fn, sg, optimizer, gather_idx, grad_mask, fmax_mask, N_total
+    )
+
+    # Compile
+    logging.info("Compiling JIT'd step...")
+    t0 = time.time()
+    freeze_mask = jnp.ones((B, 1, 1))
+    new_pos, new_ost, pse, pmf = full_step(positions, all_opt_states, freeze_mask)
+    jax.block_until_ready(pmf)
+    compile_time = time.time() - t0
+    logging.info(f"Compiled in {compile_time:.1f}s")
+
+    # Speed check
+    times = []
+    pos_tmp, ost_tmp = positions, all_opt_states
+    for _ in range(10):
+        t0 = time.perf_counter()
+        pos_tmp, ost_tmp, _, _ = full_step(pos_tmp, ost_tmp, freeze_mask)
+        jax.block_until_ready(pos_tmp)
+        times.append(time.perf_counter() - t0)
+    ms_per_step = sorted(times)[5] * 1000
+    logging.info(f"Per-step: {ms_per_step:.1f}ms for {B} molecules")
+
+    # Reset state
+    positions = jnp.array(
+        np.concatenate([m["pos"] for m in mol_data]), dtype=jnp.float32
+    )
+    pos_ext = jnp.concatenate(
+        [positions, jnp.zeros((1, 3), dtype=positions.dtype)]
+    )
+    all_opt_states = jax.vmap(optimizer.init)(pos_ext[gather_idx])
+
+    # Main loop
+    converged = [False] * B
+    converged_step = [-1] * B
+    final_energy = np.zeros(B)
+    final_fmax = np.full(B, 999.0)
+    freeze_arr = np.ones(B)
+
+    logging.info(
+        f"\nOptimizing {B} molecules, fmax<{fmax_tol}, max {max_steps} steps"
+    )
+    t_start = time.time()
+
+    for step in range(max_steps):
+        freeze_mask = jnp.array(freeze_arr)[:, None, None]
+        positions, all_opt_states, per_sys_e, per_mol_fmax = full_step(
+            positions, all_opt_states, freeze_mask
+        )
+
+        fmax_np = np.asarray(jax.block_until_ready(per_mol_fmax))
+        energy_np = np.asarray(per_sys_e)
+
+        all_done = True
+        for i in range(B):
+            if converged[i]:
+                continue
+            final_energy[i] = energy_np[i]
+            final_fmax[i] = fmax_np[i]
+            if fmax_np[i] < fmax_tol:
+                converged[i] = True
+                converged_step[i] = step
+                freeze_arr[i] = 0.0
+            else:
+                all_done = False
+
+        if all_done:
+            break
+
+        if step % 25 == 0:
+            nc = sum(converged)
+            afmax = [final_fmax[i] for i in range(B) if not converged[i]]
+            if afmax:
+                logging.info(
+                    f"  Step {step:>3} ({time.time()-t_start:>5.1f}s): "
+                    f"{nc}/{B} converged, "
+                    f"fmax=[{min(afmax):.4f}, {max(afmax):.4f}]"
+                )
+
+    t_total = time.time() - t_start
+    nc = sum(converged)
+
+    # Results
+    logging.info(f"\n{'='*80}")
+    logging.info(f"  {nc}/{B} converged in {t_total:.1f}s ({ms_per_step:.1f}ms/step)")
+    logging.info(f"{'='*80}")
+    logging.info(
+        f"{'Molecule':<28} {'Atoms':>5} {'Steps':>6} {'fmax':>10} "
+        f"{'Energy (eV)':>14} {'Conv':>5}"
+    )
+    logging.info("-" * 80)
+    for i, m in enumerate(mol_data):
+        st = converged_step[i] if converged[i] else max_steps
+        c = "Y" if converged[i] else "N"
+        logging.info(
+            f"{m['name']:<28} {m['n_atoms']:>5} {st:>6} "
+            f"{final_fmax[i]:>10.6f} {final_energy[i]:>14.4f} {c:>5}"
+        )
+
+    results = [
+        {
+            "name": mol_data[i]["name"],
+            "n_atoms": mol_data[i]["n_atoms"],
+            "steps": converged_step[i] if converged[i] else max_steps,
+            "fmax": float(final_fmax[i]),
+            "energy": float(final_energy[i]),
+            "converged": converged[i],
+        }
+        for i in range(B)
+    ]
+    output = {
+        "wall_time_s": t_total,
+        "compile_time_s": compile_time,
+        "per_step_ms": ms_per_step,
+        "converged": nc,
+        "total": B,
+        "results": results,
+    }
+    with open(out_file, "w") as f:
+        json.dump(output, f, indent=2)
+    logging.info(f"\nResults saved to {out_file}")
+    return output
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} config.yaml")
+        sys.exit(1)
+    run_relaxation(sys.argv[1])

--- a/examples/shared_lbfgs_bug.py
+++ b/examples/shared_lbfgs_bug.py
@@ -1,0 +1,153 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal reproduction: shared LBFGS across independent systems degrades convergence.
+
+This script demonstrates that when two independent quadratic systems with
+different curvatures share a single LBFGS optimizer (as happens in kUPS's
+batched relaxation), the inverse Hessian approximation is corrupted and
+convergence degrades catastrophically.
+
+No kUPS installation or ML model needed — pure NumPy.
+
+Usage:
+    python shared_lbfgs_bug.py
+"""
+
+import numpy as np
+
+
+def lbfgs_two_loop(grad, s_list, y_list, rho_list, H0, memory, iteration):
+    """Standard L-BFGS two-loop recursion (Nocedal Algorithm 7.4)."""
+    loopmax = min(memory, iteration)
+    a = np.empty(loopmax)
+    q = grad.copy()
+    for i in range(loopmax - 1, -1, -1):
+        a[i] = rho_list[i] * np.dot(s_list[i], q)
+        q -= a[i] * y_list[i]
+    z = H0 * q
+    for i in range(loopmax):
+        b = rho_list[i] * np.dot(y_list[i], z)
+        z += s_list[i] * (a[i] - b)
+    return z
+
+
+def run_independent_lbfgs(x0, grad_fn, steps=50, alpha=70.0, memory=100,
+                          maxstep=0.2):
+    """Run LBFGS on a single system (ASE-equivalent behavior)."""
+    H0 = 1.0 / alpha
+    s_list, y_list, rho_list = [], [], []
+    x, r0, g0 = x0.copy(), None, None
+    history = []
+    for step in range(steps):
+        g = grad_fn(x)
+        history.append(float(np.max(np.abs(g))))
+        if step > 0:
+            s, y = x - r0, g - g0
+            dot = np.dot(y, s)
+            if abs(dot) > 1e-30:
+                s_list.append(s)
+                y_list.append(y)
+                rho_list.append(1.0 / dot)
+                if len(s_list) > memory:
+                    s_list.pop(0)
+                    y_list.pop(0)
+                    rho_list.pop(0)
+        d = lbfgs_two_loop(g, s_list, y_list, rho_list, H0, memory, step)
+        dmax = np.max(np.abs(d))
+        if dmax > maxstep:
+            d *= maxstep / dmax
+        r0, g0 = x.copy(), g.copy()
+        x = x - d
+    return history
+
+
+def run_shared_lbfgs(x0_a, x0_b, grad_a, grad_b, steps=50, alpha=70.0,
+                     memory=100, maxstep=0.2):
+    """Run ONE shared LBFGS over concatenated [x_a, x_b].
+
+    This mimics kUPS's current batched relaxation behavior: all systems'
+    positions are concatenated and one optimizer state is shared.
+    """
+    H0 = 1.0 / alpha
+    s_list, y_list, rho_list = [], [], []
+    n_a = len(x0_a)
+    x = np.concatenate([x0_a, x0_b])
+    r0, g0 = None, None
+    hist_a, hist_b = [], []
+    for step in range(steps):
+        g = np.concatenate([grad_a(x[:n_a]), grad_b(x[n_a:])])
+        hist_a.append(float(np.max(np.abs(g[:n_a]))))
+        hist_b.append(float(np.max(np.abs(g[n_a:]))))
+        if step > 0:
+            s, y = x - r0, g - g0
+            dot = np.dot(y, s)
+            if abs(dot) > 1e-30:
+                s_list.append(s)
+                y_list.append(y)
+                rho_list.append(1.0 / dot)
+                if len(s_list) > memory:
+                    s_list.pop(0)
+                    y_list.pop(0)
+                    rho_list.pop(0)
+        d = lbfgs_two_loop(g, s_list, y_list, rho_list, H0, memory, step)
+        dmax = np.max(np.abs(d))
+        if dmax > maxstep:
+            d *= maxstep / dmax
+        r0, g0 = x.copy(), g.copy()
+        x = x - d
+    return hist_a, hist_b
+
+
+def main():
+    np.random.seed(42)
+    dim = 81  # 27 atoms × 3 coordinates (like a small drug molecule)
+
+    # System A: steep, well-conditioned (eigenvalues 10–100)
+    Q_a = np.linalg.qr(np.random.randn(dim, dim))[0]
+    H_a = Q_a @ np.diag(np.linspace(10, 100, dim)) @ Q_a.T
+
+    # System B: shallow, ill-conditioned (eigenvalues 0.1–10)
+    Q_b = np.linalg.qr(np.random.randn(dim, dim))[0]
+    H_b = Q_b @ np.diag(np.linspace(0.1, 10, dim)) @ Q_b.T
+
+    x0 = np.random.randn(dim) * 0.5
+
+    # Independent LBFGS (correct behavior — each system gets its own state)
+    indep_a = run_independent_lbfgs(x0, lambda x: H_a @ x, steps=50)
+    indep_b = run_independent_lbfgs(x0, lambda x: H_b @ x, steps=50)
+
+    # Shared LBFGS (kUPS batched behavior — one state for both)
+    batch_a, batch_b = run_shared_lbfgs(
+        x0, x0, lambda x: H_a @ x, lambda x: H_b @ x, steps=50
+    )
+
+    print("=" * 70)
+    print("  Shared vs Independent LBFGS on independent quadratic systems")
+    print("=" * 70)
+    print(f"  System A: eigenvalues [10, 100], dim={dim}")
+    print(f"  System B: eigenvalues [0.1, 10], dim={dim}")
+    print(f"  alpha=70, memory=100, maxstep=0.2, steps=50\n")
+
+    print(f"  {'Step':>4}  {'A indep':>10} {'A shared':>10} {'ratio':>10}"
+          f"  {'B indep':>10} {'B shared':>10} {'ratio':>10}")
+    print("  " + "-" * 66)
+    for i in [0, 5, 10, 20, 30, 40, 49]:
+        ra = batch_a[i] / indep_a[i] if indep_a[i] > 1e-30 else float("inf")
+        rb = batch_b[i] / indep_b[i] if indep_b[i] > 1e-30 else float("inf")
+        print(f"  {i:>4}  {indep_a[i]:>10.2e} {batch_a[i]:>10.2e} {ra:>9.1f}x"
+              f"  {indep_b[i]:>10.2e} {batch_b[i]:>10.2e} {rb:>9.1f}x")
+
+    print(f"\n  Final gmax after 50 steps:")
+    ratio_a = batch_a[-1] / indep_a[-1] if indep_a[-1] > 1e-30 else float("inf")
+    print(f"    System A: Independent={indep_a[-1]:.2e}  "
+          f"Shared={batch_a[-1]:.2e}  ({ratio_a:.0f}x worse)")
+    print(f"    System B: Independent={indep_b[-1]:.2e}  "
+          f"Shared={batch_b[-1]:.2e}")
+    print(f"\n  The shared LBFGS corrupts System A's convergence by mixing")
+    print(f"  curvature information from the unrelated System B into the")
+    print(f"  inverse Hessian approximation via the s·y dot products.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Problem

When `relax_mlff` optimizes multiple independent structures (e.g., drug molecules), all systems share a single LBFGS optimizer state over the concatenated position vector. The L-BFGS `s·y` dot products in the two-loop recursion mix curvature information from unrelated potential energy surfaces, corrupting the inverse Hessian approximation. This causes 1/25 convergence instead of 22/25.

See companion issue #94 for a minimal pure-NumPy reproduction (`examples/shared_lbfgs_bug.py`).

### Context

This was discovered by Sam Blau and an AI assistant (Claude, via [Axon](https://www.mirrorphysics.com) by Mirror Physics) while benchmarking kUPS for batched molecular geometry optimization. We think kUPS is a promising framework and hope this is useful.

### Fix

After the batched gradient computation (one forward+backward pass over all concatenated atoms), split gradients by system, pad to a common shape, and run `jax.vmap(optimizer.update)` over independent per-molecule optimizer states. The entire step — gradient + split + pad + vmapped LBFGS + unpad + scatter — compiles into a single JIT'd kernel.

### Results (25 drug molecules, UMA-s-1p2 OMol, H100)

| Method | Converged (fmax < 0.01 eV/Å) | Wall time | Per-step |
|--------|-------------------------------|-----------|----------|
| ASE LBFGS (PyTorch, sequential) | 22/25 | 287s | 105ms/mol |
| `relax_mlff` (shared LBFGS) | 1/25 | 145s | — |
| **This PR (vmapped per-molecule LBFGS)** | **22/25** | **19s** | **94ms/all 25** |

Step counts match ASE exactly (e.g., tafamidis: 19 both, dapagliflozin: 40 both, lenalidomide: 37 both). The 3 unconverged molecules are the same ones ASE can't converge in 200 steps.

### What's included

- `examples/shared_lbfgs_bug.py` — minimal pure-NumPy reproduction of the shared-LBFGS convergence bug (no kUPS or GPU needed)
- `examples/relax_mlff_vmapped.py` — standalone proof-of-concept implementing the fix using kUPS's model loading and optimizer primitives

### Design notes

This PR adds example scripts rather than modifying kUPS internals directly, since we're external contributors and wanted to demonstrate the approach without presuming how it should integrate into the Table/Lens/Propagator architecture. The key pattern is:

```python
# After batched gradient: grad shape (N_total, 3)
# Split by system using static gather indices (JIT-friendly)
padded_grad = grad_extended[gather_indices] * grad_mask  # (B, max_atoms, 3)

# Per-molecule vmapped LBFGS (independent states)
vmapped_update = jax.vmap(lambda g, s, p: optimizer.update(g, s, p))
updates, new_states = vmapped_update(padded_grad, per_mol_states, padded_pos)

# Scatter back to concatenated positions
positions = positions.at[scatter_indices].add(flat_updates)
```

A natural integration into kUPS could be a `per_system_optimizer: bool` flag in `RelaxParameters` that switches the `RelaxationPropagator` to use vmapped states. The vmapped LBFGS kernel compiles in <1s and runs in <1ms — the overhead is negligible.

