### PR TITLE
refactor: Replace inclusion/exclusion indices with group-based motif lookup in blocking spheres

### DIFF
--- a/src/kups/potential/classical/blocking.py
+++ b/src/kups/potential/classical/blocking.py
@@ -11,7 +11,7 @@ Particles inside blocking spheres experience infinite repulsion, automatically
 rejecting Monte Carlo moves that violate spatial constraints.
 """
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, overload
+from typing import TYPE_CHECKING, Any, Literal, Protocol, Sequence, overload
 
 import jax
 import jax.numpy as jnp
@@ -19,7 +19,7 @@ from jax import Array
 
 from kups.core.cell import Cell
 from kups.core.data import Index, Table
-from kups.core.lens import Lens, SimpleLens, View
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import Edges, NearestNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
@@ -32,9 +32,9 @@ from kups.core.potential import (
 )
 from kups.core.typing import (
     ExclusionId,
+    GroupId,
     HasCell,
-    HasExclusionIndex,
-    HasInclusionIndex,
+    HasGroupIndex,
     HasMotifIndex,
     HasPositionsAndSystemIndex,
     InclusionId,
@@ -45,13 +45,20 @@ from kups.core.typing import (
 from kups.core.utils.jax import dataclass, field
 from kups.potential.common.energy import (
     EnergyFunction,
-    PositionAndCell,
     PotentialFromEnergy,
     Sum,
     SumComposer,
     Summand,
-    position_and_cell_idx_view,
 )
+
+
+class BlockingSpheresConfig(Protocol):
+    """Protocol for a single blocking sphere description (center and radius)."""
+
+    @property
+    def center(self) -> tuple[float, float, float]: ...
+    @property
+    def radius(self) -> float: ...
 
 
 @dataclass
@@ -71,17 +78,46 @@ class BlockingSpheresParameters:
     motif: Index[MotifId]
 
     def __post_init__(self):
-        if isinstance(self.radii, Array):
-            assert (*self.radii.shape, 3) == self.positions.shape
+        if not isinstance(self.radii, Array):
+            return
+        assert (*self.radii.shape, 3) == self.positions.shape, (
+            f"Positions shape {self.positions.shape} must match radii shape {self.radii.shape} with last dimension 3"
+        )
+        assert self.radii.shape == self.system.shape == self.motif.shape, (
+            f"Radii, system, and motif must have the same shape: {self.radii.shape}, {self.system.shape}, {self.motif.shape}"
+        )
+
+    @staticmethod
+    def from_data(data: Sequence[Sequence[Sequence[BlockingSpheresConfig]]]):
+        """Build parameters from a nested sequence of sphere configurations.
+
+        Args:
+            data: Nested sequence indexed as ``data[system_idx][motif_idx][sphere_idx]``,
+                yielding the sphere configurations for each (system, motif) pair.
+
+        Returns:
+            BlockingSpheresParameters with flattened arrays of radii, positions,
+            system assignments, and motif assignments.
+        """
+        radii = []
+        positions = []
+        system = []
+        motif = []
+        for sys_idx, sys_spheres in enumerate(data):
+            for motif_idx, motif_spheres in enumerate(sys_spheres):
+                for sphere in motif_spheres:
+                    radii.append(sphere.radius)
+                    positions.append(sphere.center)
+                    system.append(SystemId(sys_idx))
+                    motif.append(MotifId(motif_idx))
+        radii = jnp.array(radii)
+        positions = jnp.array(positions).reshape(-1, 3)
+        system = Index.new(system, label=SystemId).populate_max_count()
+        motif = Index.new(motif, label=MotifId).populate_max_count()
+        return BlockingSpheresParameters(radii, positions, system, motif)
 
 
-class _BlockingParticles(
-    HasPositionsAndSystemIndex,
-    HasMotifIndex,
-    HasInclusionIndex,
-    HasExclusionIndex,
-    Protocol,
-): ...
+class _BlockingParticles(HasPositionsAndSystemIndex, HasGroupIndex, Protocol): ...
 
 
 @dataclass
@@ -108,30 +144,26 @@ class IsBlockingSpheresProbe(Protocol):
 
 
 @dataclass
-class BlockingSpheresPotentialInput[
-    Points: _BlockingParticles,
-    MaybeCell: Cell | None,
-]:
+class BlockingSpheresPotentialInput:
     """Input for blocking spheres energy calculation.
 
     Attributes:
         parameters: Blocking sphere positions and radii
-        particles: Indexed particle data with positions, system, and motif index
-        cell: Optional cell for periodic boundary conditions
+        particles: Indexed particle data with positions, system, and group index
+        groups: Indexed group data providing the motif index for each group
+        cell: Per-system cell used for periodic boundary wrapping
         edges: Particle-sphere pairs to check for blocking
     """
 
     parameters: BlockingSpheresParameters
-    particles: Table[ParticleId, Points]
-    cell: MaybeCell
+    particles: Table[ParticleId, _BlockingParticles]
+    groups: Table[GroupId, HasMotifIndex]
+    cell: Table[SystemId, Cell]
     edges: Edges[Literal[2]]
 
 
-def blocking_spheres_energy[
-    Points: _BlockingParticles,
-    UC: Cell | None,
-](
-    inp: BlockingSpheresPotentialInput[Points, UC],
+def blocking_spheres_energy(
+    inp: BlockingSpheresPotentialInput,
 ) -> WithPatch[Table[SystemId, Energy], IdPatch]:
     """Calculate blocking spheres potential energy.
 
@@ -143,50 +175,48 @@ def blocking_spheres_energy[
     Returns:
         Energy and patch with infinite energy for blocked particles.
     """
-    edge_idx = inp.edges.indices.indices
-    particle_idx, sph_idx = edge_idx[:, 0], edge_idx[:, 1]
-    batch_data = inp.particles.data.system.indices[particle_idx]
-    diffs = (
-        inp.particles.data.positions[particle_idx] - inp.parameters.positions[sph_idx]
-    )
-    if inp.cell is not None:
-        cell = inp.cell[batch_data]
-        diffs = cell.wrap(diffs)
+    particle_motif_idx = inp.edges.indices[:, 0]
+    sph_idx = inp.edges.indices[:, 1].indices
+    particles = inp.particles[particle_motif_idx]
+    particle_sys = particles.system
+    diffs = particles.positions - inp.parameters.positions[sph_idx]
+    diffs = inp.cell[particle_sys].wrap(diffs)
     dists = jnp.linalg.norm(diffs, axis=-1)
     radii = inp.parameters.radii[sph_idx]
-    raw_energies = jnp.where(
-        (dists < radii)
-        & (
-            inp.particles.data.motif.indices[particle_idx]
-            == inp.parameters.motif.indices[sph_idx]
-        ),
-        jnp.inf,
-        0.0,
+    sph_motif = inp.parameters.motif[sph_idx]
+    # Compare motifs in a merged keyspace so that groups whose motif has no
+    # sphere (and OOB-sentinel groups, e.g. buffered empty slots) never match
+    # any sphere motif and therefore are not blocked.
+    group_motif_idx, sph_motif_idx = Index.match(
+        inp.groups[particles.group].motif, sph_motif
     )
-    batch_idx = Index(inp.particles.data.system.keys, batch_data)
-    energies = batch_idx.sum_over(raw_energies)
+    raw_energies = jnp.where(
+        (dists < radii) & (group_motif_idx == sph_motif_idx), jnp.inf, 0.0
+    )
+    energies = particle_sys.sum_over(raw_energies)
     return WithPatch(energies, IdPatch())
 
 
 @dataclass
-class BlockingSpheresSumComposer[
-    State,
-    Ptch: Patch,
-    S: HasCell,
-    Points: _BlockingParticles,
-](SumComposer[State, BlockingSpheresPotentialInput[Points, Cell], Ptch]):
+class BlockingSpheresSumComposer[State, Ptch: Patch](
+    SumComposer[State, BlockingSpheresPotentialInput, Ptch]
+):
     """Composer for blocking spheres potential in energy summation.
 
     Attributes:
         particles_view: Extracts indexed particle data from state
+        groups_view: Extracts indexed group data (motif assignments) from state
         systems_view: Extracts indexed systems from state
         parameters_view: Extracts blocking sphere parameters from state
         neighborlist_view: Extracts neighbor list instance from state
         probe: Probe providing a IsBlockingSpheresProbe
     """
 
-    particles_view: View[State, Table[ParticleId, Points]] = field(static=True)
-    systems_view: View[State, Table[SystemId, S]] = field(static=True)
+    particles_view: View[State, Table[ParticleId, _BlockingParticles]] = field(
+        static=True
+    )
+    groups_view: View[State, Table[GroupId, HasMotifIndex]] = field(static=True)
+    systems_view: View[State, Table[SystemId, HasCell]] = field(static=True)
     parameters_view: View[State, BlockingSpheresParameters] = field(static=True)
     neighborlist_view: View[State, NearestNeighborList] = field(static=True)
     probe: Probe[State, Ptch, IsBlockingSpheresProbe] | None = field(static=True)
@@ -211,16 +241,21 @@ class BlockingSpheresSumComposer[
         max_radii = jax.ops.segment_max(parameters.radii, seg_ids, len(systems.keys))
         cutoffs = Table(systems.keys, max_radii)
 
+        # NNList particles
+        nnlist_particles = particles.map_data(
+            lambda p: _BlockingSpherePoints(
+                positions=p.positions,
+                system=(sys := p.system.apply_mask(p.group.valid_mask)),
+                inclusion=sys.to_cls(InclusionId),
+                exclusion=Index.arange(len(sys), label=ExclusionId),
+            )
+        )
+
         # Build sphere rh as Indexed[ParticleId, _BlockingSpherePoints]
         p = parameters.positions.shape[0]
-        sphere_inclusion = Index(
-            tuple(InclusionId(lab) for lab in parameters.system.keys),
-            parameters.system.indices,
-        )
-        sphere_exclusion = Index(
-            tuple(ExclusionId(-1 - i) for i in range(p)),
-            jnp.arange(p),
-        )
+        sphere_inclusion = parameters.system.to_cls(InclusionId)
+        # Let's just pick negative exclusion IDs for spheres to avoid any possible overlap with particle exclusion IDs
+        sphere_exclusion = Index.new(tuple(ExclusionId(-1 - i) for i in range(p)))
         spheres = Table.arange(
             _BlockingSpherePoints(
                 positions=parameters.positions,
@@ -231,41 +266,37 @@ class BlockingSpheresSumComposer[
             label=ParticleId,
         )
 
-        edges = neighborlist(particles, spheres, systems, cutoffs)
-        cell = systems.data.cell
+        edges = neighborlist(nnlist_particles, spheres, systems, cutoffs)
+        cell = systems.map_data(lambda s: s.cell)
+        groups = self.groups_view(state)
         return Sum(
-            Summand(BlockingSpheresPotentialInput(parameters, particles, cell, edges))
+            Summand(
+                BlockingSpheresPotentialInput(
+                    parameters, particles, groups, cell, edges
+                )
+            )
         )
 
 
-def make_blocking_spheres_potential[
-    State,
-    Gradients,
-    Hessians,
-    Ptch: Patch,
-    Points: _BlockingParticles,
-    S: HasCell,
-](
-    particles_view: View[State, Table[ParticleId, Points]],
-    systems_view: View[State, Table[SystemId, S]],
+def make_blocking_spheres_potential[State, Gradients, Hessians, Ptch: Patch](
+    particles_view: View[State, Table[ParticleId, _BlockingParticles]],
+    groups_view: View[State, Table[GroupId, HasMotifIndex]],
+    systems_view: View[State, Table[SystemId, HasCell]],
     parameters_view: View[State, BlockingSpheresParameters],
     neighborlist_view: View[State, NearestNeighborList],
     probe: Probe[State, Ptch, IsBlockingSpheresProbe] | None,
-    gradient_lens: Lens[BlockingSpheresPotentialInput[Points, Cell], Gradients],
+    gradient_lens: Lens[BlockingSpheresPotentialInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
 ) -> PotentialFromEnergy[
-    State,
-    BlockingSpheresPotentialInput[Points, Cell],
-    Gradients,
-    Hessians,
-    Ptch,
+    State, BlockingSpheresPotentialInput, Gradients, Hessians, Ptch
 ]:
     """Create blocking sphere potential for excluded volume constraints.
 
     Args:
         particles_view: Extracts indexed particle data from state
+        groups_view: Extracts indexed group data (motif assignments) from state
         systems_view: Extracts indexed systems from state
         parameters_view: Extracts blocking sphere parameters (positions, radii)
         neighborlist_view: Extracts neighbor list instance
@@ -282,6 +313,7 @@ def make_blocking_spheres_potential[
         blocking_spheres_energy,
         BlockingSpheresSumComposer(
             particles_view=particles_view,
+            groups_view=groups_view,
             systems_view=systems_view,
             parameters_view=parameters_view,
             neighborlist_view=neighborlist_view,
@@ -301,6 +333,8 @@ class IsBlockingSpheresState(Protocol):
     @property
     def particles(self) -> Table[ParticleId, _BlockingParticles]: ...
     @property
+    def groups(self) -> Table[GroupId, HasMotifIndex]: ...
+    @property
     def systems(self) -> Table[SystemId, HasCell]: ...
     @property
     def blocking_spheres_parameters(self) -> BlockingSpheresParameters: ...
@@ -312,71 +346,35 @@ class IsBlockingSpheresState(Protocol):
 def make_blocking_spheres_from_state[State](
     state: Lens[State, IsBlockingSpheresState],
     probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, Any]: ...
 
 
 @overload
-def make_blocking_spheres_from_state[State](
-    state: Lens[State, IsBlockingSpheresState],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, Any]: ...
-
-
-@overload
 def make_blocking_spheres_from_state[State, P: Patch](
     state: Lens[State, IsBlockingSpheresState],
     probe: Probe[State, P, IsBlockingSpheresProbe],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, P]: ...
 
 
-@overload
-def make_blocking_spheres_from_state[State, P: Patch](
-    state: Lens[State, IsBlockingSpheresState],
-    probe: Probe[State, P, IsBlockingSpheresProbe],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_blocking_spheres_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-) -> Any:
+def make_blocking_spheres_from_state(state: Any, probe: Any = None) -> Any:
     """Create a blocking spheres potential, optionally with incremental updates.
 
     Args:
-        state: Lens into the sub-state providing particles, systems, blocking sphere
-            parameters, and neighbor list.
+        state: Lens into the sub-state providing particles, groups, systems,
+            blocking sphere parameters, and neighbor list.
         probe: Probe returning a IsBlockingSpheresProbe; ``None`` for full
             recomputation.
-        compute_position_and_cell_gradients: When ``True``, compute gradients
-            w.r.t. particle positions and lattice vectors.
 
     Returns:
         Configured blocking spheres Potential.
     """
     gradient_lens: Any = EMPTY_LENS
     patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[BlockingSpheresPotentialInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.particles.map_data(lambda p: p.positions),
-                Table(x.particles.data.system.keys, x.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
     if probe is not None:
         patch_idx_view = patch_idx_view or empty_patch_idx_view
     return make_blocking_spheres_potential(
         state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.groups),
         state.focus(lambda x: x.systems),
         state.focus(lambda x: x.blocking_spheres_parameters),
         state.focus(lambda x: x.blocking_spheres_neighborlist),

--- a/test/potential/test_blocking_spheres.py
+++ b/test/potential/test_blocking_spheres.py
@@ -6,10 +6,11 @@
 import jax
 import jax.numpy as jnp
 
+from kups.core.cell import PeriodicCell, TriclinicFrame
 from kups.core.data.index import Index
 from kups.core.data.table import Table
 from kups.core.neighborlist import Edges
-from kups.core.typing import ExclusionId, InclusionId, MotifId, ParticleId, SystemId
+from kups.core.typing import GroupId, MotifId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
 from kups.potential.classical.blocking import (
     BlockingSpheresParameters,
@@ -20,37 +21,49 @@ from kups.potential.classical.blocking import (
 
 @dataclass
 class ParticleData:
-    """Particle data with positions, system, and motif index."""
+    """Particle data with positions, system, and group index."""
 
     positions: jax.Array
     system: Index[SystemId]
+    group: Index[GroupId]
+
+
+@dataclass
+class GroupData:
+    """Group data carrying motif assignment."""
+
     motif: Index[MotifId]
-    inclusion: Index[InclusionId]
-    exclusion: Index[ExclusionId]
 
 
 def _make_particles(
     positions: jax.Array,
     system_ids: list[int],
-    motif_ids: list[int],
+    group_ids: list[int],
 ) -> Table[ParticleId, ParticleData]:
     system = Index.new([SystemId(i) for i in system_ids])
+    group = Index.new([GroupId(i) for i in group_ids])
+    return Table.arange(ParticleData(positions, system, group), label=ParticleId)
+
+
+def _make_groups(motif_ids: list[int]) -> Table[GroupId, GroupData]:
     motif = Index.new([MotifId(i) for i in motif_ids])
-    inclusion = Index(
-        tuple(InclusionId(lab) for lab in system.keys),
-        system.indices,
+    return Table.arange(GroupData(motif), label=GroupId)
+
+
+def _make_cell(n_systems: int, box_size: float = 1000.0):
+    """Large cubic per-system cells, so wrap is effectively identity."""
+    cells = PeriodicCell(
+        TriclinicFrame.from_matrix(
+            jnp.broadcast_to(jnp.eye(3) * box_size, (n_systems, 3, 3))
+        )
     )
-    exclusion = Index.arange(len(system_ids), label=ExclusionId)
-    return Table.arange(
-        ParticleData(positions, system, motif, inclusion, exclusion),
-        label=ParticleId,
-    )
+    return Table(tuple(SystemId(i) for i in range(n_systems)), cells)
 
 
 def create_test_edges(
     particles: Table[ParticleId, ParticleData], indices: list[list[int]]
 ) -> Edges:
-    """Helper function to create Edges with proper shifts for testing."""
+    """Build Edges with zero shifts from a list of [particle_idx, sphere_idx] pairs."""
     if not indices:
         return Edges(
             indices=Index(particles.keys, jnp.zeros((0, 2), dtype=int)),
@@ -70,14 +83,12 @@ class TestBlockingSpheresEnergy:
 
     @classmethod
     def setup_class(cls):
-        """Set up test data for energy calculations."""
-        cls.radii = jnp.array([1.0, 2.0])
-        cls.sphere_positions = jnp.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+        """Set up test data: two spheres in system 0, motif 0."""
         cls.parameters = BlockingSpheresParameters(
-            radii=cls.radii,
-            positions=cls.sphere_positions,
-            system=Index.new([SystemId(i) for i in [0, 0]]),
-            motif=Index.new([MotifId(i) for i in [0, 0]]),
+            radii=jnp.array([1.0, 2.0]),
+            positions=jnp.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]]),
+            system=Index.new([SystemId(0), SystemId(0)]),
+            motif=Index.new([MotifId(0), MotifId(0)]),
         )
         cls.particle_positions = jnp.array(
             [
@@ -87,91 +98,236 @@ class TestBlockingSpheresEnergy:
                 [10.0, 0.0, 0.0],  # Outside both spheres
             ]
         )
+        # 4 particles, each in its own group; all groups have motif 0.
         cls.particles = _make_particles(
-            cls.particle_positions, [0, 0, 0, 0], [0, 0, 0, 0]
+            cls.particle_positions, [0, 0, 0, 0], [0, 1, 2, 3]
+        )
+        cls.groups = _make_groups([0, 0, 0, 0])
+        cls.cell = _make_cell(1)
+
+    def _make_input(self, particles, edges, groups=None, cell=None):
+        return BlockingSpheresPotentialInput(
+            parameters=self.parameters,
+            particles=particles,
+            groups=groups if groups is not None else self.groups,
+            cell=cell if cell is not None else self.cell,
+            edges=edges,
         )
 
     def test_energy_scenarios(self):
-        """Merged: inside + outside + boundary + multiple + no_edges + with_cell."""
+        """Merged: inside + outside + boundary + multiple + no_edges."""
         energy_fn = _jit_blocking_spheres_energy
 
         # Inside sphere -> infinite energy
-        edges_in = create_test_edges(self.particles, [[0, 0]])
-        inp_in = BlockingSpheresPotentialInput(
-            parameters=self.parameters,
-            particles=self.particles,
-            cell=None,
-            edges=edges_in,
+        result_in = energy_fn(
+            self._make_input(
+                self.particles, create_test_edges(self.particles, [[0, 0]])
+            )
         )
-        result_in = energy_fn(inp_in)
         assert jnp.isinf(result_in.data.data[0])
 
         # Outside sphere -> zero energy
-        edges_out = create_test_edges(self.particles, [[3, 0]])
-        inp_out = BlockingSpheresPotentialInput(
-            parameters=self.parameters,
-            particles=self.particles,
-            cell=None,
-            edges=edges_out,
+        result_out = energy_fn(
+            self._make_input(
+                self.particles, create_test_edges(self.particles, [[3, 0]])
+            )
         )
-        result_out = energy_fn(inp_out)
         assert result_out.data.data[0] == 0.0
 
-        # On boundary -> finite energy
+        # On boundary -> finite energy (dist == radius is not strictly less)
         boundary_particles = _make_particles(jnp.array([[1.0, 0.0, 0.0]]), [0], [0])
-        edges_bnd = create_test_edges(boundary_particles, [[0, 0]])
-        inp_bnd = BlockingSpheresPotentialInput(
-            parameters=self.parameters,
-            particles=boundary_particles,
-            cell=None,
-            edges=edges_bnd,
+        result_bnd = energy_fn(
+            self._make_input(
+                boundary_particles,
+                create_test_edges(boundary_particles, [[0, 0]]),
+                groups=_make_groups([0]),
+            )
         )
-        result_bnd = energy_fn(inp_bnd)
         assert jnp.isfinite(result_bnd.data.data[0])
 
         # Multiple particles + spheres -> inf if any overlap
-        edges_multi = create_test_edges(
-            self.particles,
-            [[0, 0], [1, 0], [2, 1], [3, 1]],
+        result_multi = energy_fn(
+            self._make_input(
+                self.particles,
+                create_test_edges(self.particles, [[0, 0], [1, 0], [2, 1], [3, 1]]),
+            )
         )
-        inp_multi = BlockingSpheresPotentialInput(
-            parameters=self.parameters,
-            particles=self.particles,
-            cell=None,
-            edges=edges_multi,
-        )
-        result_multi = energy_fn(inp_multi)
         assert jnp.isinf(result_multi.data.data[0])
 
         # No edges -> zero energy
-        edges_none = create_test_edges(self.particles, [])
-        inp_none = BlockingSpheresPotentialInput(
-            parameters=self.parameters,
-            particles=self.particles,
-            cell=None,
-            edges=edges_none,
+        result_none = energy_fn(
+            self._make_input(self.particles, create_test_edges(self.particles, []))
         )
-        result_none = energy_fn(inp_none)
         assert result_none.data.data[0] == 0.0
 
-        # With cell (still inside) -> infinite
-        cell_particles = _make_particles(jnp.array([[0.5, 0.0, 0.0]]), [0], [0])
-        edges_cell = create_test_edges(cell_particles, [[0, 0]])
-        inp_cell = BlockingSpheresPotentialInput(
-            parameters=self.parameters,
-            particles=cell_particles,
-            cell=None,
-            edges=edges_cell,
+    def test_move_into_sphere_then_out(self):
+        """Position-driven energy: a particle moving into a sphere yields inf,
+        moving out yields 0. This is what the MCMC layer relies on to accept
+        or reject proposed moves: each call evaluates the post-move energy.
+        """
+        parameters = BlockingSpheresParameters(
+            radii=jnp.array([1.0]),
+            positions=jnp.array([[0.0, 0.0, 0.0]]),
+            system=Index.new([SystemId(0)]),
+            motif=Index.new([MotifId(0)]),
         )
-        result_cell = energy_fn(inp_cell)
-        assert jnp.isinf(result_cell.data.data[0])
+        groups = _make_groups([0])
+        cell = _make_cell(1)
+
+        def energy_at(pos):
+            particles = _make_particles(jnp.array([pos]), [0], [0])
+            return blocking_spheres_energy(
+                BlockingSpheresPotentialInput(
+                    parameters=parameters,
+                    particles=particles,
+                    groups=groups,
+                    cell=cell,
+                    edges=create_test_edges(particles, [[0, 0]]),
+                )
+            ).data.data[0]
+
+        # Move into the sphere -> inf (move would be rejected by MCMC).
+        assert jnp.isinf(energy_at([0.3, 0.0, 0.0]))
+        # Move back out -> 0 (move would be accepted).
+        assert energy_at([2.5, 0.0, 0.0]) == 0.0
+        # Move into a different point inside the sphere -> inf.
+        assert jnp.isinf(energy_at([0.0, 0.5, 0.0]))
+
+    def test_pbc_wrapping_blocks_across_boundary(self):
+        """A particle on the far side of the box and a sphere at the origin
+        are within blocking range when periodic boundary conditions wrap them
+        together.
+        """
+        L = 10.0
+        parameters = BlockingSpheresParameters(
+            radii=jnp.array([1.0]),
+            positions=jnp.array([[0.0, 0.0, 0.0]]),
+            system=Index.new([SystemId(0)]),
+            motif=Index.new([MotifId(0)]),
+        )
+        # Particle at L - 0.4: real-space distance ~9.6, but PBC distance ~0.4 < 1.0.
+        particles = _make_particles(jnp.array([[L - 0.4, 0.0, 0.0]]), [0], [0])
+        cell = Table(
+            (SystemId(0),),
+            PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * L)),
+        )
+        result = blocking_spheres_energy(
+            BlockingSpheresPotentialInput(
+                parameters=parameters,
+                particles=particles,
+                groups=_make_groups([0]),
+                cell=cell,
+                edges=create_test_edges(particles, [[0, 0]]),
+            )
+        )
+        assert jnp.isinf(result.data.data[0])
+
+    def test_motif_filtering(self):
+        """A sphere only blocks particles whose group's motif matches the sphere's motif."""
+        # Two spheres, one per motif; both centered at origin so geometry alone wouldn't discriminate.
+        parameters = BlockingSpheresParameters(
+            radii=jnp.array([1.0, 1.0]),
+            positions=jnp.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+            system=Index.new([SystemId(0), SystemId(0)]),
+            motif=Index.new([MotifId(0), MotifId(1)]),
+        )
+        particles = _make_particles(jnp.array([[0.5, 0.0, 0.0]]), [0], [0])
+        # The particle's group has motif 1 -> sphere 0 (motif 0) does NOT block,
+        # sphere 1 (motif 1) DOES block.
+        groups = _make_groups([1])
+        cell = _make_cell(1)
+
+        # Match: motif 1 sphere blocks
+        result_match = blocking_spheres_energy(
+            BlockingSpheresPotentialInput(
+                parameters=parameters,
+                particles=particles,
+                groups=groups,
+                cell=cell,
+                edges=create_test_edges(particles, [[0, 1]]),
+            )
+        )
+        assert jnp.isinf(result_match.data.data[0])
+
+        # Mismatch: motif 0 sphere does not block
+        result_miss = blocking_spheres_energy(
+            BlockingSpheresPotentialInput(
+                parameters=parameters,
+                particles=particles,
+                groups=groups,
+                cell=cell,
+                edges=create_test_edges(particles, [[0, 0]]),
+            )
+        )
+        assert result_miss.data.data[0] == 0.0
+
+    def test_motif_outside_sphere_keyspace_does_not_block(self):
+        """A particle whose group's motif is absent from the sphere motif keyspace
+        is never blocked, regardless of position. Without this, a host config
+        whose adsorbates include species without spheres would crash the energy
+        function.
+        """
+        # Sphere keyspace covers only motif 0.
+        parameters = BlockingSpheresParameters(
+            radii=jnp.array([1.0]),
+            positions=jnp.array([[0.0, 0.0, 0.0]]),
+            system=Index.new([SystemId(0)]),
+            motif=Index.new([MotifId(0)]),
+        )
+        # Particle is geometrically inside, but its group has motif 1
+        # (not present in any sphere) -> must not block.
+        particles = _make_particles(jnp.array([[0.5, 0.0, 0.0]]), [0], [0])
+        groups = _make_groups([1])
+        result = blocking_spheres_energy(
+            BlockingSpheresPotentialInput(
+                parameters=parameters,
+                particles=particles,
+                groups=groups,
+                cell=_make_cell(1),
+                edges=create_test_edges(particles, [[0, 0]]),
+            )
+        )
+        assert result.data.data[0] == 0.0
+
+    def test_oob_group_sentinel_does_not_block(self):
+        """Buffer-slot semantics: a particle whose group is the OOB sentinel
+        (e.g. an empty MCMC buffer slot) is not blocked, even when its position
+        falls inside a sphere matching another particle's motif.
+        """
+        parameters = BlockingSpheresParameters(
+            radii=jnp.array([1.0]),
+            positions=jnp.array([[0.0, 0.0, 0.0]]),
+            system=Index.new([SystemId(0)]),
+            motif=Index.new([MotifId(0)]),
+        )
+        # Two groups so the OOB sentinel is a meaningful out-of-vocab index;
+        # both groups carry motif 0 so a clamping bug would silently block.
+        groups = Table.arange(
+            GroupData(Index.new([MotifId(0), MotifId(0)])),
+            label=GroupId,
+        )
+        # Particle 0's group is masked out -> OOB sentinel; particle 1 is real.
+        group = Index.new([GroupId(0), GroupId(1)]).apply_mask(jnp.array([False, True]))
+        positions = jnp.array([[0.5, 0.0, 0.0], [10.0, 0.0, 0.0]])
+        particles = Table.arange(
+            ParticleData(positions, Index.new([SystemId(0), SystemId(0)]), group),
+            label=ParticleId,
+        )
+        # Edge connects the OOB-group particle to the sphere it sits inside.
+        result = blocking_spheres_energy(
+            BlockingSpheresPotentialInput(
+                parameters=parameters,
+                particles=particles,
+                groups=groups,
+                cell=_make_cell(1),
+                edges=create_test_edges(particles, [[0, 0]]),
+            )
+        )
+        assert result.data.data[0] == 0.0
 
     def test_edge_cases(self):
         """Merged: zero_radius + negative_radius + very_large_distances."""
-        # Different shapes from class fixture, so use raw function
-        energy_fn = blocking_spheres_energy
-
-        # Zero radius sphere
+        # Zero radius sphere -> dist (=0) is not strictly less than 0 -> finite
         params_zero = BlockingSpheresParameters(
             radii=jnp.array([0.0]),
             positions=jnp.array([[0.0, 0.0, 0.0]]),
@@ -179,14 +335,16 @@ class TestBlockingSpheresEnergy:
             motif=Index.new([MotifId(0)]),
         )
         particles_z = _make_particles(jnp.array([[0.0, 0.0, 0.0]]), [0], [0])
-        edges_z = create_test_edges(particles_z, [[0, 0]])
-        inp_z = BlockingSpheresPotentialInput(
-            parameters=params_zero,
-            particles=particles_z,
-            cell=None,
-            edges=edges_z,
+        groups_z = _make_groups([0])
+        result_z = blocking_spheres_energy(
+            BlockingSpheresPotentialInput(
+                parameters=params_zero,
+                particles=particles_z,
+                groups=groups_z,
+                cell=_make_cell(1),
+                edges=create_test_edges(particles_z, [[0, 0]]),
+            )
         )
-        result_z = energy_fn(inp_z)
         assert jnp.isfinite(result_z.data.data[0])
 
         # Negative radius sphere -> never blocks
@@ -196,19 +354,18 @@ class TestBlockingSpheresEnergy:
             system=Index.new([SystemId(0)]),
             motif=Index.new([MotifId(0)]),
         )
-        particles_n = _make_particles(jnp.array([[0.0, 0.0, 0.0]]), [0], [0])
-        edges_n = create_test_edges(particles_n, [[0, 0]])
-        inp_n = BlockingSpheresPotentialInput(
-            parameters=params_neg,
-            particles=particles_n,
-            cell=None,
-            edges=edges_n,
+        result_n = blocking_spheres_energy(
+            BlockingSpheresPotentialInput(
+                parameters=params_neg,
+                particles=particles_z,
+                groups=groups_z,
+                cell=_make_cell(1),
+                edges=create_test_edges(particles_z, [[0, 0]]),
+            )
         )
-        result_n = energy_fn(inp_n)
-        assert jnp.isfinite(result_n.data.data[0])
         assert result_n.data.data[0] == 0.0
 
-        # Very large distances -> zero energy
+        # Very large distance -> zero energy
         params_far = BlockingSpheresParameters(
             radii=jnp.array([1.0]),
             positions=jnp.array([[0.0, 0.0, 0.0]]),
@@ -216,19 +373,19 @@ class TestBlockingSpheresEnergy:
             motif=Index.new([MotifId(0)]),
         )
         particles_f = _make_particles(jnp.array([[1e6, 0.0, 0.0]]), [0], [0])
-        edges_f = create_test_edges(particles_f, [[0, 0]])
-        inp_f = BlockingSpheresPotentialInput(
-            parameters=params_far,
-            particles=particles_f,
-            cell=None,
-            edges=edges_f,
+        result_f = blocking_spheres_energy(
+            BlockingSpheresPotentialInput(
+                parameters=params_far,
+                particles=particles_f,
+                groups=_make_groups([0]),
+                cell=_make_cell(1, box_size=1e9),
+                edges=create_test_edges(particles_f, [[0, 0]]),
+            )
         )
-        result_f = energy_fn(inp_f)
-        assert jnp.isfinite(result_f.data.data[0])
         assert result_f.data.data[0] == 0.0
 
     def test_jit_gradient(self):
-        """Test that gradients can be computed through JIT compiled function."""
+        """Gradients can flow through the JIT-compiled energy."""
 
         def energy_wrapper(positions):
             parameters = BlockingSpheresParameters(
@@ -238,40 +395,63 @@ class TestBlockingSpheresEnergy:
                 motif=Index.new([MotifId(0)]),
             )
             particles = _make_particles(positions, [0], [0])
-            edges = create_test_edges(particles, [[0, 0]])
             inp = BlockingSpheresPotentialInput(
                 parameters=parameters,
                 particles=particles,
-                cell=None,
-                edges=edges,
+                groups=_make_groups([0]),
+                cell=_make_cell(1),
+                edges=create_test_edges(particles, [[0, 0]]),
             )
             return blocking_spheres_energy(inp).data.data[0]
 
-        positions = jnp.array([[2.0, 0.0, 0.0]])
-        grad_fn = jax.jit(jax.grad(energy_wrapper))
-        gradient = grad_fn(positions)
+        gradient = jax.jit(jax.grad(energy_wrapper))(jnp.array([[2.0, 0.0, 0.0]]))
         assert jnp.all(jnp.isfinite(gradient))
 
     def test_multiple_batches(self):
-        """Test energy calculation with multiple batches."""
+        """Energy is summed per-system across two systems."""
         parameters = BlockingSpheresParameters(
             radii=jnp.array([1.0, 1.5]),
             positions=jnp.array([[0.0, 0.0, 0.0], [3.0, 0.0, 0.0]]),
-            system=Index.new([SystemId(i) for i in [0, 1]]),
-            motif=Index.new([MotifId(i) for i in [0, 0]]),
+            system=Index.new([SystemId(0), SystemId(1)]),
+            motif=Index.new([MotifId(0), MotifId(0)]),
         )
         particles = _make_particles(
             jnp.array([[0.5, 0.0, 0.0], [6.0, 0.0, 0.0]]),
             [0, 1],
-            [0, 0],
+            [0, 1],
         )
-        edges = create_test_edges(particles, [[0, 0], [1, 1]])
         inp = BlockingSpheresPotentialInput(
             parameters=parameters,
             particles=particles,
-            cell=None,
-            edges=edges,
+            groups=_make_groups([0, 0]),
+            cell=_make_cell(2),
+            edges=create_test_edges(particles, [[0, 0], [1, 1]]),
         )
         result = blocking_spheres_energy(inp)
         assert jnp.isinf(result.data.data[0])
         assert jnp.isfinite(result.data.data[1])
+
+
+class TestBlockingSpheresParametersFromData:
+    """Test BlockingSpheresParameters.from_data."""
+
+    def test_flattens_nested_sequence(self):
+        """Nested [system][motif][sphere] sequence flattens with correct assignments."""
+
+        @dataclass
+        class _Sphere:
+            center: tuple[float, float, float]
+            radius: float
+
+        data = [
+            [
+                [_Sphere((0.0, 0.0, 0.0), 1.0), _Sphere((1.0, 0.0, 0.0), 0.5)],
+                [_Sphere((2.0, 0.0, 0.0), 2.0)],
+            ],
+            [[_Sphere((3.0, 0.0, 0.0), 1.5)]],
+        ]
+        params = BlockingSpheresParameters.from_data(data)
+        assert params.radii.tolist() == [1.0, 0.5, 2.0, 1.5]
+        assert params.system.indices.tolist() == [0, 0, 0, 1]
+        assert params.motif.indices.tolist() == [0, 0, 1, 0]
+        assert params.positions.shape == (4, 3)


### PR DESCRIPTION
Replaced particle-level inclusion/exclusion indices with a group-based motif lookup system to simplify the blocking sphere constraint logic and improve data organization.

Furthermore, we ignore every particle that is not assigned to a group in blocking spheres.  
  
We remove the gradient computations since its always 0.

We expand tests to cover more expected behaviors.