### PR TITLE
chore: Bump pyright to 1.1.409 and inline sdist includes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,12 +84,7 @@ build-backend = "hatchling.build"
 packages = ["src/kups"]
 
 [tool.hatch.build.targets.sdist]
-include = [
-    "/src",
-    "/LICENSE",
-    "/README.md",
-    "/pyproject.toml",
-]
+include = ["/src", "/LICENSE", "/README.md", "/pyproject.toml"]
 
 [dependency-groups]
 cuda = ["jax[cuda]>=0.7.2; sys_platform == 'linux'"]
@@ -117,7 +112,7 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest-cov>=6.2.1",
     "pytest-testmon>=2.1.3",
-    "pyright>=1.1.408",
+    "pyright>=1.1.409",
 ]
 hf = ["huggingface-hub>=1.11.0"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1608,7 +1608,7 @@ provides-extras = ["cuda", "hf"]
 cuda = [{ name = "jax", extras = ["cuda"], marker = "sys_platform == 'linux'", specifier = ">=0.7.2" }]
 dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pyright", specifier = ">=1.1.408" },
+    { name = "pyright", specifier = ">=1.1.409" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-env", specifier = ">=1.1.5" },
@@ -2783,15 +2783,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.408"
+version = "1.1.409"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Bumps pyright from 1.1.408 to 1.1.409 and inlines the sdist includes list in pyproject.toml for better readability.