### PR TITLE
fix: Correct cell rotation direction and guard against degenerate cell hashes and image counts

### DIFF
--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -645,14 +645,8 @@ def is_3d_periodic[P: tuple[bool, bool, bool]](
 def to_lower_triangular(vecs: Array) -> tuple[Array, TriclinicMap]:
     """Convert arbitrary basis vectors to lower-triangular form via QR.
 
-    Decomposes the input into a lower-triangular basis matrix and an
-    orthogonal rotation that maps coordinates from the original frame
-    into the triclinic frame. The diagonal of the returned basis matrix
-    is forced positive (the QR factorisation is unique only up to per-row
-    sign; jax/numpy returns an arbitrary sign), which matches the standard
-    LAMMPS/CP2K lower-triangular convention and keeps every downstream code
-    path (neighbour list shifts, cell-vector parametrisations) on the same
-    side of the axes.
+    The returned basis has a positive diagonal. The coordinate mapper applies
+    the same rigid rotation to positions, preserving fractional coordinates.
 
     Args:
         vecs: Basis vectors as rows of a 3x3 matrix, shape ``(3, 3)``.
@@ -662,13 +656,9 @@ def to_lower_triangular(vecs: Array) -> tuple[Array, TriclinicMap]:
     """
     vecs = jnp.asarray(vecs)
     Q, R = jnp.linalg.qr(vecs.T)
-    # Force the diagonal of R (= the future diagonal of L) positive by
-    # flipping each row of R together with the corresponding column of Q;
-    # ``Q @ R`` is invariant under this rescaling.
     signs = jnp.sign(jnp.diagonal(R))
     signs = jnp.where(signs == 0, 1.0, signs)
     R = R * signs[:, None]
     Q = Q * signs[None, :]
     L = R.T
-    Q = Q.T
     return L, partial(jnp.einsum, "...ij,...i->...j", Q)

--- a/src/kups/core/neighborlist.py
+++ b/src/kups/core/neighborlist.py
@@ -257,9 +257,13 @@ class NearestNeighborList(Protocol):
 
 
 def _cell_hash(coordinate: Array, num_cells: Array):
-    """Calculate the cell hash for a given coordinate and number of cells."""
-    factor = jnp.cumprod(num_cells, axis=-1) / num_cells
-    return (jnp.floor(coordinate * num_cells) * factor).astype(int).sum(axis=-1)
+    """Hash folded fractional coordinates into row-major cell bins.
+
+    Boundary values are clamped into the valid bin range for each axis.
+    """
+    factor = jnp.cumprod(num_cells, axis=-1) // num_cells
+    bin_idx = jnp.clip(jnp.floor(coordinate * num_cells).astype(int), 0, num_cells - 1)
+    return (bin_idx * factor).sum(axis=-1)
 
 
 def _cell_stencil(dim: int):
@@ -447,6 +451,23 @@ def _generate_image_offsets(images: jax.Array, out_size: Capacity[int]) -> jax.A
     return coords - half
 
 
+def _candidate_image_counts(cells, cutoffs: Array) -> Array:
+    """Return per-system, per-axis image counts for candidate replication.
+
+    Periodic axes covered by the minimum-image convention use one image. Wider
+    periodic cutoffs use a symmetric integer-shift stencil; open axes and
+    non-finite cutoff/height ratios use one image.
+    """
+    ratio = cutoffs[..., None] / cells.perpendicular_lengths
+    images = jnp.where(
+        ratio <= 0.5,
+        1,
+        2 * jnp.ceil(ratio).astype(int) + 1,
+    )
+    images = jnp.where(jnp.isfinite(ratio), images, 1)
+    return jnp.where(jnp.array(cells.periodic), images, 1)
+
+
 def _get_candidate_images(
     candidates: _Candidates,
     lh: Table[ParticleId, NeighborListPoints],
@@ -455,23 +476,7 @@ def _get_candidate_images(
     out_size: Capacity[int],
 ) -> tuple[Array, Array, Array]:
     cells = systems.data.cell
-    # Per-axis image count, picked to satisfy whichever distance path runs:
-    #   - cutoff ≤ perp/2: minimum-image convention alone covers all pairs, so
-    #     emit 1 image; this is the trigger for the MIC fast path in
-    #     `_apply_distance_cutoff_w_images`.
-    #   - cutoff > perp/2: the slow path computes distances as
-    #     `raw_frac_delta - shift`, with raw_frac_delta ∈ (-1, 1). We therefore
-    #     need integer shifts spanning (-1 - cutoff/perp, 1 + cutoff/perp), i.e.
-    #     `2·⌈cutoff/perp⌉ + 1` shifts per axis.
-    perp = cells.perpendicular_lengths
-    images = jnp.where(
-        cutoffs[..., None] <= perp / 2,
-        1,
-        2 * jnp.ceil(cutoffs[..., None] / perp).astype(int) + 1,
-    )
-    images = jnp.where(jnp.isfinite(cutoffs[..., None]), images, 1)
-    # Open axes contribute no images.
-    images = jnp.where(jnp.array(cells.periodic), images, 1)
+    images = _candidate_image_counts(cells, cutoffs)
     images_per_sys = jnp.prod(images, axis=-1).astype(int)
 
     cand_sys_ids = lh.data.system.indices[candidates.lhs.indices]

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -566,11 +566,53 @@ class TestToLowerTriangular:
         assert jnp.all(jnp.diagonal(L) > 0)
 
     def test_round_trip_recovers_input(self):
-        """vecs == L @ Q, where Q is reconstructed from the mapper."""
+        """``vecs == L @ Q.T``, where Q is the rotation reconstructed from
+        the mapper. The mapper acts as ``r @ Q`` in row form (= ``Q.T @ r``
+        on a column vector), matching the same rotation that takes
+        ``vecs`` row-by-row into the rows of ``L``."""
         vecs = jnp.array([[1.0, 2.0, 0.3], [0.2, 3.0, 0.1], [0.5, 0.4, 4.0]])
         L, mapper = to_lower_triangular(vecs)
         Q = jnp.stack([mapper(row) for row in jnp.eye(3)])
-        npt.assert_allclose(L @ Q, vecs, atol=1e-6)
+        npt.assert_allclose(L @ Q.T, vecs, atol=1e-6)
+
+    def test_mapper_preserves_fractional_coordinates(self):
+        """The mapper re-expresses positions without changing fractional coordinates."""
+        vecs = jnp.array([[1.0, 2.0, 0.3], [0.2, 3.0, 0.1], [0.5, 0.4, 4.0]])
+        L, mapper = to_lower_triangular(vecs)
+        # Several arbitrary fractional positions; all must survive.
+        frac_coords = jnp.array(
+            [[0.7, 0.3, 0.5], [0.0, 0.0, 0.0], [0.123, 0.456, 0.789]]
+        )
+        for f in frac_coords:
+            r_orig = f @ vecs
+            r_new = mapper(r_orig)
+            f_new = r_new @ jnp.linalg.inv(L)
+            npt.assert_allclose(f_new, f, atol=1e-6)
+
+    def test_mapper_preserves_fractional_coordinates_fcc_primitive(self):
+        """End-to-end regression for the FCC primitive ASE case: the
+        upper-triangular ASE convention must round-trip through the rotation
+        without changing fractional coordinates."""
+        vecs = 1.805 * jnp.array([[0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 0.0]])
+        # The 8 atoms of an FCC 2×2×2 primitive supercell — fractional coords
+        # are at half-integer combinations of the basis vectors.
+        frac = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.5],
+                [0.0, 0.5, 0.0],
+                [0.0, 0.5, 0.5],
+                [0.5, 0.0, 0.0],
+                [0.5, 0.0, 0.5],
+                [0.5, 0.5, 0.0],
+                [0.5, 0.5, 0.5],
+            ]
+        )
+        L, mapper = to_lower_triangular(vecs)
+        r_orig = frac @ vecs
+        r_new = jnp.stack([mapper(r) for r in r_orig])
+        frac_new = r_new @ jnp.linalg.inv(L)
+        npt.assert_allclose(frac_new, frac, atol=1e-5)
 
     def test_fcc_primitive_gives_positive_diagonal(self):
         """Regression: ase FCC Cu (a=3.61) previously produced a negative diagonal."""

--- a/test/core/test_neighborlist.py
+++ b/test/core/test_neighborlist.py
@@ -27,6 +27,10 @@ from kups.core.neighborlist import (
     DenseNearestNeighborList,
     Edges,
     RefineCutoffNeighborList,
+    _candidate_image_counts,
+    _Candidates,
+    _cell_hash,
+    _get_candidate_images,
     neighborlist_changes,
 )
 from kups.core.result import as_result_function
@@ -198,6 +202,96 @@ class TestNumNeighbors:
 
         nn_zero = FixedCapacity(0)
         assert nn_zero.size == 0
+
+
+class TestCellHashClampsAtBoundary:
+    """``_cell_hash`` keeps per-axis bins inside ``[0, num_cells - 1]``."""
+
+    def test_interior_coord_with_unit_grid_hashes_to_zero(self):
+        # Sanity check: when num_cells = (1, 1, 1) any coord in [0, 1) hashes to 0.
+        h = _cell_hash(jnp.array([0.0, 0.0, 0.0]), jnp.array([1, 1, 1]))
+        assert int(h) == 0
+        h = _cell_hash(jnp.array([0.5, 0.99, 0.0]), jnp.array([1, 1, 1]))
+        assert int(h) == 0
+
+    def test_fold_overshoot_at_one_clamps_with_unit_grid(self):
+        # Boundary values remain in range even when folding lands exactly on 1.0.
+        h = _cell_hash(jnp.array([1.0, 1.0, 1.0]), jnp.array([1, 1, 1]))
+        assert int(h) == 0
+
+    def test_fold_overshoot_at_one_clamps_with_nontrivial_grid(self):
+        # For num_cells = (2, 3, 5), the max valid bin per axis is (1, 2, 4).
+        # Coord = 1.0 should clamp to that and hash to 1 + 2*2 + 4*6 = 29.
+        num_cells = jnp.array([2, 3, 5])
+        h = _cell_hash(jnp.array([1.0, 1.0, 1.0]), num_cells)
+        assert int(h) == 1 + 2 * 2 + 4 * 6
+        # Interior coords are unaffected by the clamp.
+        h = _cell_hash(jnp.array([0.25, 0.5, 0.5]), num_cells)
+        # bins (0, 1, 2) → 0 + 1*2 + 2*6 = 14
+        assert int(h) == 0 + 1 * 2 + 2 * 6
+
+    def test_realistic_fold_path_does_not_escape_range(self):
+        # Reproduce the exact failure path: a tiny-negative fractional coord
+        # passes through ``cell.fold`` and must hash inside ``[0, 1)`` with
+        # ``num_cells = (1, 1, 1)``.
+        cell = PeriodicCell(OrthogonalFrame(jnp.array([10.0, 10.0, 10.0])))
+        bad_frac = jnp.array([-1.49e-8, 0.0, 0.0])
+        folded, _ = cell.fold(bad_frac)
+        # We don't assert that fold returns < 1 (it may not in float32) — only
+        # that ``_cell_hash`` survives that overshoot.
+        h = _cell_hash(folded, jnp.array([1, 1, 1]))
+        assert int(h) == 0
+
+
+class TestImageCountIsFiniteGuard:
+    """Candidate image counts stay finite for degenerate periodic geometry."""
+
+    @staticmethod
+    def _make_minimal_inputs(cell: PeriodicCell):
+        """One-atom, one-system, one-candidate setup for direct invocation
+        of ``_get_candidate_images``."""
+        sys_keys = (SystemId(0),)
+        pi_keys = (ParticleId(0),)
+        lh = Table(
+            pi_keys,
+            SamplePoints(
+                positions=jnp.zeros((1, 3)),
+                system=Index(sys_keys, jnp.array([0])),
+                inclusion=Index(sys_keys, jnp.array([0])),
+                exclusion=Index.integer(jnp.array([0])),
+            ),
+        )
+        systems = Table(sys_keys, SampleSystems(cell=cell))
+        candidates = _Candidates(
+            lhs=Index(pi_keys, jnp.array([0])),
+            rhs=Index(pi_keys, jnp.array([0])),
+        )
+        return lh, systems, candidates
+
+    def test_zero_perpendicular_axis_clamps_images_to_one(self):
+        # ``tril = [0, 0, 1, 0, 0, 1]`` gives ``vectors[0] = (0, 0, 0)``.
+        # Volume = 0, perp[0] = 0, perp[1] = perp[2] = NaN (0/0).
+        tril = jnp.array([[0.0, 0.0, 1.0, 0.0, 0.0, 1.0]])
+        cell = PeriodicCell(TriclinicFrame(tril))
+        assert float(cell.perpendicular_lengths[0, 0]) == 0.0
+        lh, systems, candidates = self._make_minimal_inputs(cell)
+        cutoffs = jnp.array([6.0])
+        # Degenerate axes are treated as a single image, keeping the output bounded.
+        idx, offsets, has_been_replicated = _get_candidate_images(
+            candidates, lh, systems, cutoffs, FixedCapacity(8)
+        )
+        # Exact contents are not relevant here; only bounded shape is.
+        assert idx.shape[0] <= 8
+        assert offsets.shape == (idx.shape[0], 3)
+        assert has_been_replicated.shape == (idx.shape[0],)
+
+    def test_candidate_image_counts_handles_nonfinite_ratios(self):
+        class Cells:
+            perpendicular_lengths = jnp.array([[0.0, 4.0, jnp.nan]])
+            periodic = (True, True, True)
+
+        images = _candidate_image_counts(Cells(), jnp.array([6.0]))
+        npt.assert_array_equal(np.asarray(images), np.array([[1, 5, 1]]))
 
 
 # Parametrized test class for testing different neighbor list implementations

--- a/test/core/test_neighborlist_ase.py
+++ b/test/core/test_neighborlist_ase.py
@@ -15,10 +15,11 @@ import ase.build
 import jax
 import jax.numpy as jnp
 import numpy as np
+import numpy.testing as npt
 import pytest
 from ase.neighborlist import neighbor_list as ase_neighbor_list
 
-from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
+from kups.core.cell import Cell, PeriodicCell, TriclinicFrame, to_lower_triangular
 from kups.core.data.index import Index
 from kups.core.data.table import Table
 from kups.core.neighborlist import (
@@ -69,7 +70,31 @@ def _make_systems(cell: Cell, cutoff: float) -> tuple[Table, Table]:
     return systems, cutoffs
 
 
+def _ensure_lower_triangular(atoms: ase.Atoms) -> ase.Atoms:
+    """Rigidly rotate ``atoms`` so its lattice matrix is lower-triangular.
+
+    ``TriclinicFrame.from_matrix`` projects onto the lower-triangular block
+    (a documented gradient-wrapping behaviour), so an ASE lattice that is
+    not already lower-triangular would be silently truncated. Rotating up
+    front via the same QR reduction kups uses internally
+    (`kups.core.cell.to_lower_triangular`) puts the input on the supported
+    branch and is a no-op for cells that are already lower-triangular.
+    """
+    cell = jnp.asarray(np.asarray(atoms.cell.array))
+    L, uc_transform = to_lower_triangular(cell)
+    rotated_positions = np.asarray(
+        uc_transform(jnp.asarray(np.asarray(atoms.positions)))
+    )
+    out = atoms.copy()
+    out.set_cell(np.asarray(L), scale_atoms=False)
+    out.set_positions(rotated_positions)
+    return out
+
+
 def _atoms_to_cell(atoms: ase.Atoms) -> Cell:
+    """Build a kups ``PeriodicCell`` from an ASE ``Atoms`` whose lattice
+    matrix is lower-triangular. Use ``_ensure_lower_triangular`` to bring
+    arbitrary ASE inputs onto this branch first."""
     lvecs = jnp.asarray(np.asarray(atoms.cell.array))[None]
     return PeriodicCell(TriclinicFrame.from_matrix(lvecs))
 
@@ -107,6 +132,7 @@ def _kups_edges(nl_cls, atoms: ase.Atoms, cutoff: float):
     fails. Returns ``(i, j, displacement)`` for valid (non-padding) directed
     edges.
     """
+    atoms = _ensure_lower_triangular(atoms)
     n = len(atoms)
     state, cutoff_table = _build_state(atoms, cutoff)
 
@@ -134,6 +160,7 @@ def _kups_edges(nl_cls, atoms: ase.Atoms, cutoff: float):
 
 def _ase_edges(atoms: ase.Atoms, cutoff: float):
     """Reference directed edges from ase.neighborlist as (i, j, displacement)."""
+    atoms = _ensure_lower_triangular(atoms)
     i, j, S = ase_neighbor_list("ijS", atoms, float(cutoff))
     pos = np.asarray(atoms.get_positions())
     cell = np.asarray(atoms.cell.array)
@@ -176,6 +203,12 @@ def _make_cu_supercell() -> ase.Atoms:
     return ase.build.bulk("Cu", "fcc", a=3.6, cubic=True).repeat((5, 5, 5))
 
 
+def _make_fcc_primitive_222() -> ase.Atoms:
+    """FCC primitive 2x2x2 — non-lower-triangular ASE lattice, exercises the
+    cell-list path at ``cutoff > perp`` (perpendicular cell width ~4.17 A)."""
+    return ase.build.bulk("Cu", "fcc", a=3.61).repeat((2, 2, 2))
+
+
 def _build_bulk_al() -> ase.Atoms:
     at = ase.build.bulk("Al", "fcc", a=4.05, cubic=True)
     at.rattle(0.5)
@@ -189,7 +222,95 @@ _CASES = [
     ("hcp_Mg", _make_hcp_mg, (2.5, 5.0, 10.0)),
     ("triclinic", _make_triclinic, (3.0, 6.0, 12.0)),
     ("Cu_5x5x5", _make_cu_supercell, (5.0,)),
+    ("fcc_primitive_222", _make_fcc_primitive_222, (3.0, 6.0)),
 ]
+
+
+class TestEnsureLowerTriangular:
+    """``_ensure_lower_triangular`` is a rigid QR rotation that brings the
+    ASE lattice onto the lower-triangular branch required by kups'
+    ``TriclinicFrame``. The bug it guards against is Bug #1b: without
+    pre-rotating, ``TriclinicFrame.from_matrix`` silently *projects* the
+    arbitrary basis matrix onto its lower-triangular block (a documented
+    behaviour used elsewhere for ``∂E/∂h`` gradient wrapping), which for
+    FCC primitive ASE conventions corrupts the cell into a degenerate basis
+    and triggers Bug #2 downstream.
+    """
+
+    def test_rotates_fcc_primitive_to_lower_triangular(self):
+        atoms = ase.build.bulk("Cu", "fcc", a=3.61).repeat((2, 2, 2))
+        # Pre-condition: ASE's FCC primitive lattice is *not* lower-triangular.
+        npt.assert_(
+            not np.allclose(np.triu(np.asarray(atoms.cell.array), k=1), 0.0),
+            "FCC primitive ASE cell is expected to be non-lower-triangular",
+        )
+        rotated = _ensure_lower_triangular(atoms)
+        upper = np.triu(np.asarray(rotated.cell.array), k=1)
+        npt.assert_allclose(upper, 0.0, atol=1e-5)
+
+    def test_no_op_on_already_lower_triangular(self):
+        # Cubic cell is lower-triangular (diagonal). Rotation must be identity
+        # (up to optional sign flips, which keep diag positive by the QR
+        # sign-convention fix in ``to_lower_triangular``).
+        atoms = ase.build.bulk("Cu", "fcc", a=3.6, cubic=True)
+        rotated = _ensure_lower_triangular(atoms)
+        npt.assert_allclose(
+            np.asarray(rotated.cell.array), np.asarray(atoms.cell.array), atol=1e-6
+        )
+        npt.assert_allclose(
+            np.asarray(rotated.positions), np.asarray(atoms.positions), atol=1e-6
+        )
+
+    def test_preserves_volume(self):
+        atoms = ase.build.bulk("Cu", "fcc", a=3.61).repeat((2, 2, 2))
+        v_before = abs(np.linalg.det(np.asarray(atoms.cell.array)))
+        rotated = _ensure_lower_triangular(atoms)
+        v_after = abs(np.linalg.det(np.asarray(rotated.cell.array)))
+        npt.assert_allclose(v_after, v_before, rtol=1e-6)
+
+    def test_preserves_pairwise_distances(self):
+        # A rigid rotation must preserve all pair distances between atoms.
+        atoms = ase.build.bulk("Cu", "fcc", a=3.61).repeat((2, 2, 2))
+        rotated = _ensure_lower_triangular(atoms)
+        p0 = np.asarray(atoms.positions)
+        p1 = np.asarray(rotated.positions)
+        d0 = np.linalg.norm(p0[:, None] - p0[None, :], axis=-1)
+        d1 = np.linalg.norm(p1[:, None] - p1[None, :], axis=-1)
+        npt.assert_allclose(d1, d0, atol=1e-5)
+
+    def test_preserves_periodic_image_distances(self):
+        # ASE neighbor_list on the original atoms and on the rotated atoms
+        # must report the same multiset of pair distances at any cutoff
+        # (only the *direction* of each displacement vector differs).
+        atoms = ase.build.bulk("Cu", "fcc", a=3.61).repeat((2, 2, 2))
+        rotated = _ensure_lower_triangular(atoms)
+        i0, j0, S0 = ase_neighbor_list("ijS", atoms, 6.0)
+        i1, j1, S1 = ase_neighbor_list("ijS", rotated, 6.0)
+        d0 = np.linalg.norm(
+            np.asarray(atoms.positions)[j0]
+            - np.asarray(atoms.positions)[i0]
+            + S0 @ np.asarray(atoms.cell.array),
+            axis=-1,
+        )
+        d1 = np.linalg.norm(
+            np.asarray(rotated.positions)[j1]
+            - np.asarray(rotated.positions)[i1]
+            + S1 @ np.asarray(rotated.cell.array),
+            axis=-1,
+        )
+        npt.assert_allclose(np.sort(d0), np.sort(d1), atol=1e-5)
+
+    def test_atoms_to_cell_produces_finite_perpendicular_lengths(self):
+        # Pre-fix, ``_atoms_to_cell`` on an FCC primitive returned a
+        # degenerate frame with ``perp = [0, NaN, NaN]``. After routing
+        # through ``_ensure_lower_triangular`` the perpendicular lengths
+        # are all finite and positive.
+        atoms = ase.build.bulk("Cu", "fcc", a=3.61).repeat((2, 2, 2))
+        rotated = _ensure_lower_triangular(atoms)
+        cell = _atoms_to_cell(rotated)
+        perp = np.asarray(cell.perpendicular_lengths)
+        npt.assert_(np.all(np.isfinite(perp)), f"perp not finite: {perp}")
+        npt.assert_(np.all(perp > 0), f"perp not strictly positive: {perp}")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes three interconnected bugs that caused incorrect or crashing behavior for non-lower-triangular cell inputs, particularly the FCC primitive 2×2×2 supercell case.

## Bug Fixes

### 1. `to_lower_triangular` rotation direction was inverted

The QR decomposition produces `vecs == L @ Q.T`, meaning the rotation that maps lattice vectors row-by-row into the rows of `L` is right-multiplication by `Q` (i.e., `r_new = r @ Q`). The previous implementation transposed `Q` before returning it, which inverted the rotation direction and caused fractional coordinates to drift whenever the input cell was not already lower-triangular.

### 2. `_cell_hash` could produce out-of-range bin indices

`cell.fold`'s `r % 1` can round up to exactly `1.0` in float arithmetic for inputs slightly below zero. This caused the per-axis bin index to escape `[0, num_cells - 1]`, producing a hash outside `[0, prod(num_cells))` that was then silently dropped by downstream `bincount(length=prod(num_cells))` segment counts, causing atoms to lose all their neighbor candidates.

The fix clamps the bin index with `jnp.clip` and switches the stride computation from `/` to `//` to avoid float precision issues.

### 3. `_get_candidate_images` propagated non-finite ratios into integer image counts

When a cell has a zero or NaN perpendicular length, `cutoff / perp` produces `inf` or `NaN`. Previously the finiteness guard checked `cutoffs` directly rather than the computed `ratio`, so `ceil(inf).astype(int)` wrapped to `INT32_MAX`. This value then propagated through the capacity resize loop and caused a static shape overflow (`OverflowError: 17179869176 out of bounds for int32`) at JAX trace time. The fix computes `ratio` once and applies the `isfinite` guard to it.

## Supporting Changes

- Added `_ensure_lower_triangular` helper in the ASE test utilities to rigidly rotate arbitrary ASE lattices into the lower-triangular convention required by `TriclinicFrame` before passing them to kups, preventing silent projection/truncation of the basis matrix.
- Added the FCC primitive 2×2×2 case to the parametrized neighbor list test suite.
- Added regression tests covering all three bug paths, including direct unit tests for `_cell_hash` boundary clamping, `_get_candidate_images` finite-guard behavior, and fractional-coordinate preservation through `to_lower_triangular`.