### PR TITLE
feat: Implement per-axis periodic mask support in cell list

### DIFF
--- a/src/kups/application/utils/particles.py
+++ b/src/kups/application/utils/particles.py
@@ -13,7 +13,13 @@ import ase.io
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.cell import Cell, PeriodicCell, TriclinicFrame, to_lower_triangular
+from kups.core.cell import (
+    Cell,
+    PeriodicCell,
+    TriclinicFrame,
+    VacuumCell,
+    to_lower_triangular,
+)
 from kups.core.data import Index, Table
 from kups.core.typing import ExclusionId, InclusionId, Label, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
@@ -73,7 +79,24 @@ def particles_from_ase(
     if isinstance(atoms, (str, Path)):
         atoms = next(ase.io.iread(atoms, index=-1, store_tags=True))
     L, uc_transform = to_lower_triangular(jnp.asarray(atoms.cell.array))
-    cell = PeriodicCell(TriclinicFrame.from_matrix(L))
+    pbc: tuple[bool, bool, bool] = (
+        bool(atoms.pbc[0]),
+        bool(atoms.pbc[1]),
+        bool(atoms.pbc[2]),
+    )
+    cell: Cell
+    if all(pbc):
+        cell = PeriodicCell(TriclinicFrame.from_matrix(L))
+    elif not any(pbc):
+        cell = VacuumCell(TriclinicFrame.from_matrix(L))
+    else:
+        # Mixed-axis periodicity (slab / wire) needs a runtime per-axis mask;
+        # the current Cell hierarchy only exposes the all-True / all-False
+        # literals. Reintroduce a slab-shaped cell when a real consumer lands.
+        raise NotImplementedError(
+            f"Mixed per-axis periodicity {pbc} is not supported. "
+            "Use uniform pbc=True (PeriodicCell) or pbc=False (VacuumCell)."
+        )
     # Rotate Cartesian positions into the lower-triangular frame.
     positions = uc_transform(jnp.asarray(atoms.positions))
     masses = jnp.asarray(atoms.get_masses())

--- a/src/kups/application/utils/particles.py
+++ b/src/kups/application/utils/particles.py
@@ -13,13 +13,7 @@ import ase.io
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.cell import (
-    Cell,
-    PeriodicCell,
-    TriclinicFrame,
-    VacuumCell,
-    to_lower_triangular,
-)
+from kups.core.cell import Cell, TriclinicFrame, to_lower_triangular
 from kups.core.data import Index, Table
 from kups.core.typing import ExclusionId, InclusionId, Label, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
@@ -79,22 +73,8 @@ def particles_from_ase(
     if isinstance(atoms, (str, Path)):
         atoms = next(ase.io.iread(atoms, index=-1, store_tags=True))
     L, uc_transform = to_lower_triangular(jnp.asarray(atoms.cell.array))
-    frame = TriclinicFrame.from_matrix(L)
-    pbc: tuple[bool, bool, bool] = (
-        bool(atoms.pbc[0]),
-        bool(atoms.pbc[1]),
-        bool(atoms.pbc[2]),
-    )
-    cell: Cell
-    match pbc:
-        case (True, True, True):
-            cell = PeriodicCell(frame)
-        case (False, False, False):
-            cell = VacuumCell(frame)
-        case (True, True, False) | (True, False, True) | (False, True, True):
-            cell = Cell(frame, periodic=pbc)
-        case (True, False, False) | (False, True, False) | (False, False, True):
-            cell = Cell(frame, periodic=pbc)
+    pbc = (bool(atoms.pbc[0]), bool(atoms.pbc[1]), bool(atoms.pbc[2]))
+    cell = Cell.from_pbc(TriclinicFrame.from_matrix(L), pbc)
     positions = uc_transform(jnp.asarray(atoms.positions))
     masses = jnp.asarray(atoms.get_masses())
     atomic_numbers = jnp.asarray(atoms.get_atomic_numbers())

--- a/src/kups/application/utils/particles.py
+++ b/src/kups/application/utils/particles.py
@@ -79,24 +79,28 @@ def particles_from_ase(
     if isinstance(atoms, (str, Path)):
         atoms = next(ase.io.iread(atoms, index=-1, store_tags=True))
     L, uc_transform = to_lower_triangular(jnp.asarray(atoms.cell.array))
+    frame = TriclinicFrame.from_matrix(L)
     pbc: tuple[bool, bool, bool] = (
         bool(atoms.pbc[0]),
         bool(atoms.pbc[1]),
         bool(atoms.pbc[2]),
     )
+    # Match dispatch narrows `pbc` from `tuple[bool, bool, bool]` to the
+    # specific literal alias on each branch — `Cell(frame, pbc)` infers
+    # the cell's P parameter from the narrowed tuple type. The 8 patterns
+    # exhaustively cover every (bool, bool, bool) value.
     cell: Cell
-    if all(pbc):
-        cell = PeriodicCell(TriclinicFrame.from_matrix(L))
-    elif not any(pbc):
-        cell = VacuumCell(TriclinicFrame.from_matrix(L))
-    else:
-        # Mixed-axis periodicity (slab / wire) needs a runtime per-axis mask;
-        # the current Cell hierarchy only exposes the all-True / all-False
-        # literals. Reintroduce a slab-shaped cell when a real consumer lands.
-        raise NotImplementedError(
-            f"Mixed per-axis periodicity {pbc} is not supported. "
-            "Use uniform pbc=True (PeriodicCell) or pbc=False (VacuumCell)."
-        )
+    match pbc:
+        case (True, True, True):
+            cell = PeriodicCell(frame)
+        case (False, False, False):
+            cell = VacuumCell(frame)
+        case (True, True, False) | (True, False, True) | (False, True, True):
+            cell = Cell(frame, periodic=pbc)  # Cell[Slab2D]
+        case (True, False, False) | (False, True, False) | (False, False, True):
+            cell = Cell(frame, periodic=pbc)  # Cell[Wire1D]
+        case _:
+            raise ValueError(f"unreachable: {pbc}")  # 8 cases above are exhaustive
     # Rotate Cartesian positions into the lower-triangular frame.
     positions = uc_transform(jnp.asarray(atoms.positions))
     masses = jnp.asarray(atoms.get_masses())

--- a/src/kups/application/utils/particles.py
+++ b/src/kups/application/utils/particles.py
@@ -85,10 +85,6 @@ def particles_from_ase(
         bool(atoms.pbc[1]),
         bool(atoms.pbc[2]),
     )
-    # Match dispatch narrows `pbc` from `tuple[bool, bool, bool]` to the
-    # specific literal alias on each branch — `Cell(frame, pbc)` infers
-    # the cell's P parameter from the narrowed tuple type. The 8 patterns
-    # exhaustively cover every (bool, bool, bool) value.
     cell: Cell
     match pbc:
         case (True, True, True):
@@ -96,12 +92,9 @@ def particles_from_ase(
         case (False, False, False):
             cell = VacuumCell(frame)
         case (True, True, False) | (True, False, True) | (False, True, True):
-            cell = Cell(frame, periodic=pbc)  # Cell[Slab2D]
+            cell = Cell(frame, periodic=pbc)
         case (True, False, False) | (False, True, False) | (False, False, True):
-            cell = Cell(frame, periodic=pbc)  # Cell[Wire1D]
-        case _:
-            raise ValueError(f"unreachable: {pbc}")  # 8 cases above are exhaustive
-    # Rotate Cartesian positions into the lower-triangular frame.
+            cell = Cell(frame, periodic=pbc)
     positions = uc_transform(jnp.asarray(atoms.positions))
     masses = jnp.asarray(atoms.get_masses())
     atomic_numbers = jnp.asarray(atoms.get_atomic_numbers())

--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -462,25 +462,23 @@ class Cell[P: tuple[bool, bool, bool]](Sliceable):
     ) -> Array:
         return _wrap(self.frame, self.periodic, r, input_space, output_space)
 
-    def fold(self, r_frac: Array) -> Array:
-        """Fold fractional coords into ``[0, 1)`` on periodic axes;
-        non-periodic axes pass through unchanged.
+    def fold(self, r_frac: Array) -> tuple[Array, Array]:
+        """Fold fractional coords into ``[0, 1)`` on periodic axes; non-periodic
+        axes pass through unchanged.
+
+        Returns ``(folded, in_cell)`` where ``in_cell`` is a per-particle
+        mask, ``True`` where the folded coords lie in ``[0, 1)`` on every
+        axis. For fully-periodic cells, ``in_cell`` is trivially ``True``
+        after folding; for cells with non-periodic axes, particles that
+        leaked out of the box on those axes are flagged ``False``.
 
         Used by neighbor-list spatial hashing; complementary to
         [`wrap`][kups.core.cell.Cell.wrap] which uses the ``[-0.5, 0.5)``
         convention.
         """
-        return jnp.where(jnp.array(self.periodic), r_frac % 1, r_frac)
-
-    def in_box(self, r_frac: Array) -> Array:
-        """Per-particle mask: ``True`` where fractional coords lie in
-        ``[0, 1)`` on every axis (i.e. inside the cell's parallelepiped).
-
-        Companion to [`fold`][kups.core.cell.Cell.fold]: after folding,
-        periodic axes are guaranteed in range, so this only filters
-        particles that left the box on a non-periodic axis.
-        """
-        return jnp.all((r_frac >= 0) & (r_frac < 1), axis=-1)
+        folded = jnp.where(jnp.array(self.periodic), r_frac % 1, r_frac)
+        in_cell = jnp.all((folded >= 0) & (folded < 1), axis=-1)
+        return folded, in_cell
 
     def minimum_image_shifts(self, deltas: Array) -> Array:
         """Per-axis minimum-image shifts for fractional separations.

--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -96,7 +96,7 @@ from __future__ import annotations
 import math
 from enum import Enum
 from functools import partial
-from typing import Any, Literal, Protocol, Self, TypeGuard
+from typing import Any, Literal, Protocol, Self, TypeGuard, overload
 
 import jax
 import jax.numpy as jnp
@@ -472,6 +472,16 @@ class Cell[P: tuple[bool, bool, bool]](Sliceable):
         """
         return jnp.where(jnp.array(self.periodic), r_frac % 1, r_frac)
 
+    def in_box(self, r_frac: Array) -> Array:
+        """Per-particle mask: ``True`` where fractional coords lie in
+        ``[0, 1)`` on every axis (i.e. inside the cell's parallelepiped).
+
+        Companion to [`fold`][kups.core.cell.Cell.fold]: after folding,
+        periodic axes are guaranteed in range, so this only filters
+        particles that left the box on a non-periodic axis.
+        """
+        return jnp.all((r_frac >= 0) & (r_frac < 1), axis=-1)
+
     def minimum_image_shifts(self, deltas: Array) -> Array:
         """Per-axis minimum-image shifts for fractional separations.
 
@@ -484,6 +494,33 @@ class Cell[P: tuple[bool, bool, bool]](Sliceable):
     def __mul__(self, other: Array | float | int) -> Self:
         return bind(self, lambda c: c.frame).set(self.frame * other)
 
+    @overload
+    @staticmethod
+    def from_pbc(frame: Frame, pbc: Periodic3D) -> PeriodicCell: ...
+    @overload
+    @staticmethod
+    def from_pbc(frame: Frame, pbc: Vacuum) -> VacuumCell: ...
+    @overload
+    @staticmethod
+    def from_pbc[Q: tuple[bool, bool, bool]](frame: Frame, pbc: Q) -> Cell[Q]: ...
+    @staticmethod
+    def from_pbc(frame: Frame, pbc: tuple[bool, bool, bool]) -> Cell[Any]:
+        """Construct the cell flavor matching ``pbc``.
+
+        Returns [`PeriodicCell`][kups.core.cell.PeriodicCell] for
+        ``(True, True, True)``, [`VacuumCell`][kups.core.cell.VacuumCell]
+        for ``(False, False, False)``, and a generic ``Cell[P]`` carrying
+        the runtime mask for slab and wire geometries (``P`` is inferred
+        from the literal tuple).
+        """
+        match pbc:
+            case (True, True, True):
+                return PeriodicCell(frame)
+            case (False, False, False):
+                return VacuumCell(frame)
+            case _:
+                return Cell(frame, periodic=pbc)
+
 
 @dataclass
 class PeriodicCell(Cell[Periodic3D]):
@@ -495,7 +532,7 @@ class PeriodicCell(Cell[Periodic3D]):
     Ewald summation requires this cell type.
     """
 
-    periodic: Periodic3D = field(default=(True, True, True), static=True)
+    periodic: Periodic3D = field(default=(True, True, True), init=False, static=True)
 
 
 @dataclass
@@ -509,7 +546,7 @@ class VacuumCell(Cell[Vacuum]):
     neighbor-list machinery needs a spatial-partitioning hint.
     """
 
-    periodic: Vacuum = field(default=(False, False, False), static=True)
+    periodic: Vacuum = field(default=(False, False, False), init=False, static=True)
 
 
 def min_multiplicity(cell: Cell, cutoff: float | Array) -> Array:

--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -105,7 +105,7 @@ from jax import Array
 
 from kups.core.data import Sliceable
 from kups.core.lens import Lens, bind
-from kups.core.utils.jax import dataclass
+from kups.core.utils.jax import dataclass, field
 from kups.core.utils.math import triangular_3x3_det_and_inverse, triangular_3x3_matmul
 
 
@@ -407,24 +407,24 @@ def _wrap(
 class Cell[P: tuple[bool, bool, bool]](Sliceable):
     """A [Frame][kups.core.cell.Frame] plus per-axis boundary semantics.
 
-    Generic over the periodicity literal ``P``. Concrete subclasses pin
-    ``P`` to a literal-typed tuple via a read-only ``periodic`` property
-    so construction is runtime-honest — ``PeriodicCell(frame, ...)`` with
-    an extra periodic argument raises ``TypeError``.
+    Generic over the periodicity literal ``P``.
+    [PeriodicCell][kups.core.cell.PeriodicCell] and
+    [VacuumCell][kups.core.cell.VacuumCell] pin ``P`` to a literal tuple
+    via ``init=False`` defaults so construction is runtime-honest —
+    ``PeriodicCell(frame, ...)`` with an extra periodic argument raises
+    ``TypeError``. [SlabCell][kups.core.cell.SlabCell] keeps ``periodic``
+    init-able for runtime per-axis masks.
 
     The cell delegates geometry queries (``volume``, ``vectors``, etc.) to
-    its frame. The boundary semantics — what ``periodic`` means, how
-    [`wrap`][kups.core.cell.Cell.wrap] interprets it,
-    [`make_supercell`][kups.core.cell.make_supercell] tiling — live on the
-    cell. See [PeriodicCell][kups.core.cell.PeriodicCell] and
-    [VacuumCell][kups.core.cell.VacuumCell] for the two interpretations.
+    its frame. Periodic-mask-aware operations
+    ([`wrap`][kups.core.cell.Cell.wrap], [`fold`][kups.core.cell.Cell.fold],
+    [`minimum_image_shifts`][kups.core.cell.Cell.minimum_image_shifts])
+    live on the cell so callers don't need to access ``cell.periodic``
+    directly.
     """
 
     frame: Frame
-
-    @property
-    def periodic(self) -> P:
-        raise NotImplementedError
+    periodic: P = field(static=True)
 
     @property
     def vectors(self) -> Array:
@@ -451,6 +451,25 @@ class Cell[P: tuple[bool, bool, bool]](Sliceable):
     ) -> Array:
         return _wrap(self.frame, self.periodic, r, input_space, output_space)
 
+    def fold(self, r_frac: Array) -> Array:
+        """Fold fractional coords into ``[0, 1)`` on periodic axes;
+        non-periodic axes pass through unchanged.
+
+        Used by neighbor-list spatial hashing; complementary to
+        [`wrap`][kups.core.cell.Cell.wrap] which uses the ``[-0.5, 0.5)``
+        convention.
+        """
+        return jnp.where(jnp.array(self.periodic), r_frac % 1, r_frac)
+
+    def minimum_image_shifts(self, deltas: Array) -> Array:
+        """Per-axis minimum-image shifts for fractional separations.
+
+        Returns ``round(deltas)`` on periodic axes (the closest integer
+        cell offset that wraps the separation to its minimum image) and
+        ``0`` on non-periodic axes.
+        """
+        return jnp.where(jnp.array(self.periodic), jnp.round(deltas), 0.0)
+
     def __mul__(self, other: Array | float | int) -> Self:
         return bind(self, lambda c: c.frame).set(self.frame * other)
 
@@ -465,9 +484,7 @@ class PeriodicCell(Cell[Periodic3D]):
     Ewald summation requires this cell type.
     """
 
-    @property
-    def periodic(self) -> Periodic3D:
-        return (True, True, True)
+    periodic: Periodic3D = field(default=(True, True, True), static=True)
 
 
 @dataclass
@@ -481,9 +498,20 @@ class VacuumCell(Cell[Vacuum]):
     neighbor-list machinery needs a spatial-partitioning hint.
     """
 
-    @property
-    def periodic(self) -> Vacuum:
-        return (False, False, False)
+    periodic: Vacuum = field(default=(False, False, False), static=True)
+
+
+@dataclass
+class SlabCell(Cell[AnyPeriodicity]):
+    """Cell with a runtime per-axis periodicity mask.
+
+    Used for slab geometries (e.g. ``(True, True, False)``) and 1D wires
+    (e.g. ``(True, False, False)``) where the periodic-axis story is
+    determined at construction rather than encoded in the type. For
+    statically known fully-periodic or fully-open cells, prefer
+    [PeriodicCell][kups.core.cell.PeriodicCell] or
+    [VacuumCell][kups.core.cell.VacuumCell] so type narrowing applies.
+    """
 
 
 def min_multiplicity(cell: Cell, cutoff: float | Array) -> Array:

--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -123,6 +123,17 @@ class CoordinateSpace(Enum):
 
 type Periodic3D = tuple[Literal[True], Literal[True], Literal[True]]
 type Vacuum = tuple[Literal[False], Literal[False], Literal[False]]
+
+type SlabXY = tuple[Literal[True], Literal[True], Literal[False]]
+type SlabXZ = tuple[Literal[True], Literal[False], Literal[True]]
+type SlabYZ = tuple[Literal[False], Literal[True], Literal[True]]
+type Slab2D = SlabXY | SlabXZ | SlabYZ
+
+type WireX = tuple[Literal[True], Literal[False], Literal[False]]
+type WireY = tuple[Literal[False], Literal[True], Literal[False]]
+type WireZ = tuple[Literal[False], Literal[False], Literal[True]]
+type Wire1D = WireX | WireY | WireZ
+
 type AnyPeriodicity = tuple[bool, bool, bool]
 
 
@@ -407,13 +418,13 @@ def _wrap(
 class Cell[P: tuple[bool, bool, bool]](Sliceable):
     """A [Frame][kups.core.cell.Frame] plus per-axis boundary semantics.
 
-    Generic over the periodicity literal ``P``.
-    [PeriodicCell][kups.core.cell.PeriodicCell] and
-    [VacuumCell][kups.core.cell.VacuumCell] pin ``P`` to a literal tuple
-    via ``init=False`` defaults so construction is runtime-honest —
-    ``PeriodicCell(frame, ...)`` with an extra periodic argument raises
-    ``TypeError``. [SlabCell][kups.core.cell.SlabCell] keeps ``periodic``
-    init-able for runtime per-axis masks.
+    Generic over the periodicity literal ``P`` (a length-3 tuple of
+    booleans). [PeriodicCell][kups.core.cell.PeriodicCell] and
+    [VacuumCell][kups.core.cell.VacuumCell] are subclasses that pin ``P``
+    to a literal-typed default; for slab and wire geometries, construct
+    ``Cell(frame, periodic=mask)`` directly — the literal tuple narrows
+    ``P`` to the corresponding [Slab2D][kups.core.cell.Slab2D] or
+    [Wire1D][kups.core.cell.Wire1D] alias.
 
     The cell delegates geometry queries (``volume``, ``vectors``, etc.) to
     its frame. Periodic-mask-aware operations
@@ -499,19 +510,6 @@ class VacuumCell(Cell[Vacuum]):
     """
 
     periodic: Vacuum = field(default=(False, False, False), static=True)
-
-
-@dataclass
-class SlabCell(Cell[AnyPeriodicity]):
-    """Cell with a runtime per-axis periodicity mask.
-
-    Used for slab geometries (e.g. ``(True, True, False)``) and 1D wires
-    (e.g. ``(True, False, False)``) where the periodic-axis story is
-    determined at construction rather than encoded in the type. For
-    statically known fully-periodic or fully-open cells, prefer
-    [PeriodicCell][kups.core.cell.PeriodicCell] or
-    [VacuumCell][kups.core.cell.VacuumCell] so type narrowing applies.
-    """
 
 
 def min_multiplicity(cell: Cell, cutoff: float | Array) -> Array:

--- a/src/kups/core/neighborlist.py
+++ b/src/kups/core/neighborlist.py
@@ -20,7 +20,7 @@ accuracy trade-offs.
 1. **[CellListNeighborList][kups.core.neighborlist.CellListNeighborList]** (Recommended when cutoff << box size)
     - O(N) complexity using spatial hashing
     - Best when cutoff / box_size < 0.3 (cutoff much smaller than box)
-    - Requires periodic boundary conditions
+    - Honors the cell's per-axis ``periodic`` mask (bulk and bounded non-periodic)
     - Efficiency improves as cutoff/box ratio decreases
 
 2. **[DenseNearestNeighborList][kups.core.neighborlist.DenseNearestNeighborList]**
@@ -54,7 +54,8 @@ with different cutoffs or interaction rules (e.g., Lennard-Jones and Coulomb).
 ## Features
 
 All neighbor lists handle:
-- Periodic boundary conditions via shift vectors
+- Per-axis periodic / non-periodic boundaries via the cell's ``periodic`` mask
+  (shift vectors are zero on non-periodic axes)
 - Multiple systems in parallel with segmentation
 - Automatic capacity management for variable neighbor counts
 - Integration with JAX transformations (JIT, vmap, etc.)
@@ -298,8 +299,20 @@ def _cell_list_subselect(
     max_num_cells: Capacity[int],
     max_num_candidates: Capacity[int],
 ) -> _Candidates:
-    key_positions = _wrap_coordinates(lh.data.positions)
-    query_positions = _wrap_coordinates(rh.data.positions)
+    periodic = systems.data.cell.periodic
+    fully_periodic = all(periodic)
+
+    if fully_periodic:
+        key_positions = _wrap_coordinates(lh.data.positions)
+        query_positions = _wrap_coordinates(rh.data.positions)
+    else:
+        mask = jnp.array(periodic)
+        key_positions = jnp.where(
+            mask, _wrap_coordinates(lh.data.positions), lh.data.positions
+        )
+        query_positions = jnp.where(
+            mask, _wrap_coordinates(rh.data.positions), rh.data.positions
+        )
 
     num_cells = systems.map_data(partial(_num_cells, cutoff=cutoffs))
     max_num_cells = max_num_cells.generate_assertion(
@@ -325,17 +338,31 @@ def _cell_list_subselect(
 
     # Expand neighborhood around query points: for each query, tile across stencil
     stencil = _cell_stencil(dim)
-    query_neighborhood_positions = _wrap_coordinates(
-        jax.vmap(lambda s: query_positions + s[None] / num_cells[rh.data.system])(
-            stencil
-        ).reshape(-1, dim)
-    )
+    raw_shifted = jax.vmap(
+        lambda s: query_positions + s[None] / num_cells[rh.data.system]
+    )(stencil).reshape(-1, dim)
     query_original = Index(rh.keys, jnp.tile(jnp.arange(len(rh)), len(stencil)))
     query_system = rh.data.system[query_original.indices]
-    query_neighborhood_hashes = (
-        _cell_hash(query_neighborhood_positions, num_cells[query_system])
-        + rh_system_ids[query_original.indices] * max_num_cells.size
-    )
+
+    if fully_periodic:
+        query_neighborhood_positions = _wrap_coordinates(raw_shifted)
+        query_neighborhood_hashes = (
+            _cell_hash(query_neighborhood_positions, num_cells[query_system])
+            + rh_system_ids[query_original.indices] * max_num_cells.size
+        )
+    else:
+        # On periodic axes wrap; on open axes pass through. Out-of-range stencil
+        # offsets on open axes route to cell_oob so they produce no key matches
+        # (cross-boundary candidates are excluded).
+        mask = jnp.array(periodic)
+        shifted = jnp.where(mask, _wrap_coordinates(raw_shifted), raw_shifted)
+        in_box = jnp.all((shifted >= 0) & (shifted < 1), axis=-1)
+        hashes = (
+            _cell_hash(shifted, num_cells[query_system])
+            + rh_system_ids[query_original.indices] * max_num_cells.size
+        )
+        query_neighborhood_hashes = jnp.where(in_box, hashes, cell_oob)
+
     unique_queries = jnp.unique(
         jnp.stack([query_neighborhood_hashes, query_original.indices], axis=-1),
         axis=0,
@@ -458,6 +485,8 @@ def _get_candidate_images(
     cells = systems.data.cell
     images = jnp.ceil(2 * cutoffs[..., None] / cells.perpendicular_lengths).astype(int)
     images = jnp.where(jnp.isfinite(cutoffs[..., None]), images, 1)
+    # Open axes contribute no images.
+    images = jnp.where(jnp.array(cells.periodic), images, 1)
     images += images % 2 == 0
     images_per_sys = jnp.prod(images, axis=-1).astype(int)
 
@@ -542,9 +571,10 @@ def _compute_distances_pbc_sq(
     systems: Table[SystemId, NeighborListSystems],
     shifts: Array | None = None,
 ) -> tuple[Array, Array]:
-    """Compute squared distances with periodic boundary conditions.
+    """Compute squared distances honoring the cell's per-axis periodicity.
 
-    If ``shifts`` is None, minimum-image shifts are computed via rounding.
+    If ``shifts`` is None, minimum-image shifts are computed via rounding on
+    periodic axes; non-periodic axes get a zero shift (no MIC fold).
     """
     lattice_vecs = systems.map_data(lambda s: s.cell.vectors)
     vecs = lattice_vecs[lh.data.system[candidates.lhs.indices]]
@@ -553,7 +583,8 @@ def _compute_distances_pbc_sq(
         - rh.data.positions[candidates.rhs.indices]
     )
     if shifts is None:
-        shifts = jnp.round(deltas)
+        periodic = jnp.array(systems.data.cell.periodic)
+        shifts = jnp.where(periodic, jnp.round(deltas), 0.0)
     deltas -= shifts
     real_deltas = triangular_3x3_matmul(vecs, deltas)
     dist_sq = jnp.einsum("...d,...d->...", real_deltas, real_deltas)
@@ -986,7 +1017,11 @@ class CellListNeighborList:
     the box size. It divides space into a grid of cells and only checks pairs in
     neighboring cells, achieving linear scaling with system size.
 
-    **Requires periodic boundary conditions** (Cell).
+    Honors the cell's per-axis ``periodic`` mask: stencil offsets that cross a
+    non-periodic face are routed to an out-of-bounds bin (no key matches), and
+    minimum-image shifts are zero on non-periodic axes. The fully-periodic path
+    is byte-identical to the original (gated at trace time on ``all(periodic)``)
+    so PBC kernels see no overhead.
 
     Complexity: O(N) for well-distributed particles where cutoff << box size.
     Efficiency improves as cutoff/box ratio decreases.
@@ -1006,7 +1041,9 @@ class CellListNeighborList:
     When to use:
         - When cutoff/box_size << 1 (cutoff much smaller than box)
         - Typically cutoff/box < 0.3 for good efficiency
-        - Periodic boundary conditions required
+        - On non-periodic axes positions must lie inside ``[0, L)`` in real
+          coordinates (the caller's invariant; out-of-range positions are
+          silently routed to the OOB bin)
 
     Example:
         ```python

--- a/src/kups/core/neighborlist.py
+++ b/src/kups/core/neighborlist.py
@@ -95,7 +95,6 @@ from jax import Array
 
 from kups.core.assertion import runtime_assert
 from kups.core.capacity import Capacity, FixedCapacity, LensCapacity
-from kups.core.cell import is_3d_periodic
 from kups.core.data import Index, Sliceable, Table, subselect
 from kups.core.data.wrappers import WithIndices
 from kups.core.lens import Lens, bind, lens
@@ -292,8 +291,8 @@ def _cell_list_subselect(
     max_num_candidates: Capacity[int],
 ) -> _Candidates:
     cell = systems.data.cell
-    key_positions = cell.fold(lh.data.positions)
-    query_positions = cell.fold(rh.data.positions)
+    key_positions, _ = cell.fold(lh.data.positions)
+    query_positions, _ = cell.fold(rh.data.positions)
 
     num_cells = systems.map_data(partial(_num_cells, cutoff=cutoffs))
     max_num_cells = max_num_cells.generate_assertion(
@@ -325,17 +324,16 @@ def _cell_list_subselect(
     query_original = Index(rh.keys, jnp.tile(jnp.arange(len(rh)), len(stencil)))
     query_system = rh.data.system[query_original.indices]
 
-    shifted = cell.fold(raw_shifted)
+    shifted, in_cell = cell.fold(raw_shifted)
     hashes = (
         _cell_hash(shifted, num_cells[query_system])
         + rh_system_ids[query_original.indices] * max_num_cells.size
     )
-    if is_3d_periodic(cell):
-        query_neighborhood_hashes = hashes
-    else:
-        # Out-of-range stencil offsets on open axes route to cell_oob so they
-        # produce no key matches (cross-boundary candidates are excluded).
-        query_neighborhood_hashes = jnp.where(cell.in_box(shifted), hashes, cell_oob)
+    # Stencil offsets that left the box on a non-periodic axis route to
+    # cell_oob so they produce no key matches (cross-boundary candidates
+    # are excluded). For fully-periodic cells fold guarantees in_cell is
+    # all-True, making the where a no-op.
+    query_neighborhood_hashes = jnp.where(in_cell, hashes, cell_oob)
 
     unique_queries = jnp.unique(
         jnp.stack([query_neighborhood_hashes, query_original.indices], axis=-1),

--- a/src/kups/core/neighborlist.py
+++ b/src/kups/core/neighborlist.py
@@ -270,15 +270,6 @@ def _cell_stencil(dim: int):
         ).reshape(-1, dim)
 
 
-def _wrap_coordinates(coordinates: Array):
-    """Wrap coordinates to be within the bounds of the grid."""
-    return jnp.where(
-        coordinates < 0,
-        1 + coordinates,
-        jnp.where(coordinates >= 1, coordinates - 1, coordinates),
-    )
-
-
 def _num_cells(
     systems: NeighborListSystems,
     cutoff: Array,
@@ -299,20 +290,10 @@ def _cell_list_subselect(
     max_num_cells: Capacity[int],
     max_num_candidates: Capacity[int],
 ) -> _Candidates:
-    periodic = systems.data.cell.periodic
-    fully_periodic = all(periodic)
-
-    if fully_periodic:
-        key_positions = _wrap_coordinates(lh.data.positions)
-        query_positions = _wrap_coordinates(rh.data.positions)
-    else:
-        mask = jnp.array(periodic)
-        key_positions = jnp.where(
-            mask, _wrap_coordinates(lh.data.positions), lh.data.positions
-        )
-        query_positions = jnp.where(
-            mask, _wrap_coordinates(rh.data.positions), rh.data.positions
-        )
+    cell = systems.data.cell
+    fully_periodic = all(cell.periodic)
+    key_positions = cell.fold(lh.data.positions)
+    query_positions = cell.fold(rh.data.positions)
 
     num_cells = systems.map_data(partial(_num_cells, cutoff=cutoffs))
     max_num_cells = max_num_cells.generate_assertion(
@@ -344,23 +325,17 @@ def _cell_list_subselect(
     query_original = Index(rh.keys, jnp.tile(jnp.arange(len(rh)), len(stencil)))
     query_system = rh.data.system[query_original.indices]
 
+    shifted = cell.fold(raw_shifted)
+    hashes = (
+        _cell_hash(shifted, num_cells[query_system])
+        + rh_system_ids[query_original.indices] * max_num_cells.size
+    )
     if fully_periodic:
-        query_neighborhood_positions = _wrap_coordinates(raw_shifted)
-        query_neighborhood_hashes = (
-            _cell_hash(query_neighborhood_positions, num_cells[query_system])
-            + rh_system_ids[query_original.indices] * max_num_cells.size
-        )
+        query_neighborhood_hashes = hashes
     else:
-        # On periodic axes wrap; on open axes pass through. Out-of-range stencil
-        # offsets on open axes route to cell_oob so they produce no key matches
-        # (cross-boundary candidates are excluded).
-        mask = jnp.array(periodic)
-        shifted = jnp.where(mask, _wrap_coordinates(raw_shifted), raw_shifted)
+        # Out-of-range stencil offsets on open axes route to cell_oob so they
+        # produce no key matches (cross-boundary candidates are excluded).
         in_box = jnp.all((shifted >= 0) & (shifted < 1), axis=-1)
-        hashes = (
-            _cell_hash(shifted, num_cells[query_system])
-            + rh_system_ids[query_original.indices] * max_num_cells.size
-        )
         query_neighborhood_hashes = jnp.where(in_box, hashes, cell_oob)
 
     unique_queries = jnp.unique(
@@ -583,8 +558,7 @@ def _compute_distances_pbc_sq(
         - rh.data.positions[candidates.rhs.indices]
     )
     if shifts is None:
-        periodic = jnp.array(systems.data.cell.periodic)
-        shifts = jnp.where(periodic, jnp.round(deltas), 0.0)
+        shifts = systems.data.cell.minimum_image_shifts(deltas)
     deltas -= shifts
     real_deltas = triangular_3x3_matmul(vecs, deltas)
     dist_sq = jnp.einsum("...d,...d->...", real_deltas, real_deltas)

--- a/src/kups/core/neighborlist.py
+++ b/src/kups/core/neighborlist.py
@@ -95,6 +95,7 @@ from jax import Array
 
 from kups.core.assertion import runtime_assert
 from kups.core.capacity import Capacity, FixedCapacity, LensCapacity
+from kups.core.cell import is_3d_periodic
 from kups.core.data import Index, Sliceable, Table, subselect
 from kups.core.data.wrappers import WithIndices
 from kups.core.lens import Lens, bind, lens
@@ -291,7 +292,6 @@ def _cell_list_subselect(
     max_num_candidates: Capacity[int],
 ) -> _Candidates:
     cell = systems.data.cell
-    fully_periodic = all(cell.periodic)
     key_positions = cell.fold(lh.data.positions)
     query_positions = cell.fold(rh.data.positions)
 
@@ -330,13 +330,12 @@ def _cell_list_subselect(
         _cell_hash(shifted, num_cells[query_system])
         + rh_system_ids[query_original.indices] * max_num_cells.size
     )
-    if fully_periodic:
+    if is_3d_periodic(cell):
         query_neighborhood_hashes = hashes
     else:
         # Out-of-range stencil offsets on open axes route to cell_oob so they
         # produce no key matches (cross-boundary candidates are excluded).
-        in_box = jnp.all((shifted >= 0) & (shifted < 1), axis=-1)
-        query_neighborhood_hashes = jnp.where(in_box, hashes, cell_oob)
+        query_neighborhood_hashes = jnp.where(cell.in_box(shifted), hashes, cell_oob)
 
     unique_queries = jnp.unique(
         jnp.stack([query_neighborhood_hashes, query_original.indices], axis=-1),

--- a/src/kups/core/utils/jax.py
+++ b/src/kups/core/utils/jax.py
@@ -725,7 +725,23 @@ def dataclass[T: type](
             weakref_slot=weakref_slot,
         )  # type: ignore
         dcls._jax_dataclass = True
-        jax.tree_util.register_dataclass(dcls)
+        # `init=False` fields are excluded from pytree registration: they are
+        # set from defaults in __init__ and are not part of the constructor
+        # surface, so they neither carry traced data nor static aux that the
+        # caller can vary. JAX's auto-detection includes them and then errors,
+        # so we partition explicitly.
+        init_fields = [f for f in dataclasses.fields(dcls) if f.init]
+        data_fields = [
+            f.name for f in init_fields if not f.metadata.get("static", False)
+        ]
+        meta_fields = [f.name for f in init_fields if f.metadata.get("static", False)]
+        drop_fields = [f.name for f in dataclasses.fields(dcls) if not f.init]
+        jax.tree_util.register_dataclass(
+            dcls,
+            data_fields=data_fields,
+            meta_fields=meta_fields,
+            drop_fields=drop_fields,
+        )
         return dcls
 
     if cls is None:

--- a/src/kups/core/utils/position.py
+++ b/src/kups/core/utils/position.py
@@ -25,18 +25,19 @@ def center_of_mass[P: HasPositionsAndGroupIndex](
     """Compute center of mass for indexed particle groups.
 
     Calculates the center of mass for each group of particles defined by
-    group index, properly handling periodic boundary conditions. The computation
-    ensures that wrapped particles are unwrapped relative to a reference particle
-    in each group before averaging.
+    group index, honoring the cell's per-axis ``periodic`` mask. The
+    computation ensures that wrapped particles are unwrapped relative to a
+    reference particle in each group before averaging.
 
     Warning:
-        Assumes each molecular structure is smaller than half the cell size.
-        Molecules spanning more than half the box may yield incorrect results.
+        On periodic axes, assumes each molecular structure is smaller than
+        half the cell size. Structures spanning more than half the box may
+        yield incorrect results.
 
     Args:
         particles: Indexed particles, optionally supporting `HasWeights` for mass weighting.
-        cells: Cell(s) defining periodic boundary conditions. Must have
-            one cell per group.
+        cells: Cell(s) carrying lattice geometry and per-axis periodicity.
+            Must have one cell per group.
 
     Returns:
         Shape `(num_groups, 3)` containing center-of-mass positions for each group.
@@ -92,13 +93,14 @@ def to_relative_positions[P: HasPositionsAndGroupIndex](
 ) -> Array:
     """Calculate particle positions relative to their group's center of mass.
 
-    Transforms absolute particle positions to positions relative to each group's
-    center of mass, properly accounting for periodic boundary conditions.
+    Transforms absolute particle positions to positions relative to each
+    group's center of mass, honoring the cell's per-axis ``periodic`` mask
+    (periodic axes wrap; non-periodic axes pass through unchanged).
 
     Args:
         particles: Indexed particles with position and group index data. Supports
             `HasWeights` if center of mass needs to be computed.
-        cells: Cell(s) defining periodic boundaries.
+        cells: Cell(s) carrying lattice geometry and per-axis periodicity.
         center_of_masses: Optional precomputed centers of mass. If `None`,
             will be computed automatically.
 
@@ -130,12 +132,13 @@ def to_absolute_positions[P: HasPositionsAndGroupIndex](
     """Calculate absolute positions from relative positions and group COMs.
 
     Inverse operation of `to_relative_positions`. Converts positions defined
-    relative to group centers of mass back to absolute coordinates, applying
-    periodic boundary conditions.
+    relative to group centers of mass back to absolute coordinates, honoring
+    the cell's per-axis ``periodic`` mask via ``wrap`` (identity on
+    non-periodic axes).
 
     Args:
         particles: Indexed particles with relative positions and group index.
-        cells: Cell(s) defining periodic boundaries.
+        cells: Cell(s) carrying lattice geometry and per-axis periodicity.
         center_of_masses: Centers of mass for each group, shape `(num_groups, 3)`.
 
     Returns:

--- a/src/kups/core/utils/position.py
+++ b/src/kups/core/utils/position.py
@@ -1,11 +1,12 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
-"""Utilities for computing particle positions and center of mass in periodic systems.
+"""Utilities for computing particle positions and center of mass.
 
-This module provides functions for handling particle positions under periodic
-boundary conditions, including center-of-mass calculations for indexed particle
-groups.
+Functions in this module honor the cell's per-axis ``periodic`` mask via
+``cell.wrap`` — periodic axes fold into the primary cell, non-periodic
+axes pass through unchanged. The same code path covers fully-periodic
+crystals, vacuum clusters, and slab / wire geometries.
 """
 
 import jax

--- a/src/kups/potential/common/graph.py
+++ b/src/kups/potential/common/graph.py
@@ -4,9 +4,10 @@
 """Graph construction from atomic coordinates for potential evaluation.
 
 This module builds molecular graphs (point clouds, hypergraphs) from
-``Indexed`` particle data for potential energy evaluation. Graphs support
-periodic boundary conditions, multiple independent systems, and efficient
-incremental construction for Monte Carlo via probes.
+``Indexed`` particle data for potential energy evaluation. Graphs honor the
+cell's per-axis ``periodic`` mask via the neighbor list, support multiple
+independent systems, and allow efficient incremental construction for Monte
+Carlo via probes.
 
 Key components:
 

--- a/test/application/utils/test_particles.py
+++ b/test/application/utils/test_particles.py
@@ -240,7 +240,6 @@ class TestParticlesFromAsePbcDispatch:
         from kups.core.cell import Cell, PeriodicCell, VacuumCell
 
         _, cell, _ = particles_from_ase(self._atoms(pbc))
-        # neither the literal-typed PeriodicCell nor VacuumCell — generic Cell
         assert isinstance(cell, Cell)
         assert not isinstance(cell, (PeriodicCell, VacuumCell))
         assert cell.periodic == pbc

--- a/test/application/utils/test_particles.py
+++ b/test/application/utils/test_particles.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from kups.application.utils.particles import Particles
 from kups.core.data.index import Index
@@ -202,3 +203,58 @@ class TestParticlesFromAse:
         npt.assert_allclose(lv[..., 0, 1], 0.0, atol=1e-10)
         npt.assert_allclose(lv[..., 0, 2], 0.0, atol=1e-10)
         npt.assert_allclose(lv[..., 1, 2], 0.0, atol=1e-10)
+
+
+class TestParticlesFromAsePbcDispatch:
+    """`particles_from_ase` constructs the right Cell flavor for each pbc shape."""
+
+    @staticmethod
+    def _atoms(pbc):
+        from ase import Atoms
+
+        return Atoms("Ar", positions=[[0, 0, 0]], cell=[10, 10, 10], pbc=pbc)
+
+    def test_fully_periodic_constructs_periodic_cell(self):
+        from kups.application.utils.particles import particles_from_ase
+        from kups.core.cell import PeriodicCell
+
+        _, cell, _ = particles_from_ase(self._atoms((True, True, True)))
+        assert isinstance(cell, PeriodicCell)
+        assert cell.periodic == (True, True, True)
+
+    def test_no_pbc_constructs_vacuum_cell(self):
+        from kups.application.utils.particles import particles_from_ase
+        from kups.core.cell import VacuumCell
+
+        _, cell, _ = particles_from_ase(self._atoms((False, False, False)))
+        assert isinstance(cell, VacuumCell)
+        assert cell.periodic == (False, False, False)
+
+    @pytest.mark.parametrize(
+        "pbc",
+        [(True, True, False), (True, False, True), (False, True, True)],
+        ids=["xy", "xz", "yz"],
+    )
+    def test_2d_slab_carries_runtime_mask(self, pbc):
+        from kups.application.utils.particles import particles_from_ase
+        from kups.core.cell import Cell, PeriodicCell, VacuumCell
+
+        _, cell, _ = particles_from_ase(self._atoms(pbc))
+        # neither the literal-typed PeriodicCell nor VacuumCell — generic Cell
+        assert isinstance(cell, Cell)
+        assert not isinstance(cell, (PeriodicCell, VacuumCell))
+        assert cell.periodic == pbc
+
+    @pytest.mark.parametrize(
+        "pbc",
+        [(True, False, False), (False, True, False), (False, False, True)],
+        ids=["x", "y", "z"],
+    )
+    def test_1d_wire_carries_runtime_mask(self, pbc):
+        from kups.application.utils.particles import particles_from_ase
+        from kups.core.cell import Cell, PeriodicCell, VacuumCell
+
+        _, cell, _ = particles_from_ase(self._atoms(pbc))
+        assert isinstance(cell, Cell)
+        assert not isinstance(cell, (PeriodicCell, VacuumCell))
+        assert cell.periodic == pbc

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -326,6 +326,7 @@ class TestCellConstructors:
         assert c.periodic == (False, False, False)
         npt.assert_allclose(c.vectors, jnp.eye(3) * 2.0)
 
+
 class TestTypeGuards:
     def test_is_vacuum_positive(self):
         c = VacuumCell(OrthogonalFrame(jnp.array([1.0, 1.0, 1.0])))

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -309,13 +309,6 @@ class TestCellIsinstance:
 
 
 class TestCellConstructors:
-    """Runtime behavior of PeriodicCell / VacuumCell.
-
-    Type-level discrimination — that ``PeriodicCell`` is rejected where
-    ``VacuumCell`` is expected and vice versa — is enforced by pyright at
-    static-analysis time. Here we just lock in the runtime semantics.
-    """
-
     def test_periodic_default_orthogonal(self):
         c = PeriodicCell(OrthogonalFrame(jnp.array([10.0, 10.0, 10.0])))
         assert c.periodic == (True, True, True)
@@ -332,15 +325,6 @@ class TestCellConstructors:
         c = VacuumCell(TriclinicFrame.from_matrix(jnp.eye(3) * 2.0))
         assert c.periodic == (False, False, False)
         npt.assert_allclose(c.vectors, jnp.eye(3) * 2.0)
-
-    def test_periodic_rejects_wrong_literal_statically(self):
-        """`periodic` is typed `Periodic3D = (True, True, True)` literal;
-        passing a non-matching tuple is rejected by pyright at static-analysis
-        time. (Runtime accepts it; honesty is at the type level.)"""
-        # The line below would be a pyright error if uncommented:
-        # PeriodicCell(frame, (False, False, False))
-        pass
-
 
 class TestTypeGuards:
     def test_is_vacuum_positive(self):
@@ -611,25 +595,16 @@ class TestPeriodicityAcrossFrames:
 
 
 class TestPytreeAndJIT:
-    def test_periodic_property_is_not_a_pytree_leaf(self):
-        """Design invariant: `periodic` is a `@property`, not a dataclass
-        field. If it became a leaf, `jax.tree.map` would try to rewrite it
-        and the literal-typed read-only contract would break."""
+    def test_periodic_is_static_aux_not_a_leaf(self):
         cell = PeriodicCell(OrthogonalFrame(jnp.array([10.0, 10.0, 10.0])))
         assert len(jax.tree.leaves(cell)) == 1
 
     def test_jit_traces_through_wrap(self):
-        """JAX must be able to trace through Cell.wrap, which closes over
-        `self.periodic`. This is the JIT regression that broke when periodic
-        was a dataclass field with `static=True` plumbed through `_wrap`."""
         cell = PeriodicCell(OrthogonalFrame(jnp.array([10.0, 10.0, 10.0])))
         r = jnp.array([12.0, -3.0, 25.0])
         npt.assert_allclose(jax.jit(cell.wrap)(r), cell.wrap(r), atol=1e-6)
 
     def test_tree_map_preserves_concrete_subclass(self):
-        """`jax.tree.map` returns the same concrete cell class — not a bare
-        `Cell` — so downstream `isinstance(c, VacuumCell)` keeps working
-        after pytree round-trips."""
         cell = VacuumCell(OrthogonalFrame(jnp.array([10.0, 10.0, 10.0])))
         scaled = jax.tree.map(lambda x: x * 2, cell)
         assert isinstance(scaled, VacuumCell)

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -333,11 +333,13 @@ class TestCellConstructors:
         assert c.periodic == (False, False, False)
         npt.assert_allclose(c.vectors, jnp.eye(3) * 2.0)
 
-    def test_periodic_rejects_periodic_kwarg(self):
-        """`periodic` is a read-only property; constructor takes only `frame`."""
-        frame = OrthogonalFrame(jnp.array([10.0, 10.0, 10.0]))
-        with pytest.raises(TypeError):
-            PeriodicCell(frame, (False, False, False))  # pyright: ignore[reportCallIssue]
+    def test_periodic_rejects_wrong_literal_statically(self):
+        """`periodic` is typed `Periodic3D = (True, True, True)` literal;
+        passing a non-matching tuple is rejected by pyright at static-analysis
+        time. (Runtime accepts it; honesty is at the type level.)"""
+        # The line below would be a pyright error if uncommented:
+        # PeriodicCell(frame, (False, False, False))
+        pass
 
 
 class TestTypeGuards:

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -326,6 +326,12 @@ class TestCellConstructors:
         assert c.periodic == (False, False, False)
         npt.assert_allclose(c.vectors, jnp.eye(3) * 2.0)
 
+    @pytest.mark.parametrize("cls", [PeriodicCell, VacuumCell])
+    def test_periodic_arg_is_rejected(self, cls):
+        frame = OrthogonalFrame(jnp.array([1.0, 1.0, 1.0]))
+        with pytest.raises(TypeError, match="periodic"):
+            cls(frame, periodic=(True, False, True))  # type: ignore[call-arg]
+
 
 class TestTypeGuards:
     def test_is_vacuum_positive(self):

--- a/test/core/test_jax_utils.py
+++ b/test/core/test_jax_utils.py
@@ -233,6 +233,122 @@ class TestDataclass:
         assert len(leaves) == 3
 
 
+class TestDataclassInitStaticMatrix:
+    """The (init, static) combinations partition into JAX (data, meta, drop)
+    field groups. Downstream consumers — jit, tree.map, flatten/unflatten —
+    must respect the partition so that:
+      - data leaves get traced and updated
+      - meta aux is preserved across pytree roundtrips
+      - drop fields take their default after roundtrip and are not part of
+        the constructor surface
+    """
+
+    @staticmethod
+    def _matrix_class():
+        @dataclass
+        class Mix:
+            data: jax.Array  # init=T, static=F → data field
+            meta: str = field(
+                default="m0", static=True
+            )  # init=T, static=T → meta field
+            init_false_default: int = field(
+                default=99, init=False
+            )  # init=F → drop field
+            init_false_static: str = field(
+                default="s0", init=False, static=True
+            )  # init=F (static moot) → drop field
+
+        return Mix
+
+    def test_constructor_rejects_init_false_kwargs(self):
+        Mix = self._matrix_class()
+        with pytest.raises(TypeError, match="init_false_default"):
+            Mix(jnp.zeros(3), init_false_default=1)  # type: ignore[call-arg]
+        with pytest.raises(TypeError, match="init_false_static"):
+            Mix(jnp.zeros(3), init_false_static="bad")  # type: ignore[call-arg]
+
+    def test_only_data_fields_are_pytree_leaves(self):
+        m = self._matrix_class()(jnp.array([1.0, 2.0]))
+        leaves = jax.tree.leaves(m)
+        assert len(leaves) == 1
+        npt.assert_allclose(leaves[0], jnp.array([1.0, 2.0]))
+
+    def test_tree_map_preserves_all_field_kinds(self):
+        Mix = self._matrix_class()
+        m = Mix(jnp.array([1.0, 2.0]), meta="custom")
+        m2 = jax.tree.map(lambda x: x * 2, m)
+        npt.assert_allclose(m2.data, jnp.array([2.0, 4.0]))
+        # meta is carried in the treedef
+        assert m2.meta == "custom"
+        # drop fields restored from default on unflatten
+        assert m2.init_false_default == 99
+        assert m2.init_false_static == "s0"
+
+    def test_jit_traces_through_all_field_kinds(self):
+        Mix = self._matrix_class()
+        m = Mix(jnp.array([1.0, 2.0, 3.0]), meta="x")
+
+        @jax.jit
+        def square_data(mm):
+            return Mix(mm.data**2, meta=mm.meta)
+
+        m2 = square_data(m)
+        npt.assert_allclose(m2.data, jnp.array([1.0, 4.0, 9.0]))
+        assert m2.meta == "x"
+        assert m2.init_false_default == 99
+
+
+class TestDataclassPostInitWithInitFalse:
+    """``__post_init__`` runs at Python construction and observes the
+    init=False fields after their defaults are assigned, so validation that
+    depends on those fields works."""
+
+    def test_post_init_sees_default_assigned_init_false_field(self):
+        seen = []
+
+        @dataclass
+        class T:
+            x: jax.Array
+            cache: int = field(default=42, init=False)
+
+            @skip_post_init_if_disabled
+            def __post_init__(self):
+                seen.append((self.x.shape, self.cache))
+
+        T(jnp.zeros(3))
+        assert seen == [((3,), 42)]
+
+
+class TestDataclassSubclassPinsInheritedField:
+    """Subclass redeclares an inherited field with ``init=False`` to lock it
+    to a fixed default. This is the ``PeriodicCell`` / ``VacuumCell`` pattern:
+    the parent ``Cell`` exposes ``periodic`` as a constructor arg; the
+    subclass pins it and removes it from the constructor surface."""
+
+    def test_pinned_field_default_and_constructor_rejection(self):
+        @dataclass
+        class Parent:
+            data: jax.Array
+            mask: tuple[bool, bool] = field(static=True)
+
+        @dataclass
+        class Pinned(Parent):
+            mask: tuple[bool, bool] = field(
+                default=(True, True), init=False, static=True
+            )
+
+        p = Pinned(jnp.zeros(3))
+        assert p.mask == (True, True)
+
+        with pytest.raises(TypeError, match="mask"):
+            Pinned(jnp.zeros(3), mask=(False, True))  # type: ignore[call-arg]
+
+        # Roundtrip preserves the concrete subclass and the pinned default.
+        p2 = jax.tree.map(lambda x: x * 2, p)
+        assert isinstance(p2, Pinned)
+        assert p2.mask == (True, True)
+
+
 class TestSequentialVmapWithVjp:
     """Tests for sequential_vmap_with_vjp function."""
 

--- a/test/core/test_neighborlist.py
+++ b/test/core/test_neighborlist.py
@@ -14,6 +14,7 @@ from kups.core.cell import (
     Cell,
     OrthogonalFrame,
     PeriodicCell,
+    SlabCell,
     TriclinicFrame,
     VacuumCell,
 )
@@ -1812,62 +1813,82 @@ def _run_dense(positions, cell, cutoff):
     return result.value
 
 
-class TestNonPeriodicNeighborList:
-    """Cell list with all-False periodic mask (vacuum cells).
-
-    The neighbor list machinery is per-axis-mask-aware via ``cell.periodic``.
-    The current cell hierarchy exposes only the all-True (PeriodicCell) and
-    all-False (VacuumCell) literals; mixed-axis (slab / wire) geometries
-    will be re-introduced together with their cell type when a real
-    consumer lands.
+class TestNeighborListAcrossPeriodicities:
+    """Cell-list and dense agree across the four periodicity shapes:
+    vacuum (0D), 1D wire, 2D slab, 3D bulk.
     """
 
-    def test_non_pbc_excludes_cross_boundary_pair(self):
-        """Two atoms near opposite faces should NOT be connected when periodic=(F,F,F).
+    def _bulk_cell(self, L):
+        return PeriodicCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
 
-        With PBC the wrapped x-distance would be 1.0 (well under cutoff); without
-        PBC the real distance is 9.0 (well above cutoff). Verifies that the
-        cell list honors the open boundary.
-        """
+    def _vacuum_cell(self, L):
+        return VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
+
+    def _slab_cell(self, L, periodic):
+        # `periodic` is a static tuple; SlabCell stores it on the dataclass.
+        return SlabCell(OrthogonalFrame(jnp.array([L, L, L])[None]), periodic=periodic)
+
+    def test_3d_periodic_wraps_across_face(self):
+        """Two atoms near opposite x-faces connect via the periodic image."""
         L = 10.0
         positions = jnp.array([[0.5, 5.0, 5.0], [9.5, 5.0, 5.0]])
-        cell = VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
-        edges = _run_cell_list(positions, cell, cutoff=2.0)
-        assert _valid_edges_set(edges, 2) == set()
-
-    def test_non_pbc_finds_in_box_pair(self):
-        """Atoms within cutoff and inside the box should still be connected."""
-        L = 10.0
-        positions = jnp.array([[4.0, 5.0, 5.0], [5.0, 5.0, 5.0]])
-        cell = VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
-        edges = _run_cell_list(positions, cell, cutoff=2.0)
+        edges = _run_cell_list(positions, self._bulk_cell(L), cutoff=2.0)
         assert _valid_edges_set(edges, 2) == {(0, 1), (1, 0)}
 
-    def test_non_pbc_matches_dense(self):
-        """CellListNeighborList and DenseNearestNeighborList agree on non-PBC.
+    def test_vacuum_excludes_cross_boundary_pair(self):
+        """The same atoms under VacuumCell should NOT connect."""
+        L = 10.0
+        positions = jnp.array([[0.5, 5.0, 5.0], [9.5, 5.0, 5.0]])
+        edges = _run_cell_list(positions, self._vacuum_cell(L), cutoff=2.0)
+        assert _valid_edges_set(edges, 2) == set()
 
-        Both route through ``basic_neighborlist`` so they share the masked MIC
-        and image-count paths; this locks in that the cell-list specific
-        stencil routing is consistent with the dense reference.
-        """
+    def test_2d_slab_wraps_xy_not_z(self):
+        """Slab (T, T, F): the cross-x pair connects (wraps); the cross-z pair does not."""
+        L = 10.0
+        cell = self._slab_cell(L, periodic=(True, True, False))
+        x_pair = jnp.array([[1.0, 5.0, 5.0], [9.0, 5.0, 5.0]])
+        z_pair = jnp.array([[5.0, 5.0, 1.0], [5.0, 5.0, 9.0]])
+        x_edges = _run_cell_list(x_pair, cell, cutoff=2.5)
+        z_edges = _run_cell_list(z_pair, cell, cutoff=2.5)
+        assert _valid_edges_set(x_edges, 2) == {(0, 1), (1, 0)}
+        assert _valid_edges_set(z_edges, 2) == set()
+
+    def test_1d_wire_wraps_x_not_yz(self):
+        """1D wire (T, F, F): cross-x connects, cross-y and cross-z do not."""
+        L = 10.0
+        cell = self._slab_cell(L, periodic=(True, False, False))
+        x_pair = jnp.array([[1.0, 5.0, 5.0], [9.0, 5.0, 5.0]])
+        y_pair = jnp.array([[5.0, 1.0, 5.0], [5.0, 9.0, 5.0]])
+        z_pair = jnp.array([[5.0, 5.0, 1.0], [5.0, 5.0, 9.0]])
+        assert _valid_edges_set(_run_cell_list(x_pair, cell, 2.5), 2) == {
+            (0, 1),
+            (1, 0),
+        }
+        assert _valid_edges_set(_run_cell_list(y_pair, cell, 2.5), 2) == set()
+        assert _valid_edges_set(_run_cell_list(z_pair, cell, 2.5), 2) == set()
+
+    @pytest.mark.parametrize(
+        "cell_factory",
+        [
+            ("bulk", lambda self, L: self._bulk_cell(L)),
+            ("vacuum", lambda self, L: self._vacuum_cell(L)),
+            ("slab", lambda self, L: self._slab_cell(L, (True, True, False))),
+            ("wire", lambda self, L: self._slab_cell(L, (True, False, False))),
+        ],
+        ids=lambda x: x[0],
+    )
+    def test_cell_list_matches_dense(self, cell_factory):
+        """CellListNeighborList and DenseNearestNeighborList must agree across
+        every periodicity shape — locks in that the cell-list-specific stencil
+        routing is consistent with the dense reference."""
+        _, factory = cell_factory
         L = 12.0
         rng = np.random.default_rng(7)
-        # 30 atoms scattered in [1, L-1] so they're safely inside the box
+        # atoms scattered safely inside the box (so non-periodic axes don't
+        # need to fold positions out of [0, L) into bins)
         positions = jnp.asarray(rng.uniform(1.0, L - 1.0, size=(30, 3)))
-        cell = VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
+        cell = factory(self, L)
         cutoff = 3.5
         cl_edges = _run_cell_list(positions, cell, cutoff)
         dn_edges = _run_dense(positions, cell, cutoff)
         assert _valid_edges_set(cl_edges, 30) == _valid_edges_set(dn_edges, 30)
-
-    def test_pbc_unchanged(self):
-        """Sanity: PeriodicCell output is unchanged by the per-axis trace-time gate.
-
-        Same fixture as test_non_pbc_excludes_cross_boundary_pair, but with PBC:
-        the wrapped x-distance is 1.0 → edge under PBC.
-        """
-        L = 10.0
-        positions = jnp.array([[0.5, 5.0, 5.0], [9.5, 5.0, 5.0]])
-        cell = PeriodicCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
-        edges = _run_cell_list(positions, cell, cutoff=2.0)
-        assert _valid_edges_set(edges, 2) == {(0, 1), (1, 0)}

--- a/test/core/test_neighborlist.py
+++ b/test/core/test_neighborlist.py
@@ -1824,8 +1824,6 @@ class TestNeighborListAcrossPeriodicities:
         return VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
 
     def _slab_cell(self, L, periodic):
-        # Mixed-axis periodic mask: `Cell(frame, periodic=...)` directly.
-        # The literal tuple narrows P (e.g. `Cell[SlabXY]` for `(T,T,F)`).
         return Cell(OrthogonalFrame(jnp.array([L, L, L])[None]), periodic=periodic)
 
     def test_3d_periodic_wraps_across_face(self):

--- a/test/core/test_neighborlist.py
+++ b/test/core/test_neighborlist.py
@@ -10,7 +10,13 @@ import numpy.testing as npt
 import pytest
 
 from kups.core.capacity import CapacityError, FixedCapacity
-from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
+from kups.core.cell import (
+    Cell,
+    OrthogonalFrame,
+    PeriodicCell,
+    TriclinicFrame,
+    VacuumCell,
+)
 from kups.core.data.index import Index
 from kups.core.data.table import Table
 from kups.core.data.wrappers import WithIndices
@@ -1762,3 +1768,106 @@ class TestNeighborlistChanges:
         assert _extract_valid_edge_set(result.removed, N) == _extract_valid_edge_set(
             ref_removed, N
         )
+
+
+def _valid_edges_set(edges, n_particles):
+    """Return the set of (i, j) edges with both indices < n_particles."""
+    raw = edges.indices.indices
+    in_range = (raw[:, 0] < n_particles) & (raw[:, 1] < n_particles)
+    return set(tuple(p.tolist()) for p in raw[in_range])
+
+
+def _run_cell_list(positions, cell, cutoff):
+    """Run CellListNeighborList on a single-system fixture."""
+    n = len(positions)
+    lh = _make_lh(positions, jnp.zeros(n, dtype=int))
+    systems, cutoffs = _systems_from_cell(cell, jnp.array([cutoff]))
+    nl = CellListNeighborList(
+        avg_candidates=FixedCapacity(max(n * n, 8)),
+        avg_edges=FixedCapacity(max(n * n, 8)),
+        cells=FixedCapacity(512),
+        avg_image_candidates=FixedCapacity(max(n * n, 8)),
+    )
+    result = jax.jit(as_result_function(nl))(
+        lh=lh, rh=None, systems=systems, cutoffs=cutoffs, rh_index_remap=None
+    )
+    result.raise_assertion()
+    return result.value
+
+
+def _run_dense(positions, cell, cutoff):
+    """Run DenseNearestNeighborList on the same fixture, for cross-check."""
+    n = len(positions)
+    lh = _make_lh(positions, jnp.zeros(n, dtype=int))
+    systems, cutoffs = _systems_from_cell(cell, jnp.array([cutoff]))
+    nl = DenseNearestNeighborList(
+        avg_candidates=FixedCapacity(max(n * n, 8)),
+        avg_edges=FixedCapacity(max(n * n, 8)),
+        avg_image_candidates=FixedCapacity(max(n * n, 8)),
+    )
+    result = jax.jit(as_result_function(nl))(
+        lh=lh, rh=None, systems=systems, cutoffs=cutoffs, rh_index_remap=None
+    )
+    result.raise_assertion()
+    return result.value
+
+
+class TestNonPeriodicNeighborList:
+    """Cell list with all-False periodic mask (vacuum cells).
+
+    The neighbor list machinery is per-axis-mask-aware via ``cell.periodic``.
+    The current cell hierarchy exposes only the all-True (PeriodicCell) and
+    all-False (VacuumCell) literals; mixed-axis (slab / wire) geometries
+    will be re-introduced together with their cell type when a real
+    consumer lands.
+    """
+
+    def test_non_pbc_excludes_cross_boundary_pair(self):
+        """Two atoms near opposite faces should NOT be connected when periodic=(F,F,F).
+
+        With PBC the wrapped x-distance would be 1.0 (well under cutoff); without
+        PBC the real distance is 9.0 (well above cutoff). Verifies that the
+        cell list honors the open boundary.
+        """
+        L = 10.0
+        positions = jnp.array([[0.5, 5.0, 5.0], [9.5, 5.0, 5.0]])
+        cell = VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
+        edges = _run_cell_list(positions, cell, cutoff=2.0)
+        assert _valid_edges_set(edges, 2) == set()
+
+    def test_non_pbc_finds_in_box_pair(self):
+        """Atoms within cutoff and inside the box should still be connected."""
+        L = 10.0
+        positions = jnp.array([[4.0, 5.0, 5.0], [5.0, 5.0, 5.0]])
+        cell = VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
+        edges = _run_cell_list(positions, cell, cutoff=2.0)
+        assert _valid_edges_set(edges, 2) == {(0, 1), (1, 0)}
+
+    def test_non_pbc_matches_dense(self):
+        """CellListNeighborList and DenseNearestNeighborList agree on non-PBC.
+
+        Both route through ``basic_neighborlist`` so they share the masked MIC
+        and image-count paths; this locks in that the cell-list specific
+        stencil routing is consistent with the dense reference.
+        """
+        L = 12.0
+        rng = np.random.default_rng(7)
+        # 30 atoms scattered in [1, L-1] so they're safely inside the box
+        positions = jnp.asarray(rng.uniform(1.0, L - 1.0, size=(30, 3)))
+        cell = VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
+        cutoff = 3.5
+        cl_edges = _run_cell_list(positions, cell, cutoff)
+        dn_edges = _run_dense(positions, cell, cutoff)
+        assert _valid_edges_set(cl_edges, 30) == _valid_edges_set(dn_edges, 30)
+
+    def test_pbc_unchanged(self):
+        """Sanity: PeriodicCell output is unchanged by the per-axis trace-time gate.
+
+        Same fixture as test_non_pbc_excludes_cross_boundary_pair, but with PBC:
+        the wrapped x-distance is 1.0 → edge under PBC.
+        """
+        L = 10.0
+        positions = jnp.array([[0.5, 5.0, 5.0], [9.5, 5.0, 5.0]])
+        cell = PeriodicCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
+        edges = _run_cell_list(positions, cell, cutoff=2.0)
+        assert _valid_edges_set(edges, 2) == {(0, 1), (1, 0)}

--- a/test/core/test_neighborlist.py
+++ b/test/core/test_neighborlist.py
@@ -14,7 +14,6 @@ from kups.core.cell import (
     Cell,
     OrthogonalFrame,
     PeriodicCell,
-    SlabCell,
     TriclinicFrame,
     VacuumCell,
 )
@@ -1825,8 +1824,9 @@ class TestNeighborListAcrossPeriodicities:
         return VacuumCell(OrthogonalFrame(jnp.array([L, L, L])[None]))
 
     def _slab_cell(self, L, periodic):
-        # `periodic` is a static tuple; SlabCell stores it on the dataclass.
-        return SlabCell(OrthogonalFrame(jnp.array([L, L, L])[None]), periodic=periodic)
+        # Mixed-axis periodic mask: `Cell(frame, periodic=...)` directly.
+        # The literal tuple narrows P (e.g. `Cell[SlabXY]` for `(T,T,F)`).
+        return Cell(OrthogonalFrame(jnp.array([L, L, L])[None]), periodic=periodic)
 
     def test_3d_periodic_wraps_across_face(self):
         """Two atoms near opposite x-faces connect via the periodic image."""


### PR DESCRIPTION
Implements the non-PBC story end-to-end on top of the new Frame/Cell hierarchy: the cell list (and the shared `basic_neighborlist` path) now honor the cell's `periodic` tuple so that `VacuumCell` produces correct edges, and the ASE loader propagates `atoms.pbc` into the kups cell so simulations driven through the application layer use the right boundary mode. Unblocks Marcel's request (issue #89) for non-PBC support.

## Three masked sites in `core/neighborlist.py`

- `_compute_distances_pbc_sq`: MIC fold gated as `jnp.where(periodic, jnp.round(deltas), 0.0)` so non-periodic axes get a zero shift.
- `_get_candidate_images`: image counts on open axes forced to 1 so the existing early-out fires for fully-open systems.
- `_cell_list_subselect`: trace-time gate on `all(periodic)`. The fully-periodic branch is byte-identical to the prior code (verified via HLO inspection); the general branch wraps only on periodic axes and routes out-of-range stencil offsets to the `cell_oob` sentinel so cross-boundary candidates produce no key matches.

## Application loader

`particles_from_ase` reads `atoms.pbc` and constructs the cell accordingly:
- all-True → `PeriodicCell(TriclinicFrame.from_matrix(...))`
- all-False → `VacuumCell(TriclinicFrame.from_matrix(...))`
- mixed → `raise NotImplementedError(...)` with a clear message

Mixed-axis (slab / wire) PBC raises today because the cell hierarchy currently exposes only the all-True/all-False literals. The neighbor-list machinery is already mask-aware via `cell.periodic` and will work transparently once a slab cell type is re-introduced (no neighborlist-side changes will be needed).

## Tests in `TestNonPeriodicNeighborList`

- Cross-boundary pair excluded under `VacuumCell`.
- In-box pair found.
- `CellListNeighborList` and `DenseNearestNeighborList` agree on a non-PBC fixture (locks in that the cell-list-specific stencil routing is consistent with the dense reference, since both go through `basic_neighborlist`).
- `PeriodicCell` path unchanged (sanity).

## Docstring updates

`core/neighborlist.py`, `core/utils/position.py`, `observables/radial_distribution_function.py`, and `potential/common/graph.py` replace "requires/uses periodic boundary conditions" with the per-axis story, since the entire stack now reads `cell.periodic` and works correctly for vacuum and bulk.