### PR TITLE
refactor: Bundle integrator params into typed `IntegratorParams` dataclasses

### DIFF
--- a/src/kups/application/md/data.py
+++ b/src/kups/application/md/data.py
@@ -28,6 +28,73 @@ from kups.md.observables import particle_kinetic_energy
 
 
 @dataclass
+class VerletParams:
+    """Control parameters for the NVE Velocity Verlet integrator.
+
+    Attributes:
+        time_step: Integration timestep ``Δt`` (internal time units), shape ``(n_systems,)``.
+    """
+
+    time_step: Array
+
+
+@dataclass
+class BAOABLangevinParams:
+    """Control parameters for the BAOAB Langevin (NVT) integrator.
+
+    Attributes:
+        time_step: Integration timestep ``Δt``, shape ``(n_systems,)``.
+        temperature: Target temperature ``T`` (K), shape ``(n_systems,)``.
+        friction_coefficient: Langevin friction ``γ`` (1/time), shape ``(n_systems,)``.
+    """
+
+    time_step: Array
+    temperature: Array
+    friction_coefficient: Array
+
+
+@dataclass
+class CSVRParams:
+    """Control parameters for the CSVR (NVT) integrator.
+
+    Attributes:
+        time_step: Integration timestep ``Δt``, shape ``(n_systems,)``.
+        temperature: Target temperature ``T`` (K), shape ``(n_systems,)``.
+        thermostat_time_constant: CSVR coupling time ``τ`` (time), shape ``(n_systems,)``.
+    """
+
+    time_step: Array
+    temperature: Array
+    thermostat_time_constant: Array
+
+
+@dataclass
+class CSVRNPTParams:
+    """Control parameters for the CSVR-NPT integrator.
+
+    Attributes:
+        time_step: Integration timestep ``Δt``, shape ``(n_systems,)``.
+        temperature: Target temperature ``T`` (K), shape ``(n_systems,)``.
+        thermostat_time_constant: CSVR coupling time ``τ`` (time), shape ``(n_systems,)``.
+        target_pressure: Target pressure ``P₀`` (energy/length³), shape ``(n_systems,)``.
+        pressure_coupling_time: Barostat coupling time ``τ_P`` (time), shape ``(n_systems,)``.
+        compressibility: Isothermal compressibility ``β`` (length³/energy), shape ``(n_systems,)``.
+        minimum_scale_factor: Minimum barostat scale factor, shape ``(n_systems,)``.
+    """
+
+    time_step: Array
+    temperature: Array
+    thermostat_time_constant: Array
+    target_pressure: Array
+    pressure_coupling_time: Array
+    compressibility: Array
+    minimum_scale_factor: Array
+
+
+type IntegratorParams = VerletParams | BAOABLangevinParams | CSVRParams | CSVRNPTParams
+
+
+@dataclass
 class MDParticles(Particles):
     """Particle state for molecular dynamics simulations.
 
@@ -71,14 +138,10 @@ class MDSystems:
 
     Attributes:
         cell: Cell geometry for each system.
-        temperature: Target temperature (K), shape ``(n_systems,)``.
-        time_step: Integration timestep (internal time units), shape ``(n_systems,)``.
-        friction_coefficient: Langevin friction (1/time), shape ``(n_systems,)``.
-        thermostat_time_constant: CSVR coupling time (time), shape ``(n_systems,)``.
-        target_pressure: Target pressure (energy/length^3), shape ``(n_systems,)``.
-        pressure_coupling_time: Barostat coupling time (time), shape ``(n_systems,)``.
-        compressibility: Isothermal compressibility (length^3/energy), shape ``(n_systems,)``.
-        minimum_scale_factor: Minimum barostat scale factor, shape ``(n_systems,)``.
+        integrator_params: Bundled integrator control parameters; concrete shape
+            (e.g. :class:`VerletParams`, :class:`BAOABLangevinParams`,
+            :class:`CSVRParams`, :class:`CSVRNPTParams`) is chosen to match the
+            selected integrator.
         cell_gradients: Energy gradient w.r.t. the cell, stored as a
             :class:`Cell` (the ``vectors`` leaf holds the
             shape-``(n_systems, 3, 3)`` gradient used by
@@ -87,14 +150,7 @@ class MDSystems:
     """
 
     cell: Cell
-    temperature: Array
-    time_step: Array
-    friction_coefficient: Array
-    thermostat_time_constant: Array
-    target_pressure: Array
-    pressure_coupling_time: Array
-    compressibility: Array
-    minimum_scale_factor: Array
+    integrator_params: IntegratorParams
     cell_gradients: Cell
     potential_energy: Array
 
@@ -187,20 +243,7 @@ def md_state_from_ase(
     systems = Table.arange(
         MDSystems(
             cell=cell,
-            temperature=jnp.array([config.temperature]),
-            time_step=jnp.array([config.time_step * FEMTO_SECOND]),
-            friction_coefficient=jnp.array(
-                [config.friction_coefficient / FEMTO_SECOND]
-            ),
-            thermostat_time_constant=jnp.array(
-                [config.thermostat_time_constant * FEMTO_SECOND]
-            ),
-            target_pressure=jnp.array([config.target_pressure * PASCAL]),
-            pressure_coupling_time=jnp.array(
-                [config.pressure_coupling_time * FEMTO_SECOND]
-            ),
-            compressibility=jnp.array([config.compressibility / PASCAL]),
-            minimum_scale_factor=jnp.array([config.minimum_scale_factor]),
+            integrator_params=_build_integrator_params(config),
             cell_gradients=tree_zeros_like(cell),
             potential_energy=jnp.array([0.0]),
         ),
@@ -210,10 +253,54 @@ def md_state_from_ase(
     return particles, systems
 
 
+def _build_integrator_params(config: MdParameters) -> IntegratorParams:
+    """Construct the concrete integrator-params dataclass matching ``config.integrator``."""
+    time_step = jnp.array([config.time_step * FEMTO_SECOND])
+    temperature = jnp.array([config.temperature])
+    match config.integrator:
+        case "verlet":
+            return VerletParams(time_step=time_step)
+        case "baoab_langevin":
+            return BAOABLangevinParams(
+                time_step=time_step,
+                temperature=temperature,
+                friction_coefficient=jnp.array(
+                    [config.friction_coefficient / FEMTO_SECOND]
+                ),
+            )
+        case "csvr":
+            return CSVRParams(
+                time_step=time_step,
+                temperature=temperature,
+                thermostat_time_constant=jnp.array(
+                    [config.thermostat_time_constant * FEMTO_SECOND]
+                ),
+            )
+        case "csvr_npt":
+            return CSVRNPTParams(
+                time_step=time_step,
+                temperature=temperature,
+                thermostat_time_constant=jnp.array(
+                    [config.thermostat_time_constant * FEMTO_SECOND]
+                ),
+                target_pressure=jnp.array([config.target_pressure * PASCAL]),
+                pressure_coupling_time=jnp.array(
+                    [config.pressure_coupling_time * FEMTO_SECOND]
+                ),
+                compressibility=jnp.array([config.compressibility / PASCAL]),
+                minimum_scale_factor=jnp.array([config.minimum_scale_factor]),
+            )
+
+
 __all__ = [
     "MDParticles",
     "MDSystems",
     "MdRunConfig",
     "MdParameters",
+    "VerletParams",
+    "BAOABLangevinParams",
+    "CSVRParams",
+    "CSVRNPTParams",
+    "IntegratorParams",
     "md_state_from_ase",
 ]

--- a/src/kups/core/typing.py
+++ b/src/kups/core/typing.py
@@ -384,6 +384,21 @@ class HasMinimumScaleFactor(Protocol):
 
 
 @runtime_checkable
+class HasIntegratorParams[P](Protocol):
+    r"""Protocol for systems carrying bundled integrator control parameters.
+
+    Attributes:
+        integrator_params: Control knobs consumed by the chosen integrator
+            (time step, thermostat/barostat coupling parameters). Concrete shape
+            of ``P`` matches one of the integrator-specific protocols defined
+            in :mod:`kups.md.integrators`.
+    """
+
+    @property
+    def integrator_params(self) -> P: ...
+
+
+@runtime_checkable
 class HasPotentialEnergy(Protocol):
     r"""Protocol for systems with a potential energy.
 

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, runtime_checkable
+from typing import Any, Literal, overload, runtime_checkable
 
 import jax
 import jax.numpy as jnp
@@ -20,6 +20,7 @@ from kups.core.typing import (
     HasCompressibility,
     HasForces,
     HasFrictionCoefficient,
+    HasIntegratorParams,
     HasMasses,
     HasMinimumScaleFactor,
     HasMomenta,
@@ -30,6 +31,7 @@ from kups.core.typing import (
     HasTemperature,
     HasThermostatTimeConstant,
     HasTimeStep,
+    IsState,
     ParticleId,
     SystemId,
 )
@@ -138,16 +140,38 @@ class WrapFlow[State, PyTree](Flow[State, PyTree]):
         return tree_map(self.cell(state).wrap, self.flow(state, dt, primal, tangent))
 
 
-def _half_time[S: HasTimeStep](sys: Table[SystemId, S]) -> Table[SystemId, S]:
-    """View that halves the time_step of a system.
+def _half_time[S: HasIntegratorParams[HasTimeStep]](
+    sys: Table[SystemId, S],
+) -> Table[SystemId, S]:
+    """View that halves the time_step nested in ``integrator_params``.
 
     Args:
-        sys: Indexed system with time_step attribute
+        sys: Indexed system whose ``integrator_params`` exposes ``time_step``.
 
     Returns:
-        New Indexed system with time_step halved
+        New Indexed system with ``integrator_params.time_step`` halved.
     """
-    return bind(sys, lambda x: x.data.time_step).apply(lambda x: x / 2)
+    return bind(sys, lambda x: x.data.integrator_params.time_step).apply(
+        lambda x: x / 2
+    )
+
+
+def _to_params[P](
+    sys: Table[SystemId, HasIntegratorParams[P]],
+) -> Table[SystemId, P]:
+    """Project a Table of systems down to its ``integrator_params`` bundle.
+
+    The resulting table shares the same primary keys but exposes the inner
+    integrator parameter pytree as its ``data``.
+    """
+    return Table(sys.keys, sys.data.integrator_params, _cls=sys._cls)
+
+
+def _half_time_params[P: HasTimeStep](
+    sys: Table[SystemId, HasIntegratorParams[P]],
+) -> Table[SystemId, P]:
+    """Project to ``integrator_params`` with ``time_step`` halved (for splitting schemes)."""
+    return _to_params(_half_time(sys))
 
 
 @runtime_checkable
@@ -267,9 +291,14 @@ class _MDParticleData(
     def position_gradients(self) -> Array: ...
 
 
+@runtime_checkable
+class IsVerletParams(HasTimeStep, Protocol):
+    r"""Integrator-params shape for :func:`make_velocity_verlet_step`."""
+
+
 def make_velocity_verlet_step[State](
     particles: Lens[State, Table[ParticleId, _MDParticleData]],
-    systems: View[State, Table[SystemId, HasTimeStep]],
+    systems: View[State, Table[SystemId, HasIntegratorParams[IsVerletParams]]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
 ) -> SequentialPropagator[State]:
@@ -303,13 +332,14 @@ def make_velocity_verlet_step[State](
         Application to small water clusters. J. Chem. Phys., 76(1), 637-649.
         DOI: 10.1063/1.442716
     """
-    sys_with_half_time = pipe(systems, _half_time)  # Δt/2 [time]
+    params = pipe(systems, _to_params)
+    params_half_time = pipe(systems, _half_time_params)  # Δt/2 [time]
     return SequentialPropagator(
         (
-            MomentumStep(particles, sys_with_half_time),
-            PositionStep(particles, systems, flow),
+            MomentumStep(particles, params_half_time),
+            PositionStep(particles, params, flow),
             derivative_computation,
-            MomentumStep(particles, sys_with_half_time),
+            MomentumStep(particles, params_half_time),
         )
     )
 
@@ -319,9 +349,10 @@ class IsStochasticParticleData(HasMomenta, HasMasses, HasSystemIndex, Protocol):
 
 
 @runtime_checkable
-class _StochasticSysData(
+class IsBAOABLangevinParams(
     HasTimeStep, HasTemperature, HasFrictionCoefficient, Protocol
-): ...
+):
+    r"""Integrator-params shape for :func:`make_baoab_langevin_step`."""
 
 
 @dataclass
@@ -358,7 +389,7 @@ class StochasticStep[State](Propagator[State]):
     particles: Lens[State, Table[ParticleId, IsStochasticParticleData]] = field(
         static=True
     )
-    system: View[State, Table[SystemId, _StochasticSysData]] = field(static=True)
+    system: View[State, Table[SystemId, IsBAOABLangevinParams]] = field(static=True)
 
     def __call__(self, key: Array, state: State) -> State:
         """Apply stochastic Ornstein-Uhlenbeck thermostat step.
@@ -401,7 +432,7 @@ class StochasticStep[State](Propagator[State]):
 
 def make_baoab_langevin_step[State](
     particles: Lens[State, Table[ParticleId, _MDParticleData]],
-    systems: View[State, Table[SystemId, _StochasticSysData]],
+    systems: View[State, Table[SystemId, HasIntegratorParams[IsBAOABLangevinParams]]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
 ) -> SequentialPropagator[State]:
@@ -437,26 +468,28 @@ def make_baoab_langevin_step[State](
         stochastic numerical methods for molecular sampling.
         Appl. Math. Res. Express, 2013(1), 34-56. DOI: 10.1093/amrx/abs010
     """
-    sys_with_half_time = pipe(systems, _half_time)
+    params = pipe(systems, _to_params)
+    params_half_time = pipe(systems, _half_time_params)
     return SequentialPropagator(
         (
-            MomentumStep(particles, sys_with_half_time),  # B
-            PositionStep(particles, sys_with_half_time, flow),  # A
-            StochasticStep(particles, systems),  # O
-            PositionStep(particles, sys_with_half_time, flow),  # A
+            MomentumStep(particles, params_half_time),  # B
+            PositionStep(particles, params_half_time, flow),  # A
+            StochasticStep(particles, params),  # O
+            PositionStep(particles, params_half_time, flow),  # A
             derivative_computation,
-            MomentumStep(particles, sys_with_half_time),  # B
+            MomentumStep(particles, params_half_time),  # B
         )
     )
 
 
 @runtime_checkable
-class _CSVRSystemData(
+class IsCSVRParams(
     HasTimeStep,
     HasTemperature,
     HasThermostatTimeConstant,
     Protocol,
-): ...
+):
+    r"""Integrator-params shape for :func:`make_csvr_step`."""
 
 
 @runtime_checkable
@@ -502,7 +535,7 @@ class CSVRStep[State](Propagator[State]):
     """
 
     particles: Lens[State, Table[ParticleId, IsCSVRParticleData]] = field(static=True)
-    systems: View[State, Table[SystemId, _CSVRSystemData]] = field(static=True)
+    systems: View[State, Table[SystemId, IsCSVRParams]] = field(static=True)
 
     def __call__(self, key: Array, state: State) -> State:
         """Apply CSVR stochastic velocity rescaling.
@@ -584,7 +617,7 @@ class CSVRStep[State](Propagator[State]):
 
 def make_csvr_step[State](
     particles: Lens[State, Table[ParticleId, _MDParticleData]],
-    systems: View[State, Table[SystemId, _CSVRSystemData]],
+    systems: View[State, Table[SystemId, HasIntegratorParams[IsCSVRParams]]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
 ) -> SequentialPropagator[State]:
@@ -619,29 +652,42 @@ def make_csvr_step[State](
         through velocity rescaling. J. Chem. Phys., 126(1), 014101.
         DOI: 10.1063/1.2408420
     """
-    systems_with_half_time = pipe(systems, _half_time)
+    params = pipe(systems, _to_params)
+    params_half_time = pipe(systems, _half_time_params)
     return SequentialPropagator(
         (
-            CSVRStep(particles, systems),
-            MomentumStep(particles, systems_with_half_time),
-            PositionStep(particles, systems, flow),
+            CSVRStep(particles, params),
+            MomentumStep(particles, params_half_time),
+            PositionStep(particles, params, flow),
             derivative_computation,
-            MomentumStep(particles, systems_with_half_time),
+            MomentumStep(particles, params_half_time),
         )
     )
 
 
 @runtime_checkable
-class _StochasticCellRescalingSystemData(
-    HasCell[Periodic3D],
+class IsCSVRNPTParams(
     HasTimeStep,
     HasTemperature,
+    HasThermostatTimeConstant,
     HasTargetPressure,
     HasPressureCouplingTime,
     HasCompressibility,
     HasMinimumScaleFactor,
     Protocol,
 ):
+    r"""Integrator-params shape for :func:`make_csvr_npt_step`."""
+
+
+@runtime_checkable
+class IsMDSystem[P](HasCell[Periodic3D], HasIntegratorParams[P], Protocol):
+    r"""Protocol for an MD system row: a periodic cell plus bundled integrator parameters."""
+
+
+@runtime_checkable
+class IsMDSystemNPT(IsMDSystem[IsCSVRNPTParams], Protocol):
+    r"""NPT MD system row: adds the cell-gradient leaf needed for the barostat."""
+
     @property
     def cell_gradients(self) -> Cell[Periodic3D]: ...
 
@@ -699,9 +745,7 @@ class StochasticCellRescalingStep[State](Propagator[State]):
     particles: Lens[State, Table[ParticleId, _BarostatParticleData]] = field(
         static=True
     )
-    systems: Lens[State, Table[SystemId, _StochasticCellRescalingSystemData]] = field(
-        static=True
-    )
+    systems: Lens[State, Table[SystemId, IsMDSystemNPT]] = field(static=True)
 
     def __call__(self, key: Array, state: State) -> State:
         """Apply stochastic cell rescaling for pressure control.
@@ -719,16 +763,17 @@ class StochasticCellRescalingStep[State](Propagator[State]):
         """
         # Extract parameters
         systems = self.systems.get(state)
+        params = systems.data.integrator_params
         # Δt: timestep [time]
-        timestep = systems.data.time_step
+        timestep = params.time_step
         # kT: thermal energy [energy]
-        thermal_energy = systems.data.temperature * BOLTZMANN_CONSTANT
+        thermal_energy = params.temperature * BOLTZMANN_CONSTANT
         # P₀: target pressure [pressure]
-        target_pressure = systems.data.target_pressure
+        target_pressure = params.target_pressure
         # τP: barostat time constant [time]
-        barostat_timescale = systems.data.pressure_coupling_time
+        barostat_timescale = params.pressure_coupling_time
         # β: isothermal compressibility [1/pressure]
-        compressibility = systems.data.compressibility
+        compressibility = params.compressibility
 
         # Get current state
         # Cell with lattice vectors L
@@ -786,7 +831,7 @@ class StochasticCellRescalingStep[State](Propagator[State]):
 
         # Safety clamp to prevent extreme scaling
         # μ ∈ [μ_min, μ_max]
-        min_scaling = systems.data.minimum_scale_factor
+        min_scaling = params.minimum_scale_factor
         max_scaling = 1.0 / min_scaling
         scaling_factor = jnp.clip(scaling_factor, min_scaling, max_scaling)
 
@@ -807,25 +852,9 @@ class StochasticCellRescalingStep[State](Propagator[State]):
         return particle_lens.focus(lambda p: p.data.positions).set(new_positions)
 
 
-@runtime_checkable
-class IsCSVRNPTSystemData(
-    HasCell[Periodic3D],
-    HasTimeStep,
-    HasTemperature,
-    HasTargetPressure,
-    HasPressureCouplingTime,
-    HasCompressibility,
-    HasMinimumScaleFactor,
-    HasThermostatTimeConstant,
-    Protocol,
-):
-    @property
-    def cell_gradients(self) -> Cell[Periodic3D]: ...
-
-
 def make_csvr_npt_step[State](
     particles: Lens[State, Table[ParticleId, _BarostatParticleData]],
-    systems: Lens[State, Table[SystemId, IsCSVRNPTSystemData]],
+    systems: Lens[State, Table[SystemId, IsMDSystemNPT]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
 ) -> SequentialPropagator[State]:
@@ -868,38 +897,59 @@ def make_csvr_npt_step[State](
              stochastic cell rescaling. J. Chem. Phys., 153(11), 114107.
              DOI: 10.1063/5.0020514
     """
-    sys_view: View[State, Table[SystemId, IsCSVRNPTSystemData]] = systems.get
-    sys_half_view: View[State, Table[SystemId, IsCSVRNPTSystemData]] = pipe(
-        systems.get, _half_time
+    params: View[State, Table[SystemId, IsCSVRNPTParams]] = pipe(
+        systems.get, _to_params
+    )
+    params_half: View[State, Table[SystemId, IsCSVRNPTParams]] = pipe(
+        systems.get, _half_time_params
     )
     return SequentialPropagator(
         (
-            CSVRStep(particles, sys_view),
-            MomentumStep(particles, sys_half_view),
-            PositionStep(particles, sys_view, flow),
+            CSVRStep(particles, params),
+            MomentumStep(particles, params_half),
+            PositionStep(particles, params, flow),
             derivative_computation,
-            MomentumStep(particles, sys_half_view),
+            MomentumStep(particles, params_half),
             StochasticCellRescalingStep(particles, systems),
             derivative_computation,
         )
     )
 
 
-@runtime_checkable
-class IsMDSystem(HasFrictionCoefficient, IsCSVRNPTSystemData, Protocol): ...
-
-
-class IsMDState(Protocol):
-    """State protocol for molecular dynamics step computation."""
-
-    @property
-    def particles(self) -> Table[ParticleId, _MDParticleData]: ...
-    @property
-    def systems(self) -> Table[SystemId, IsMDSystem]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsVerletParams]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["verlet"],
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsBAOABLangevinParams]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["baoab_langevin"],
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsCSVRParams]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["csvr"],
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystemNPT]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["csvr_npt"],
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, Any],
+    derivative_computation: Propagator[State],
+    integrator: Integrator,
+) -> Propagator[State]: ...
 
 
 def make_md_step_from_state[State](
-    state: Lens[State, IsMDState],
+    state: Lens[State, Any],
     derivative_computation: Propagator[State],
     integrator: Integrator,
 ) -> Propagator[State]:
@@ -913,18 +963,21 @@ def make_md_step_from_state[State](
     Supported integrators:
 
     - ``"verlet"`` — [Velocity Verlet][kups.md.integrators.make_velocity_verlet_step]
-      (NVE ensemble, no thermostat).
+      (NVE ensemble, no thermostat). Requires ``integrator_params: IsVerletParams``.
     - ``"baoab_langevin"`` — [BAOAB Langevin][kups.md.integrators.make_baoab_langevin_step]
-      (NVT via Langevin friction/noise).
+      (NVT via Langevin friction/noise). Requires
+      ``integrator_params: IsBAOABLangevinParams``.
     - ``"csvr"`` — [CSVR][kups.md.integrators.make_csvr_step]
-      (NVT via canonical-sampling velocity rescaling, constant volume).
+      (NVT via canonical-sampling velocity rescaling, constant volume). Requires
+      ``integrator_params: IsCSVRParams``.
     - ``"csvr_npt"`` — [CSVR-NPT][kups.md.integrators.make_csvr_npt_step]
-      (NPT via CSVR thermostat with barostat).
+      (NPT via CSVR thermostat with barostat). Requires
+      ``integrator_params: IsCSVRNPTParams`` and a ``cell_gradients`` leaf on each system.
+
+    The overloads narrow the required state protocol per ``integrator`` literal.
 
     Args:
-        state: Lens into the sub-state satisfying
-            [IsMDState][kups.md.integrators.IsMDState] (needs ``particles`` and
-            ``systems``).
+        state: Lens into the sub-state with ``particles`` and ``systems``.
         derivative_computation: Propagator that computes forces/gradients and
             updates the state (e.g. a wrapped potential).
         integrator: String key selecting the integration algorithm.
@@ -940,20 +993,24 @@ def make_md_step_from_state[State](
         state.focus(lambda x: x.systems[x.particles.data.system].cell),
         euclidean_flow,
     )
+    particles_lens = state.focus(lambda x: x.particles)
+    systems_lens = state.focus(lambda x: x.systems)
     match integrator:
         case "verlet":
-            integrator_fn = make_velocity_verlet_step
+            return make_velocity_verlet_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
         case "baoab_langevin":
-            integrator_fn = make_baoab_langevin_step
+            return make_baoab_langevin_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
         case "csvr":
-            integrator_fn = make_csvr_step
+            return make_csvr_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
         case "csvr_npt":
-            integrator_fn = make_csvr_npt_step
+            return make_csvr_npt_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
         case _:
             raise ValueError(f"Unknown integrator: {integrator}")
-    return integrator_fn(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.systems),
-        derivative_computation,
-        flow,
-    )

--- a/test/md/test_integrators.py
+++ b/test/md/test_integrators.py
@@ -48,7 +48,13 @@ class ParticleData:
 
 
 @dataclass
-class SystemData:
+class SystemParams:
+    """Bundled integrator-params for the simple harmonic-system tests.
+
+    Carries the union of fields needed by BAOAB Langevin and CSVR so the same
+    state shape can drive both integrators.
+    """
+
     time_step: Array
     temperature: Array
     friction_coefficient: Array
@@ -56,16 +62,28 @@ class SystemData:
 
 
 @dataclass
-class NPTSystemData:
+class NPTSystemParams:
+    """Bundled integrator-params for CSVR-NPT tests."""
+
     time_step: Array
     temperature: Array
     thermostat_time_constant: Array
-    cell: Cell
-    cell_gradients: Cell
     target_pressure: Array
     pressure_coupling_time: Array
     compressibility: Array
     minimum_scale_factor: Array
+
+
+@dataclass
+class SystemData:
+    integrator_params: SystemParams
+
+
+@dataclass
+class NPTSystemData:
+    cell: Cell
+    cell_gradients: Cell
+    integrator_params: NPTSystemParams
 
 
 @dataclass
@@ -98,6 +116,12 @@ def compute_temperature(state, dof):
 def get_systems(s: SimpleState) -> Table[SystemId, SystemData]:
     """Extract Table SystemData from state."""
     return s.systems
+
+
+def get_params(s: SimpleState) -> Table[SystemId, SystemParams]:
+    """Project the system table to its integrator_params bundle."""
+    sys = s.systems
+    return Table(sys.keys, sys.data.integrator_params, _cls=sys._cls)
 
 
 def run_simulation(integrator, state, key, n_equil, n_sample, extract_fn):
@@ -164,10 +188,12 @@ def create_harmonic_system(
 
     systems = Table.arange(
         SystemData(
-            time_step=jnp.array([dt]),
-            temperature=jnp.array([kT / BOLTZMANN_CONSTANT]),
-            friction_coefficient=jnp.array([gamma]),
-            thermostat_time_constant=jnp.array([tau]),
+            integrator_params=SystemParams(
+                time_step=jnp.array([dt]),
+                temperature=jnp.array([kT / BOLTZMANN_CONSTANT]),
+                friction_coefficient=jnp.array([gamma]),
+                thermostat_time_constant=jnp.array([tau]),
+            ),
         ),
         label=SystemId,
     )
@@ -237,15 +263,17 @@ def create_npt_system(
 
     systems = Table.arange(
         NPTSystemData(
-            time_step=jnp.array([dt]),
-            temperature=jnp.array([kT / BOLTZMANN_CONSTANT]),
-            thermostat_time_constant=jnp.array([tau_t]),
             cell=cell,
             cell_gradients=tree_zeros_like(cell),
-            target_pressure=jnp.array([target_pressure]),
-            pressure_coupling_time=jnp.array([tau_p]),
-            compressibility=jnp.array([compressibility]),
-            minimum_scale_factor=jnp.array([0.5]),
+            integrator_params=NPTSystemParams(
+                time_step=jnp.array([dt]),
+                temperature=jnp.array([kT / BOLTZMANN_CONSTANT]),
+                thermostat_time_constant=jnp.array([tau_t]),
+                target_pressure=jnp.array([target_pressure]),
+                pressure_coupling_time=jnp.array([tau_p]),
+                compressibility=jnp.array([compressibility]),
+                minimum_scale_factor=jnp.array([0.5]),
+            ),
         ),
         label=SystemId,
     )
@@ -294,7 +322,7 @@ class TestBasicSteps:
         state, _, _ = create_harmonic_system(n_particles=5, dt=0.01)
         step = PositionStep(
             particles=SimpleState.particles,
-            systems=SimpleState.systems.get,
+            systems=get_params,
             flow=euclidean_flow,
         )
         new_state = step(jax.random.key(0), state)
@@ -302,7 +330,7 @@ class TestBasicSteps:
         velocities = state.particles.data.momenta / state.particles.data.masses[:, None]
         expected = (
             state.particles.data.positions
-            + velocities * state.systems.data.time_step[0]
+            + velocities * state.systems.data.integrator_params.time_step[0]
         )
         assert jnp.allclose(new_state.particles.data.positions, expected, rtol=1e-6)
         assert jnp.allclose(
@@ -312,14 +340,13 @@ class TestBasicSteps:
     def test_momentum_update(self):
         """Momentum update correctness and position preservation."""
         state, _, _ = create_harmonic_system(n_particles=5, dt=0.01)
-        step = MomentumStep(
-            particles=SimpleState.particles, systems=SimpleState.systems.get
-        )
+        step = MomentumStep(particles=SimpleState.particles, systems=get_params)
         new_state = step(jax.random.key(0), state)
 
         expected = (
             state.particles.data.momenta
-            + state.particles.data.forces * state.systems.data.time_step[0]
+            + state.particles.data.forces
+            * state.systems.data.integrator_params.time_step[0]
         )
         assert jnp.allclose(new_state.particles.data.momenta, expected, rtol=1e-6)
         assert jnp.allclose(
@@ -335,9 +362,7 @@ class TestThermostatSteps:
         state, _, _ = create_harmonic_system(
             n_particles=n_particles, kT=kT_target, dt=0.02
         )
-        step = StochasticStep(
-            particles=SimpleState.particles, system=SimpleState.systems.get
-        )
+        step = StochasticStep(particles=SimpleState.particles, system=get_params)
 
         _, temps = run_simulation(
             step,
@@ -354,7 +379,7 @@ class TestThermostatSteps:
         state, _, _ = create_harmonic_system(
             n_particles=n_particles, kT=kT_target, tau=0.1, dt=0.02
         )
-        step = CSVRStep(particles=SimpleState.particles, systems=get_systems)
+        step = CSVRStep(particles=SimpleState.particles, systems=get_params)
 
         _, temps = run_simulation(
             step,
@@ -530,7 +555,7 @@ class TestNVTPhysics:
         )
         integrator = make_csvr_step(
             particles=SimpleState.particles,
-            systems=get_systems,
+            systems=SimpleState.systems.get,
             derivative_computation=deriv,
             flow=euclidean_flow,
         )
@@ -552,7 +577,7 @@ class TestNVTPhysics:
         )
         integrator2 = make_csvr_step(
             particles=SimpleState.particles,
-            systems=get_systems,
+            systems=SimpleState.systems.get,
             derivative_computation=deriv2,
             flow=euclidean_flow,
         )


### PR DESCRIPTION
> 🤖 _Auto-generated by Claude. Review and edit as needed._

Bundled integrator control parameters (time step, temperature, friction, etc.) into typed dataclasses (`VerletParams`, `BAOABLangevinParams`, `CSVRParams`, `CSVRNPTParams`) and added a `HasIntegratorParams` protocol to improve type safety and code organization.  
  
Fixes #117