### PR TITLE
feat: add Frame.from_matrix

### DIFF
--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -212,6 +212,18 @@ class Frame(Protocol):
         [make_supercell][kups.core.cell.make_supercell] to build supercells."""
         ...
 
+    @classmethod
+    def from_matrix(cls, vecs: Array) -> Self:
+        """Construct from a ``(..., 3, 3)`` basis matrix.
+
+        Projects the input onto the frame's parameter space — entries
+        not represented by the parameterisation are discarded
+        (``OrthogonalFrame`` keeps the diagonal; ``TriclinicFrame``
+        keeps the lower-triangular block). Used to wrap a generic
+        ``∂E/∂h`` matrix back into the same frame type as an input cell.
+        """
+        ...
+
 
 def _build_vectors(lengths: Array, angles: Array) -> Array:
     """Construct a lower-triangular 3x3 matrix from crystallographic parameters.
@@ -369,6 +381,17 @@ class OrthogonalFrame(Sliceable):
     """
 
     lengths: Array
+
+    @classmethod
+    def from_matrix(cls, vecs: Array) -> Self:
+        """Construct from a diagonal basis matrix, shape ``(..., 3, 3)``.
+
+        Projects the input matrix onto the orthogonal subspace by taking
+        its diagonal — off-diagonal entries are discarded, matching the
+        3-parameter ``(Lx, Ly, Lz)`` representation.
+        """
+        vecs = jnp.asarray(vecs)
+        return cls(jnp.diagonal(vecs, axis1=-2, axis2=-1))
 
     @property
     def vectors(self) -> Array:

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -231,6 +231,17 @@ class TestOrthogonalFrame:
         frame = OrthogonalFrame(jnp.array([2.0, 3.0, 4.0]))
         npt.assert_allclose(frame.vectors, jnp.diag(jnp.array([2.0, 3.0, 4.0])))
 
+    def test_from_matrix_extracts_diagonal(self):
+        vecs = jnp.array([[2.0, 0.7, 0.0], [0.0, 3.0, 0.0], [0.4, 0.0, 4.0]])
+        frame = OrthogonalFrame.from_matrix(vecs)
+        npt.assert_allclose(frame.lengths, jnp.array([2.0, 3.0, 4.0]))
+
+    def test_from_matrix_batched(self):
+        vecs = jnp.stack([jnp.diag(jnp.array([2.0, 3.0, 4.0]))] * 2)
+        frame = OrthogonalFrame.from_matrix(vecs)
+        assert frame.lengths.shape == (2, 3)
+        npt.assert_allclose(frame.lengths[0], jnp.array([2.0, 3.0, 4.0]))
+
     def test_inverse_vectors(self):
         frame = OrthogonalFrame(jnp.array([2.0, 3.0, 4.0]))
         npt.assert_allclose(


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Add `Frame.from_matrix()` classmethod to construct frames from arbitrary 3×3 basis matrices by projecting onto each frame type's parameter space (diagonal for orthogonal, lower-triangular for triclinic). This enables wrapping generic stress/strain tensors back into the original frame representation.