### PR TITLE
refactor: Adopt optax force convention in FIRE/FIRE2 transforms

### DIFF
--- a/src/kups/relaxation/transforms/fire.py
+++ b/src/kups/relaxation/transforms/fire.py
@@ -11,6 +11,33 @@ adaptive ``dt`` / ``alpha`` / ``n_pos`` state is stored as a
 ``Table[K, Array]`` — one entry per system. Running batched independent
 systems through this transform is bit-identical to running them one at a
 time.
+
+API convention
+--------------
+Following the optax composability pattern, the ``updates`` argument to
+:meth:`ScaleByFire.update` is the *descent direction* (force
+``F = -∇L``), not the raw gradient. The transform integrates ``updates``
+directly as a force and emits a position step ``Δx`` such that
+``apply_updates(x, Δx) = x + Δx`` descends.
+
+If your upstream produces a raw gradient ``∇L``, prepend a sign-flip in
+the chain. Any per-system clipping (force cap or per-particle step cap)
+composes the same way:
+
+.. code-block:: python
+
+    from kups.relaxation.optimizer import chain
+    from kups.relaxation.transforms import (
+        ClipByGlobalNorm, MaxStepSize, ScaleByFire,
+    )
+    import optax
+
+    optimizer = chain(
+        optax.scale(-1.0),                 # ∇L  →  F = -∇L
+        ScaleByFire(dt_start=0.1),
+        ClipByGlobalNorm(max_norm=10.0),   # per-system L2 force cap
+        MaxStepSize(max_step_size=0.1),    # per-particle Δx cap
+    )
 """
 
 from __future__ import annotations
@@ -63,6 +90,12 @@ class ScaleByFire[Params](Optimizer[Params, ScaleByFireState]):
     ``dt`` / ``alpha`` / ``n_pos`` and sees its own per-system power and
     norms.
 
+    The transform follows the optax convention: ``updates`` passed to
+    :meth:`update` is interpreted as the force ``F = -∇L`` (the descent
+    direction). Sign conversion from a raw gradient and any clipping live
+    in the surrounding :func:`kups.relaxation.optimizer.chain` — see the
+    module docstring for a worked example.
+
     .. note::
 
         This is the original FIRE 1.0. For most production relaxations
@@ -77,10 +110,12 @@ class ScaleByFire[Params](Optimizer[Params, ScaleByFireState]):
         run is known to be stable. FIRE 1.0 remains useful as a
         well-tested baseline and for comparison with legacy results.
 
-    For step-size clipping, compose this transform with
-    :class:`kups.relaxation.transforms.ClipByGlobalNorm` (per-system L2
-    cap) or :class:`kups.relaxation.transforms.MaxStepSize` (per-particle
-    cap) via :func:`kups.relaxation.optimizer.chain`.
+    Composable clipping:
+
+    * :class:`kups.relaxation.transforms.ClipByGlobalNorm` — per-system
+      L2 cap on the input force (prepend before FIRE).
+    * :class:`kups.relaxation.transforms.MaxStepSize` — per-particle
+      ∞/L2 cap on the output displacement (append after FIRE).
 
     Attributes:
         dt_start: Initial timestep.
@@ -139,23 +174,21 @@ class ScaleByFire[Params](Optimizer[Params, ScaleByFireState]):
         del params, kwargs
         idx = state.index_prefix
 
-        # F = -gradient (FIRE uses forces, pointing downhill).
-        forces = jax.tree.map(jnp.negative, updates)
-
-        # v <- v + dt[s] · F   (per-system dt broadcast back per particle).
+        # ``updates`` IS the force F = -∇L (optax convention); see module
+        # docstring. v <- v + dt[s] · F (per-system dt broadcast per particle).
         velocity = jax.tree.map(
             lambda v, sf: v + sf,
             state.velocity,
-            tree_scale_per_row(forces, state.dt, idx),
+            tree_scale_per_row(updates, state.dt, idx),
         )
 
         # Per-system power P = F · v and its sign.
-        power = tree_vdot(forces, velocity, idx)
+        power = tree_vdot(updates, velocity, idx)
         positive = power.data > 0.0
 
         # Per-system L2 norms; safe denominator for ||F||.
         v_norm = tree_segment_norm(velocity, idx)
-        f_norm = tree_segment_norm(forces, idx)
+        f_norm = tree_segment_norm(updates, idx)
         safe_f_norm = jnp.maximum(f_norm.data, 1e-10)
 
         # Mixed velocity per particle: v' = (1-α)·v + α·||v||/||F|| · F.
@@ -164,7 +197,7 @@ class ScaleByFire[Params](Optimizer[Params, ScaleByFireState]):
         mixed_velocity = jax.tree.map(
             lambda a, b: a + b,
             tree_scale_per_row(velocity, v_scale, idx),
-            tree_scale_per_row(forces, f_scale, idx),
+            tree_scale_per_row(updates, f_scale, idx),
         )
 
         # Adaptive dt / alpha / n_pos updates per system.

--- a/src/kups/relaxation/transforms/fire2.py
+++ b/src/kups/relaxation/transforms/fire2.py
@@ -12,10 +12,33 @@ adaptive ``dt`` / ``alpha`` / ``n_pos`` state is stored as a
 systems through this transform is bit-identical to running them one at a
 time.
 
-For step-size clipping outside the LAMMPS-style ``dmax`` (which is built
-in), compose with :class:`kups.relaxation.transforms.ClipByGlobalNorm`
-(per-system L2) or :class:`kups.relaxation.transforms.MaxStepSize`
-(per-particle L2) via :func:`kups.relaxation.optimizer.chain`.
+API convention
+--------------
+Following the optax composability pattern, the ``updates`` argument to
+:meth:`ScaleByFire2.update` is the *descent direction* (force
+``F = -∇L``), not the raw gradient. The transform integrates ``updates``
+as a force and emits a position step ``Δx`` such that
+``apply_updates(x, Δx) = x + Δx`` descends.
+
+Convert a raw gradient with a sign-flip transform at the head of the
+chain. Per-system L2 clipping on the input force and per-particle Δx
+clipping on the output both compose around FIRE 2.0 — the built-in
+LAMMPS ``dmax`` (``max_step``) is independent of these:
+
+.. code-block:: python
+
+    from kups.relaxation.optimizer import chain
+    from kups.relaxation.transforms import (
+        ClipByGlobalNorm, MaxStepSize, ScaleByFire2,
+    )
+    import optax
+
+    optimizer = chain(
+        optax.scale(-1.0),                  # ∇L  →  F = -∇L
+        ScaleByFire2(dt_start=0.1),         # built-in dmax also active
+        ClipByGlobalNorm(max_norm=10.0),    # per-system L2 force cap
+        MaxStepSize(max_step_size=0.05),    # extra per-particle Δx cap
+    )
 """
 
 from __future__ import annotations
@@ -76,6 +99,15 @@ class ScaleByFire2[Params](Optimizer[Params, ScaleByFire2State]):
     ``kups.relaxation.optax.scale_by_fire2``; with multiple systems each
     system independently adapts its own ``dt`` / ``alpha`` / ``n_pos``
     and sees its own per-system power, norms and ``dmax``.
+
+    The transform follows the optax convention: ``updates`` passed to
+    :meth:`update` is interpreted as the force ``F = -∇L`` (the descent
+    direction). Sign conversion from a raw gradient and any external
+    clipping live in the surrounding
+    :func:`kups.relaxation.optimizer.chain` — see the module docstring
+    for a worked example. The LAMMPS-style ``dmax`` clip configured via
+    :attr:`max_step` is internal to FIRE 2.0 and applies on top of any
+    composed clipping.
 
     Attributes:
         dt_start: Initial timestep.
@@ -152,12 +184,11 @@ class ScaleByFire2[Params](Optimizer[Params, ScaleByFire2State]):
         dt_data = state.dt.data
         alpha_data = state.alpha.data
         float_dtype = dt_data.dtype
-
-        forces = jax.tree.map(lambda g: -g, updates)
         n_total = state.n_total + 1
 
-        # ----- P = v_old · F per system (LAMMPS: vdotfall) ----------------
-        power = tree_vdot(forces, state.velocity, idx).data
+        # ``updates`` IS the force F = -∇L (optax convention); see module
+        # docstring. P = v_old · F per system (LAMMPS: vdotfall).
+        power = tree_vdot(updates, state.velocity, idx).data
         positive = power > 0.0
 
         # ----- n_pos (LAMMPS: ntimestep - last_negative) ------------------
@@ -199,7 +230,7 @@ class ScaleByFire2[Params](Optimizer[Params, ScaleByFire2State]):
 
         # ----- Mixing scales (use OLD velocity, per system) --------------
         v_old_sq = tree_vdot(state.velocity, state.velocity, idx).data
-        f_sq = tree_vdot(forces, forces, idx).data
+        f_sq = tree_vdot(updates, updates, idx).data
 
         if self.use_abc:
             abc = jnp.where(
@@ -227,7 +258,7 @@ class ScaleByFire2[Params](Optimizer[Params, ScaleByFire2State]):
         # ----- dmax: compute dtv (non-ABC only) per system ----------------
         if self.max_step is not None and not self.use_abc:
             abs_v = jax.tree.map(jnp.abs, state.velocity)
-            abs_f = jax.tree.map(jnp.abs, forces)
+            abs_f = jax.tree.map(jnp.abs, updates)
             vmax_pos = tree_segment_max(abs_v, idx).data
             vmax_neg = new_dt * tree_segment_max(abs_f, idx).data
             vmax = jnp.where(positive, vmax_pos, vmax_neg)
@@ -252,14 +283,14 @@ class ScaleByFire2[Params](Optimizer[Params, ScaleByFire2State]):
         v_pre = tree_scale_per_row(state.velocity, gate, idx)
 
         # ----- Euler-implicit kick: v += dtv · F --------------------------
-        scaled_f = tree_scale_per_row(forces, Table(keys, dtv), idx)
+        scaled_f = tree_scale_per_row(updates, Table(keys, dtv), idx)
         v_int = jax.tree.map(jnp.add, v_pre, scaled_f)
 
         # ----- Mixing (applied only when P > 0): v = s1·v + s2·F ----------
         v_mixed = jax.tree.map(
             jnp.add,
             tree_scale_per_row(v_int, Table(keys, scale1), idx),
-            tree_scale_per_row(forces, Table(keys, scale2), idx),
+            tree_scale_per_row(updates, Table(keys, scale2), idx),
         )
         new_velocity = tree_where_per_row(Table(keys, positive), v_mixed, v_int, idx)
 

--- a/test/relaxation/transforms/test_fire.py
+++ b/test/relaxation/transforms/test_fire.py
@@ -1,14 +1,22 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the per-system FIRE transform."""
+"""Tests for the per-system FIRE transform.
+
+``ScaleByFire`` takes ``updates`` as the force ``F = -∇L`` (the descent
+direction), matching the optax composability convention. Tests therefore
+pass ``-grad`` (or pre-flipped forces) into :meth:`update`.
+"""
 
 import jax.numpy as jnp
 import numpy.testing as npt
 import optax
 
 from kups.core.data.index import Index
+from kups.core.data.table import Table
 from kups.core.typing import SystemId
+from kups.relaxation.optimizer import chain
+from kups.relaxation.transforms.clip_by_global_norm import ClipByGlobalNorm
 from kups.relaxation.transforms.fire import ScaleByFire, ScaleByFireState
 
 from ...clear_cache import clear_cache  # noqa: F401
@@ -38,12 +46,13 @@ class TestScaleByFireGlobalFallback:
         npt.assert_array_equal(state.velocity["b"], jnp.zeros((1, 3, 3)))
 
     def test_convergence_on_quadratic(self):
+        # L(x) = 0.5·x²  ⇒  ∇L = x, force F = -x.
         new = ScaleByFire(dt_start=0.05, dt_max=0.5)
         x = jnp.array([5.0])
         state = new.init(x)
         for _ in range(100):
-            upd, state = new.update(x, state, x)
-            x = optax.apply_updates(x, upd)
+            upd, state = new.update(-x, state, x)
+            x = jnp.asarray(optax.apply_updates(x, upd))
         npt.assert_allclose(x, jnp.zeros(1), atol=1e-2)
 
 
@@ -56,9 +65,9 @@ class TestScaleByFirePerSystem:
             state = opt.init(x0)
             x = x0
             for _ in range(8):
-                upd, state = opt.update(x, state, x)
-                x = optax.apply_updates(x, upd)
-            return jnp.asarray(x)
+                upd, state = opt.update(-x, state, x)
+                x = jnp.asarray(optax.apply_updates(x, upd))
+            return x
 
         x_a = jnp.array([5.0, -3.0])
         x_b = jnp.array([0.5, 0.2])
@@ -70,25 +79,23 @@ class TestScaleByFirePerSystem:
         state = opt.init(batched, index_prefix=idx)
         x = batched
         for _ in range(8):
-            upd, state = opt.update(x, state, x)
-            x = optax.apply_updates(x, upd)
+            upd, state = opt.update(-x, state, x)
+            x = jnp.asarray(optax.apply_updates(x, upd))
 
         npt.assert_allclose(x, sep, atol=1e-6)
 
     def test_dt_evolves_per_system(self):
         """One system makes progress (dt grows), the other oscillates (dt shrinks)."""
         opt = ScaleByFire(dt_start=0.1, n_min=2, f_inc=1.5, f_dec=0.5)
-        # System 0: positive-power oscillator-friendly start.
-        # System 1: gradient flipped each step → power goes negative.
         idx = _system_index([0, 1], 2)
         x = jnp.array([1.0, 1.0])
         state = opt.init(x, index_prefix=idx)
 
-        # Drive system 0 with consistently negative gradient (downhill);
-        # drive system 1 with alternating gradient sign.
+        # System 0: constant force → P>0 each step → dt grows.
+        # System 1: force flips sign each step → P<0 → dt shrinks.
         for step in range(6):
-            grad = jnp.array([-1.0, 1.0 if step % 2 == 0 else -1.0])
-            _, state = opt.update(grad, state, x)
+            force = jnp.array([1.0, -1.0 if step % 2 == 0 else 1.0])
+            _, state = opt.update(force, state, x)
 
         assert float(state.dt.data[0]) > 0.1  # system 0 grew
         assert float(state.dt.data[1]) < 0.1  # system 1 shrank
@@ -100,8 +107,6 @@ class TestScaleByFirePerSystem:
 
         # Hand-construct a state with non-zero velocity for both systems.
         keys = (SystemId(0), SystemId(1))
-        from kups.core.data.table import Table
-
         state = ScaleByFireState(
             velocity=jnp.array([[1.0], [1.0], [1.0], [1.0]]),
             dt=Table(keys, jnp.array([0.1, 0.1])),
@@ -110,13 +115,54 @@ class TestScaleByFirePerSystem:
             index_prefix=idx,
         )
 
-        # Gradient pointing AGAINST current velocity for system 0
+        # Force pointing AGAINST current velocity for system 0
         # (so v · F < 0 → P < 0 → reset). Aligned for system 1.
-        grad = jnp.array([[1.0], [1.0], [-1.0], [-1.0]])
+        force = jnp.array([[-1.0], [-1.0], [1.0], [1.0]])
         opt = ScaleByFire(dt_start=0.1)
-        _, new_state = opt.update(grad, state, params)
+        _, new_state = opt.update(force, state, params)
 
         npt.assert_allclose(new_state.velocity[0:2], jnp.zeros((2, 1)), atol=1e-6)
         assert float(jnp.linalg.norm(new_state.velocity[2:4])) > 0.0
         assert int(new_state.n_pos.data[0]) == 0  # system 0 reset
         assert int(new_state.n_pos.data[1]) == 4  # system 1 incremented
+
+
+class TestScaleByFireComposability:
+    """``ScaleByFire`` should compose cleanly with other optax/kups transforms."""
+
+    def test_chain_with_sign_flip_matches_force_input(self):
+        """``chain(optax.scale(-1), ScaleByFire())`` accepts ∇L and gives the
+        same trajectory as passing ``-∇L`` directly to a bare ``ScaleByFire``."""
+        x0 = jnp.array([5.0])
+
+        direct = ScaleByFire(dt_start=0.05, dt_max=0.5)
+        composed = chain(optax.scale(-1.0), ScaleByFire(dt_start=0.05, dt_max=0.5))
+
+        x_direct = x0
+        s_direct = direct.init(x_direct)
+        x_composed = x0
+        s_composed = composed.init(x_composed)
+
+        for _ in range(20):
+            # Quadratic: ∇L = x, force = -x.
+            upd_d, s_direct = direct.update(-x_direct, s_direct, x_direct)
+            x_direct = jnp.asarray(optax.apply_updates(x_direct, upd_d))
+            upd_c, s_composed = composed.update(x_composed, s_composed, x_composed)
+            x_composed = jnp.asarray(optax.apply_updates(x_composed, upd_c))
+
+        npt.assert_allclose(x_composed, x_direct, atol=1e-6)
+
+    def test_chain_with_clip_caps_input_force(self):
+        """Prepending ``ClipByGlobalNorm`` clips the force seen by FIRE."""
+        idx = _system_index([0, 0], 1)
+        x = jnp.array([10.0, 0.0])
+
+        dt = 0.1
+        max_norm = 1.0
+        opt = chain(ClipByGlobalNorm(max_norm=max_norm), ScaleByFire(dt_start=dt))
+        state = opt.init(x, index_prefix=idx)
+
+        # Huge unclipped force: ||F||=100. After clip ||F̂||=max_norm.
+        # First step from v=0 yields Δx = dt² · F̂, so |Δx|∞ ≤ dt² · max_norm.
+        upd, _ = opt.update(jnp.array([100.0, 0.0]), state, x)
+        assert float(jnp.max(jnp.abs(upd))) <= dt * dt * max_norm + 1e-6

--- a/test/relaxation/transforms/test_fire2.py
+++ b/test/relaxation/transforms/test_fire2.py
@@ -1,7 +1,12 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the per-system FIRE 2.0 / ABC-FIRE transform."""
+"""Tests for the per-system FIRE 2.0 / ABC-FIRE transform.
+
+``ScaleByFire2`` takes ``updates`` as the force ``F = -∇L`` (the descent
+direction), matching the optax composability convention. Tests therefore
+pass ``-grad`` (or pre-flipped forces) into :meth:`update`.
+"""
 
 import jax.numpy as jnp
 import numpy.testing as npt
@@ -10,7 +15,10 @@ import optax
 from kups.core.data.index import Index
 from kups.core.data.table import Table
 from kups.core.typing import SystemId
+from kups.relaxation.optimizer import chain
+from kups.relaxation.transforms.clip_by_global_norm import ClipByGlobalNorm
 from kups.relaxation.transforms.fire2 import ScaleByFire2, ScaleByFire2State
+from kups.relaxation.transforms.max_step_size import MaxStepSize
 
 from ...clear_cache import clear_cache  # noqa: F401
 
@@ -65,18 +73,18 @@ class TestScaleByFire2GlobalFallback:
         opt = ScaleByFire2(dt_start=0.1, n_min=2)
         params = jnp.array([1.0])
         state = opt.init(params)
-        gradient = jnp.array([-1.0])
+        force = jnp.array([1.0])  # F = -∇L for ∇L = -1.0
         for i in range(4):
-            _, state = opt.update(gradient, state, params)
+            _, state = opt.update(force, state, params)
             assert int(state.n_total) == i + 1
 
     def test_positive_power_increases_n_pos(self):
         opt = ScaleByFire2(dt_start=0.1, n_min=2, delaystep_start=False)
         params = jnp.array([1.0])
         state = opt.init(params)
-        gradient = jnp.array([-1.0])
+        force = jnp.array([1.0])
         for _ in range(4):
-            _, state = opt.update(gradient, state, params)
+            _, state = opt.update(force, state, params)
         assert int(state.n_pos.data[0]) > 0
 
     def test_dt_increases_after_n_min_positive_steps(self):
@@ -91,9 +99,9 @@ class TestScaleByFire2GlobalFallback:
         params = jnp.array([1.0])
         state = opt.init(params)
         initial_dt = float(state.dt.data[0])
-        gradient = jnp.array([-1.0])
+        force = jnp.array([1.0])
         for _ in range(6):
-            _, state = opt.update(gradient, state, params)
+            _, state = opt.update(force, state, params)
         assert float(state.dt.data[0]) > initial_dt
 
     def test_dt_decreases_on_negative_power(self):
@@ -102,8 +110,8 @@ class TestScaleByFire2GlobalFallback:
             velocity=jnp.array([1.0]), dt=0.1, n_pos=5, n_total=10
         )
         params = jnp.array([1.0])
-        gradient = jnp.array([1.0])  # F=-1, v=+1 → P=-1
-        _, new_state = opt.update(gradient, state, params)
+        force = jnp.array([-1.0])  # F=-1, v=+1 → P=-1
+        _, new_state = opt.update(force, state, params)
         npt.assert_allclose(float(new_state.dt.data[0]), 0.05)
 
     def test_dt_bounded_by_dt_min(self):
@@ -112,9 +120,9 @@ class TestScaleByFire2GlobalFallback:
         state = _single_sys_state(
             velocity=jnp.array([1.0]), dt=0.02, n_pos=0, n_total=10
         )
-        gradient = jnp.array([1.0])
+        force = jnp.array([-1.0])
         for _ in range(10):
-            _, state = opt.update(gradient, state, params)
+            _, state = opt.update(force, state, params)
             # Re-inject opposing velocity to keep P<=0.
             state = _single_sys_state(
                 velocity=jnp.array([1.0]),
@@ -134,9 +142,9 @@ class TestScaleByFire2GlobalFallback:
         )
         v_old = jnp.array([2.0])
         state = _single_sys_state(velocity=v_old, dt=0.1, n_pos=0, n_total=10)
-        gradient = jnp.array([1.0])  # F=-1, v=+2 → P=-2
+        force = jnp.array([-1.0])  # F=-1, v=+2 → P=-2
         params = jnp.array([0.0])
-        updates, new_state = opt.update(gradient, state, params)
+        updates, new_state = opt.update(force, state, params)
         # On P<=0: v_pre=0, v_int = dtv*F; new_velocity is v_int. Δx = new_dt*v_int + backtrack.
         new_dt = float(new_state.dt.data[0])
         v_int = new_dt * (-1.0)
@@ -146,19 +154,19 @@ class TestScaleByFire2GlobalFallback:
 
     def test_halfstepback_disabled(self):
         v_old = jnp.array([2.0])
-        gradient = jnp.array([1.0])
+        force = jnp.array([-1.0])
         params = jnp.array([0.0])
         u_with, s_with = ScaleByFire2(
             dt_start=0.1, max_step=None, halfstepback=True, delaystep_start=False
         ).update(
-            gradient,
+            force,
             _single_sys_state(velocity=v_old, dt=0.1, n_pos=0, n_total=10),
             params,
         )
         u_without, _ = ScaleByFire2(
             dt_start=0.1, max_step=None, halfstepback=False, delaystep_start=False
         ).update(
-            gradient,
+            force,
             _single_sys_state(velocity=v_old, dt=0.1, n_pos=0, n_total=10),
             params,
         )
@@ -176,8 +184,8 @@ class TestScaleByFire2GlobalFallback:
         )
         params = jnp.array([1.0])
         state = opt.init(params)
-        gradient = jnp.array([-1.0])
-        _, new_state = opt.update(gradient, state, params)
+        force = jnp.array([1.0])
+        _, new_state = opt.update(force, state, params)
         npt.assert_allclose(float(new_state.dt.data[0]), 0.1)
         npt.assert_allclose(float(new_state.alpha.data[0]), 0.25)
 
@@ -191,8 +199,8 @@ class TestScaleByFire2GlobalFallback:
         )
         params = jnp.array([1.0])
         state = opt.init(params)
-        gradient = jnp.array([-1.0])
-        _, new_state = opt.update(gradient, state, params)
+        force = jnp.array([1.0])
+        _, new_state = opt.update(force, state, params)
         npt.assert_allclose(float(new_state.dt.data[0]), 0.05)
 
     def test_negative_power_resets_velocity_and_alpha(self):
@@ -212,8 +220,8 @@ class TestScaleByFire2GlobalFallback:
             n_total=20,
         )
         params = jnp.array([1.0])
-        gradient = jnp.array([1.0])  # P = -5 < 0
-        _, new_state = opt.update(gradient, state, params)
+        force = jnp.array([-1.0])  # P = v·F = 5·(-1) = -5 < 0
+        _, new_state = opt.update(force, state, params)
         assert int(new_state.n_pos.data[0]) == 0
         npt.assert_allclose(float(new_state.alpha.data[0]), alpha_start)
         # v_pre=0, v_int = dtv*F; new_velocity = v_int (no mixing on P<=0).
@@ -225,7 +233,7 @@ class TestScaleByFire2GlobalFallback:
 
     def test_abc_differs_from_non_abc_at_small_n(self):
         v_old = jnp.array([1.0, 0.5])
-        gradient = jnp.array([-1.0, -0.5])  # F · v > 0
+        force = jnp.array([1.0, 0.5])  # F · v > 0
         params = jnp.array([1.0, 0.0])
 
         def run(use_abc: bool) -> ScaleByFire2State:
@@ -247,7 +255,7 @@ class TestScaleByFire2GlobalFallback:
                 max_step=None,
                 delaystep_start=False,
                 use_abc=use_abc,
-            ).update(gradient, state, params)
+            ).update(force, state, params)
             return s
 
         s_plain = run(False)
@@ -283,8 +291,8 @@ class TestScaleByFire2GlobalFallback:
             index_prefix=_system_index([0, 0], 1),
         )
         params = jnp.array([0.0, 0.0])
-        gradient = jnp.array([-1.0, 0.0])
-        _, new_state = opt.update(gradient, state, params)
+        force = jnp.array([1.0, 0.0])
+        _, new_state = opt.update(force, state, params)
         limit = max_step / float(new_state.dt.data[0])
         assert float(jnp.max(jnp.abs(jnp.asarray(new_state.velocity)))) <= limit + 1e-6
 
@@ -296,8 +304,8 @@ class TestScaleByFire2GlobalFallback:
             velocity=jnp.array([100.0]), dt=1.0, n_pos=10, n_total=20
         )
         params = jnp.array([0.0])
-        gradient = jnp.array([-10.0])
-        updates, _ = opt.update(gradient, state, params)
+        force = jnp.array([10.0])
+        updates, _ = opt.update(force, state, params)
         assert float(jnp.abs(jnp.asarray(updates)[0])) > 1.0
 
     def test_max_step_clips_non_abc(self):
@@ -321,27 +329,28 @@ class TestScaleByFire2GlobalFallback:
             index_prefix=_system_index([0, 0], 1),
         )
         params = jnp.array([0.0, 0.0])
-        gradient = jnp.array([-1.0, 0.0])
-        updates, _ = opt.update(gradient, state, params)
+        force = jnp.array([1.0, 0.0])
+        updates, _ = opt.update(force, state, params)
         assert float(jnp.max(jnp.abs(jnp.asarray(updates)))) <= max_step + 1e-6
 
     def test_convergence_on_quadratic(self):
+        # L(x) = 0.5·x²  ⇒  ∇L = x, force F = -x.
         opt = ScaleByFire2(dt_start=0.05, dt_max=0.5, max_step=0.5)
         x = jnp.array([5.0])
         state = opt.init(x)
         for _ in range(200):
-            updates, state = opt.update(x, state, x)
-            x = optax.apply_updates(x, updates)
-        npt.assert_allclose(jnp.asarray(x), jnp.zeros(1), atol=1e-2)
+            updates, state = opt.update(-x, state, x)
+            x = jnp.asarray(optax.apply_updates(x, updates))
+        npt.assert_allclose(x, jnp.zeros(1), atol=1e-2)
 
     def test_convergence_on_quadratic_abc(self):
         opt = ScaleByFire2(dt_start=0.05, dt_max=0.5, max_step=0.5, use_abc=True)
         x = jnp.array([5.0])
         state = opt.init(x)
         for _ in range(200):
-            updates, state = opt.update(x, state, x)
-            x = optax.apply_updates(x, updates)
-        npt.assert_allclose(jnp.asarray(x), jnp.zeros(1), atol=1e-2)
+            updates, state = opt.update(-x, state, x)
+            x = jnp.asarray(optax.apply_updates(x, updates))
+        npt.assert_allclose(x, jnp.zeros(1), atol=1e-2)
 
 
 class TestScaleByFire2PerSystem:
@@ -353,9 +362,9 @@ class TestScaleByFire2PerSystem:
             state = opt.init(x0)
             x = x0
             for _ in range(8):
-                upd, state = opt.update(x, state, x)
-                x = optax.apply_updates(x, upd)
-            return jnp.asarray(x)
+                upd, state = opt.update(-x, state, x)
+                x = jnp.asarray(optax.apply_updates(x, upd))
+            return x
 
         x_a = jnp.array([5.0, -3.0])
         x_b = jnp.array([0.5, 0.2])
@@ -367,8 +376,8 @@ class TestScaleByFire2PerSystem:
         state = opt.init(batched, index_prefix=idx)
         x = batched
         for _ in range(8):
-            upd, state = opt.update(x, state, x)
-            x = optax.apply_updates(x, upd)
+            upd, state = opt.update(-x, state, x)
+            x = jnp.asarray(optax.apply_updates(x, upd))
         npt.assert_allclose(x, sep, atol=1e-6)
 
     def test_per_system_dmax_clip(self):
@@ -393,8 +402,8 @@ class TestScaleByFire2PerSystem:
         )
         params = jnp.array([0.0, 0.0, 0.0, 0.0])
         # Both systems get positive power.
-        gradient = jnp.array([-1.0, 0.0, -1.0, 0.0])
-        upd, _ = opt.update(gradient, state, params)
+        force = jnp.array([1.0, 0.0, 1.0, 0.0])
+        upd, _ = opt.update(force, state, params)
         # ∞-norm of each system's update ≈ max_step. LAMMPS dmax bounds
         # ``dtv·|v_old|_∞``, not the final Δx after mixing — allow a small
         # O(dtv²·F) overshoot.
@@ -412,11 +421,72 @@ class TestScaleByFire2PerSystem:
         idx = _system_index([0, 1], 2)
         x = jnp.array([1.0, 1.0])
         state = opt.init(x, index_prefix=idx)
-        # System 0: gradient = +x (downhill descent), positive power keeps building.
-        # System 1: alternating gradient sign — power flips negative each step.
+        # System 0: constant force → P>0 every step.
+        # System 1: force flips sign each step → P<0 → n_pos keeps resetting.
         for step in range(6):
-            grad = jnp.array([1.0, 1.0 if step % 2 == 0 else -1.0])
-            _, state = opt.update(grad, state, x)
+            force = jnp.array([-1.0, -1.0 if step % 2 == 0 else 1.0])
+            _, state = opt.update(force, state, x)
         # System 0 should have accumulated several positive-power steps.
         # System 1 should have reset n_pos to 0 frequently.
         assert int(state.n_pos.data[0]) > int(state.n_pos.data[1])
+
+
+class TestScaleByFire2Composability:
+    """``ScaleByFire2`` should compose cleanly with other transforms."""
+
+    def test_chain_with_sign_flip_matches_force_input(self):
+        """``chain(optax.scale(-1), ScaleByFire2())`` accepts ∇L and gives the
+        same trajectory as passing ``-∇L`` directly to a bare ``ScaleByFire2``."""
+        x0 = jnp.array([5.0])
+
+        direct = ScaleByFire2(dt_start=0.05, dt_max=0.5, max_step=0.5)
+        composed = chain(
+            optax.scale(-1.0),
+            ScaleByFire2(dt_start=0.05, dt_max=0.5, max_step=0.5),
+        )
+
+        x_direct = x0
+        s_direct = direct.init(x_direct)
+        x_composed = x0
+        s_composed = composed.init(x_composed)
+
+        for _ in range(20):
+            upd_d, s_direct = direct.update(-x_direct, s_direct, x_direct)
+            x_direct = jnp.asarray(optax.apply_updates(x_direct, upd_d))
+            upd_c, s_composed = composed.update(x_composed, s_composed, x_composed)
+            x_composed = jnp.asarray(optax.apply_updates(x_composed, upd_c))
+
+        npt.assert_allclose(x_composed, x_direct, atol=1e-6)
+
+    def test_chain_with_external_clip_caps_displacement(self):
+        """``MaxStepSize`` appended after FIRE 2.0 caps the per-particle Δx,
+        independently of (and on top of) the built-in LAMMPS ``dmax``."""
+        idx = _system_index([0, 0], 1)
+        x = jnp.zeros((2, 3))  # 2 particles, 3D — natural per-particle shape
+
+        external_cap = 0.01
+        opt = chain(
+            ScaleByFire2(dt_start=1.0, dt_max=10.0, max_step=1.0),
+            MaxStepSize(max_step_size=external_cap),
+        )
+        state = opt.init(x, index_prefix=idx)
+
+        force = jnp.array([[100.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        upd, _ = opt.update(force, state, x)
+        per_particle = jnp.linalg.norm(upd, axis=-1)
+        assert float(jnp.max(per_particle)) <= external_cap + 1e-6
+
+    def test_chain_clip_then_fire_runs(self):
+        """``ClipByGlobalNorm → ScaleByFire2`` chain converges on a quadratic."""
+        idx = _system_index([0], 1)
+        x = jnp.array([5.0])
+
+        opt = chain(
+            ClipByGlobalNorm(max_norm=2.0),
+            ScaleByFire2(dt_start=0.05, dt_max=0.5, max_step=0.5),
+        )
+        state = opt.init(x, index_prefix=idx)
+        for _ in range(200):
+            upd, state = opt.update(-x, state, x)
+            x = jnp.asarray(optax.apply_updates(x, upd))
+        npt.assert_allclose(x, jnp.zeros(1), atol=1e-2)


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Adopts the optax convention where FIRE/FIRE2 transforms interpret `updates` as the descent direction (force `F = -∇L`) rather than raw gradients, enabling composable optimizer chains with sign-flip and clipping transforms. Updated docstrings with usage examples and test cases to reflect this API change.