### PR TITLE
fix: Force positive diagonal in `to_lower_triangular` QR decomposition

### DIFF
--- a/src/kups/application/utils/path.py
+++ b/src/kups/application/utils/path.py
@@ -38,7 +38,7 @@ def get_model_path(path: str | Path) -> Path:
     if path_str.startswith(HF_PREFIX):
         try:
             from huggingface_hub import (  # pyright: ignore[reportMissingImports]
-                hf_hub_download,
+                hf_hub_download,  # pyright: ignore[reportAttributeAccessIssue]
             )
         except ImportError as e:
             raise ImportError(

--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -647,7 +647,12 @@ def to_lower_triangular(vecs: Array) -> tuple[Array, TriclinicMap]:
 
     Decomposes the input into a lower-triangular basis matrix and an
     orthogonal rotation that maps coordinates from the original frame
-    into the triclinic frame.
+    into the triclinic frame. The diagonal of the returned basis matrix
+    is forced positive (the QR factorisation is unique only up to per-row
+    sign; jax/numpy returns an arbitrary sign), which matches the standard
+    LAMMPS/CP2K lower-triangular convention and keeps every downstream code
+    path (neighbour list shifts, cell-vector parametrisations) on the same
+    side of the axes.
 
     Args:
         vecs: Basis vectors as rows of a 3x3 matrix, shape ``(3, 3)``.
@@ -656,6 +661,14 @@ def to_lower_triangular(vecs: Array) -> tuple[Array, TriclinicMap]:
         Tuple of (lower_triangular_vectors, coordinate_rotation_fn).
     """
     vecs = jnp.asarray(vecs)
-    Q, L = jnp.linalg.qr(vecs.T)
-    Q, L = Q.T, L.T
+    Q, R = jnp.linalg.qr(vecs.T)
+    # Force the diagonal of R (= the future diagonal of L) positive by
+    # flipping each row of R together with the corresponding column of Q;
+    # ``Q @ R`` is invariant under this rescaling.
+    signs = jnp.sign(jnp.diagonal(R))
+    signs = jnp.where(signs == 0, 1.0, signs)
+    R = R * signs[:, None]
+    Q = Q * signs[None, :]
+    L = R.T
+    Q = Q.T
     return L, partial(jnp.einsum, "...ij,...i->...j", Q)

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -546,6 +546,40 @@ class TestToLowerTriangular:
         r = jnp.array([1.0, 2.0, 3.0])
         npt.assert_allclose(jnp.linalg.norm(mapper(r)), jnp.linalg.norm(r), atol=1e-6)
 
+    @pytest.mark.parametrize(
+        "vecs",
+        [
+            # FCC primitive vectors (a=3.61), historically produced a negative diagonal.
+            1.805 * jnp.array([[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]]),
+            # Swap-yz input (negative determinant).
+            jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0]]),
+            # Random rotations of a positive-diagonal lower-triangular cell.
+            *[
+                jnp.array([[2.0, 0.0, 0.0], [0.5, 3.0, 0.0], [0.1, 0.2, 4.0]])
+                @ jnp.linalg.qr(jax.random.normal(jax.random.key(seed), (3, 3)))[0]
+                for seed in (0, 1, 2)
+            ],
+        ],
+    )
+    def test_diagonal_is_positive_for_various_inputs(self, vecs):
+        L, _ = to_lower_triangular(vecs)
+        assert jnp.all(jnp.diagonal(L) > 0)
+
+    def test_round_trip_recovers_input(self):
+        """vecs == L @ Q, where Q is reconstructed from the mapper."""
+        vecs = jnp.array([[1.0, 2.0, 0.3], [0.2, 3.0, 0.1], [0.5, 0.4, 4.0]])
+        L, mapper = to_lower_triangular(vecs)
+        Q = jnp.stack([mapper(row) for row in jnp.eye(3)])
+        npt.assert_allclose(L @ Q, vecs, atol=1e-6)
+
+    def test_fcc_primitive_gives_positive_diagonal(self):
+        """Regression: ase FCC Cu (a=3.61) previously produced a negative diagonal."""
+        import ase.build
+
+        vecs = jnp.asarray(ase.build.bulk("Cu", "fcc", a=3.61).cell.array)
+        L, _ = to_lower_triangular(vecs)
+        assert jnp.all(jnp.diagonal(L) > 0)
+
 
 _FRAMES = pytest.mark.parametrize(
     "frame",


### PR DESCRIPTION
Fixes `to_lower_triangular` to always produce a lower-triangular basis matrix with a positive diagonal.

The QR factorisation is unique only up to per-row sign flips, and JAX/NumPy return an arbitrary sign. This caused downstream failures (neighbour list shifts, cell-vector parametrisations) when inputs such as FCC primitive vectors produced a negative diagonal. The fix rescales each row of `R` and the corresponding column of `Q` by the sign of the diagonal entry, leaving `Q @ R` invariant while guaranteeing a positive diagonal consistent with the LAMMPS/CP2K lower-triangular convention.

Tests are added to cover:
- A parametrised suite of inputs known to previously produce a negative diagonal (FCC primitive vectors, negative-determinant cells, random rotations of a valid lower-triangular cell)
- A round-trip check that `L @ Q` recovers the original basis vectors
- A regression test using ASE-generated FCC Cu cell vectors (`a=3.61`)

Also suppresses a `pyright` `reportAttributeAccessIssue` warning on the `hf_hub_download` import.