### PR TITLE
feat: Add `Table.index` property and replace `Index.new` call sites

### DIFF
--- a/src/kups/application/mcmc/logging.py
+++ b/src/kups/application/mcmc/logging.py
@@ -140,8 +140,8 @@ def make_mcmc_logged_data[S: IsMCMCState](
     host_positions = np.where(is_host)[0]
     ads_positions = np.where(~is_host)[0]
 
-    host_idx = Index(particles.keys, jnp.asarray(host_positions))
-    ads_idx = Index(particles.keys, jnp.asarray(ads_positions))
+    host_idx = particles.index[host_positions]
+    ads_idx = particles.index[ads_positions]
     host_keys = tuple(particles.keys[int(i)] for i in host_positions)
     ads_keys = tuple(particles.keys[int(i)] for i in ads_positions)
 

--- a/src/kups/application/md/simulation.py
+++ b/src/kups/application/md/simulation.py
@@ -15,7 +15,6 @@ from kups.application.md.logging import MDLoggedData
 from kups.application.utils.propagate import run_simulation_cycles, run_warmup_cycles
 from kups.core.cell import Cell
 from kups.core.data import Table
-from kups.core.data.index import Index
 from kups.core.lens import Lens, lens
 from kups.core.logging import CompositeLogger, TqdmLogger
 from kups.core.potential import (
@@ -103,8 +102,8 @@ def make_md_propagator[State: IsMdState, Grad: IsMdGradients](
                 )
             ),
             lambda x: PotentialOut(
-                Index.new(x.systems.keys),  # type: ignore
-                (x.particles.data.system, Index.new(x.systems.keys)),
+                x.systems.index,  # type: ignore
+                (x.particles.data.system, x.systems.index),
                 EMPTY,
             ),  # type: ignore
         )

--- a/src/kups/application/relaxation/simulation.py
+++ b/src/kups/application/relaxation/simulation.py
@@ -18,7 +18,6 @@ from kups.application.relaxation.logging import RelaxLoggedData
 from kups.application.utils.propagate import run_simulation_cycles
 from kups.core.cell import Cell
 from kups.core.data import Table
-from kups.core.data.index import Index
 from kups.core.lens import Lens, View, lens
 from kups.core.logging import CompositeLogger, TqdmLogger
 from kups.core.potential import (
@@ -102,8 +101,8 @@ def make_relax_propagator[State: IsRelaxState, Gradients: IsRelaxGradients](
             )
         ),
         lambda x: PotentialOut(
-            Index.new(x.systems.keys),  # type: ignore
-            (x.particles.data.system, Index.new(x.systems.keys)),
+            x.systems.index,  # type: ignore
+            (x.particles.data.system, x.systems.index),
             EMPTY,
         ),  # type: ignore
     )

--- a/src/kups/core/data/table.py
+++ b/src/kups/core/data/table.py
@@ -156,6 +156,11 @@ class Table(Batched, Generic[TKey, TData]):
         index = tuple(map(label, range(n_items)))
         return Table(index, data, _cls=label)
 
+    @property
+    def index(self) -> Index[TKey]:
+        """Return the primary keys as an ``Index``."""
+        return Index(self.keys, jnp.arange(len(self.keys)), max_count=1, _cls=self.cls)
+
     def at[L: SupportsSorting, D](
         self: Table[L, D], index: Index[L], *, args: ScatterArgs | None = None
     ) -> BoundLens[D, D]:
@@ -349,8 +354,7 @@ class Table(Batched, Generic[TKey, TData]):
                     f"Key set mismatch at argument {i + 1}: "
                     f"expected {set(base.keys)}, got {set(other.keys)}"
                 )
-            idx = Index.new(list(base.keys))
-            return other[idx]
+            return other[base.index]
 
         aligned = [_align(o, i) for i, o in enumerate(others)]
         return Table(base.keys, (base.data, *aligned), _cls=base._cls)

--- a/src/kups/mcmc/moves.py
+++ b/src/kups/mcmc/moves.py
@@ -234,7 +234,7 @@ def propose_group_translation(
     selected = random_select_groups(next(chain), groups, particles, capacity)
     selected_data = particles[selected]
     selected_particles = Table.arange(selected_data, label=ParticleId)
-    sys_idx = Index.new(systems.keys)
+    sys_idx = systems.index
     width = step_width[sys_idx]
     translations = Table(
         systems.keys,
@@ -254,7 +254,7 @@ def propose_group_rotation(
 ) -> ParticlePositionChanges:
     """Propose a random rigid-body rotation of one group per system."""
     chain = key_chain(key)
-    sys_idx = Index.new(systems.keys)
+    sys_idx = systems.index
     width = step_width[sys_idx]
     selected = random_select_groups(next(chain), groups, particles, capacity)
     selected_data = particles[selected]
@@ -308,7 +308,7 @@ def propose_particle_translation(
     random_ints = jax.random.bits(next(chain), shape=(n_sys,), dtype=jnp.uint32)
     raw_particle_ids = particles.data.system.select_per_label(random_ints)
     particle_ids = Index(particles.keys, raw_particle_ids)
-    sys_idx = Index.new(systems.keys)
+    sys_idx = systems.index
     width = step_width[sys_idx]
     translation = (
         distribution(

--- a/src/kups/mcmc/probability.py
+++ b/src/kups/mcmc/probability.py
@@ -30,7 +30,6 @@ from jax import Array
 
 from kups.core.constants import BOLTZMANN_CONSTANT
 from kups.core.data import Table
-from kups.core.data.index import Index
 from kups.core.lens import Lens, View
 from kups.core.patch import ComposedPatch, IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
@@ -323,7 +322,7 @@ def make_boltzmann_probability_ratio[State, Move: Patch](
                 x.systems.map_data(lambda x: x.potential_energy), EMPTY, EMPTY
             )
         ),
-        state.focus(lambda x: PotentialOut(Index.new(x.systems.keys), EMPTY, EMPTY)),  # type: ignore
+        state.focus(lambda x: PotentialOut(x.systems.index, EMPTY, EMPTY)),  # type: ignore
     )
     return potential, BoltzmannLogProbabilityRatio(
         state.focus(lambda x: x.systems.map_data(lambda s: s.temperature)),

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -263,7 +263,7 @@ class EwaldLongRangeInput[State]:
 
     @property
     def kvecs(self) -> Array:
-        sys_idx = Index.new(list(self.point_cloud.systems.keys))
+        sys_idx = self.point_cloud.systems.index
         return triangular_3x3_matmul(
             self.point_cloud.systems.data.cell.inverse_vectors.mT[:, None] * 2 * jnp.pi,
             self.parameters.reciprocal_lattice_shifts[sys_idx],
@@ -284,7 +284,7 @@ def ewald_self_interaction_energy(
     Summed per system via segment_sum. Positions in Ang, charges in e,
     energy in eV.
     """
-    sys_idx = Index.new(list(inp.graph.systems.keys))
+    sys_idx = inp.graph.systems.index
     energies = (
         -jax.ops.segment_sum(
             inp.graph.particles.data.charges**2,
@@ -368,7 +368,7 @@ def prefactor(inp: EwaldLongRangeInput) -> Array:
     Returns:
         Prefactor array, shape ``(batch_size, n_kvecs)``.
     """
-    sys_idx = Index.new(inp.point_cloud.systems.keys)
+    sys_idx = inp.point_cloud.systems.index
     alpha = inp.parameters.alpha[sys_idx]
     rls = inp.parameters.reciprocal_lattice_shifts[sys_idx]
     kv = inp.kvecs
@@ -572,7 +572,7 @@ def structure_factor[State](
             inp.changes_from_prev,
         )
     patch = (
-        EwaldCachePatch(sk, Index.new(inp.point_cloud.systems.keys), inp.cache_lens)
+        EwaldCachePatch(sk, inp.point_cloud.systems.index, inp.cache_lens)
         if inp.cache_lens is not None
         else IdPatch()
     )

--- a/src/kups/potential/common/energy.py
+++ b/src/kups/potential/common/energy.py
@@ -25,7 +25,7 @@ import jax.numpy as jnp
 from jax import Array
 
 from kups.core.cell import Cell
-from kups.core.data import Index, Table
+from kups.core.data import Table
 from kups.core.lens import Lens, View
 from kups.core.patch import ComposedPatch, IdPatch, IndexLensPatch, Patch, WithPatch
 from kups.core.potential import (
@@ -65,7 +65,7 @@ def position_and_cell_idx_view(
 ) -> PotentialOut[PositionAndCell, EmptyType]:
     return PotentialOut(
         empty_patch_idx_view(state).total_energies,
-        PositionAndCell(state.particles.data.system, Index.new(state.systems.keys)),
+        PositionAndCell(state.particles.data.system, state.systems.index),
         EMPTY,
     )
 

--- a/test/core/test_propagator.py
+++ b/test/core/test_propagator.py
@@ -10,7 +10,6 @@ import pytest
 from jax import Array
 
 from kups.core.assertion import runtime_assert
-from kups.core.data.index import Index
 from kups.core.data.table import Table
 from kups.core.lens import SimpleLens, bind, view
 from kups.core.parameter_scheduler import (
@@ -84,7 +83,7 @@ class ArrayPatch:
 
     def __call__(self, state: ExampleState, accept: Accept) -> ExampleState:
         # Apply increment only where accept is True
-        sys_idx = Index.new(list(accept.keys))
+        sys_idx = accept.index
         new_value = jnp.where(
             accept[sys_idx][0], state.array_data + self.increment, state.array_data
         )
@@ -100,7 +99,7 @@ class ExamplePatch:
 
     def __call__(self, state: ExampleState, accept: Accept) -> ExampleState:
         # Apply increment only where accept is True
-        sys_idx = Index.new(list(accept.keys))
+        sys_idx = accept.index
         new_value = jnp.where(
             accept[sys_idx][0], state.value + self.increment, state.value
         )

--- a/test/core/test_table.py
+++ b/test/core/test_table.py
@@ -100,6 +100,32 @@ class TestUtilities:
         npt.assert_array_equal(new.data, [10.0, 20.0])
 
 
+class TestIndex:
+    def test_index_property(self):
+        # String keys: returns Index with arange indices and max_count=1
+        t = Table(("a", "b", "c"), jnp.array([10.0, 20.0, 30.0]))
+        idx = t.index
+        assert idx.keys == ("a", "b", "c")
+        assert idx.max_count == 1
+        assert idx.cls is str
+        npt.assert_array_equal(idx.indices, jnp.arange(3))
+
+        # Integer-typed keys preserve cls via _cls
+        ti = Table.arange(jnp.array([1.0, 2.0, 3.0]), label=ParticleId)
+        assert ti.index.cls is ParticleId
+        assert ti.index.keys == ti.keys
+
+        # Round-trip: indexing self by self.index returns the original data
+        npt.assert_array_equal(t[t.index], t.data)
+
+        # Empty table with explicit _cls
+        empty = Table((), jnp.zeros(0), _cls=str)
+        empty_idx = empty.index
+        assert empty_idx.keys == ()
+        assert empty_idx.cls is str
+        assert empty_idx.indices.shape == (0,)
+
+
 class TestAt:
     def test_get_and_set(self):
         data = jnp.array([1.0, 2.0, 3.0])

--- a/test/potential/test_internal.py
+++ b/test/potential/test_internal.py
@@ -168,7 +168,7 @@ class TestInternalEnergies:
         @dataclass
         class AssertionPatch:
             def __call__(self, state: MockState, accept: Accept) -> MockState:
-                sys_idx = Index.new(accept.keys)
+                sys_idx = accept.index
                 runtime_assert(
                     predicate=jnp.array(True),
                     message="Test assertion from patch",

--- a/test/potential/test_local_mliap.py
+++ b/test/potential/test_local_mliap.py
@@ -84,7 +84,7 @@ class AtomPatch(Patch[State]):
 
     def __call__(self, state: State, accept: Accept) -> State:
         prev_positions = state.atoms.data.positions[self.indices]
-        mask = accept[Index.new(list(accept.keys))]
+        mask = accept[accept.index]
         new_pos = jnp.where(mask, self.new_positions, prev_positions)
         return (
             bind(state)


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Add `Table.index` property that returns an `Index` of the table's primary keys, replacing scattered `Index.new()` call sites throughout the codebase for cleaner, more consistent API usage.