### PR TITLE
ci: fix t4 github runner labels

### DIFF
--- a/.github/workflows/statistical.yaml
+++ b/.github/workflows/statistical.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate:
-    runs-on: nvidia-t4-runners
+    runs-on: t4-gpu-github
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Updates the label to use the new GitHub t4 runners for the Statistical Validation workflow