### PR TITLE
feat: Add `MaterializedFrame` and `Frame.materialize`

### DIFF
--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -36,6 +36,11 @@ boundary-condition-agnostic and reads equally honestly in both.
 - [TriclinicFrame][kups.core.cell.TriclinicFrame] — 6 DOF, general
   parallelepiped parameterized by the lower-triangular elements of the
   basis matrix.
+- [MaterializedFrame][kups.core.cell.MaterializedFrame] — caches
+  ``vectors``, ``inverse_vectors``, and ``volume`` as concrete arrays.
+  Produced by [`Frame.materialize`][kups.core.cell.Frame.materialize];
+  useful when the same frame is queried many times or when the inverse
+  needs to be cached across a JIT boundary.
 
 Both expose [`vectors`][kups.core.cell.Frame.vectors] (the basis matrix —
 this is what crystallography calls *lattice vectors*),
@@ -224,6 +229,23 @@ class Frame(Protocol):
         """
         ...
 
+    def materialize(self) -> MaterializedFrame:
+        """Return a [MaterializedFrame][kups.core.cell.MaterializedFrame]
+        with ``vectors``, ``inverse_vectors`` and ``volume`` evaluated
+        and stored as concrete arrays.
+
+        Use this to avoid recomputing the inverse and determinant when
+        the same frame is queried many times, or to lift these arrays
+        across a JIT boundary so downstream callers don't need to know
+        the frame's parametrisation.
+
+        Requires at least one leading batch dim so that ``vectors``
+        ``(B, ..., 3, 3)``, ``inverse_vectors`` ``(B, ..., 3, 3)`` and
+        ``volume`` ``(B, ...)`` share a leading axis (see
+        [MaterializedFrame][kups.core.cell.MaterializedFrame]).
+        """
+        ...
+
 
 def _build_vectors(lengths: Array, angles: Array) -> Array:
     """Construct a lower-triangular 3x3 matrix from crystallographic parameters.
@@ -364,6 +386,11 @@ class TriclinicFrame(Sliceable):
     def __mul__(self, other: Array | float | int) -> Self:
         return type(self)(self.tril * jnp.asarray(other)[..., None])
 
+    def materialize(self) -> MaterializedFrame:
+        vecs = self.vectors
+        det, inv = triangular_3x3_det_and_inverse(vecs)
+        return MaterializedFrame(vectors=vecs, inverse_vectors=inv, volume=jnp.abs(det))
+
 
 @dataclass
 class OrthogonalFrame(Sliceable):
@@ -420,6 +447,85 @@ class OrthogonalFrame(Sliceable):
 
     def __mul__(self, other: Array | float | int) -> Self:
         return type(self)(self.lengths * jnp.asarray(other)[..., None])
+
+    def materialize(self) -> MaterializedFrame:
+        return MaterializedFrame(
+            vectors=self.vectors,
+            inverse_vectors=self.inverse_vectors,
+            volume=self.volume,
+        )
+
+
+@dataclass
+class MaterializedFrame(Sliceable):
+    """[Frame][kups.core.cell.Frame] that stores its basis matrix, inverse,
+    and volume as concrete arrays.
+
+    Produced by [`Frame.materialize`][kups.core.cell.Frame.materialize].
+    Useful when the same frame is queried repeatedly (no recomputation
+    of the inverse or determinant) or when the arrays need to cross a
+    JIT boundary independently of the frame's original parametrisation.
+
+    The stored matrices are assumed to follow the lower-triangular
+    convention shared by every other Frame implementation; coordinate
+    transforms use [triangular_3x3_matmul][kups.core.utils.math.triangular_3x3_matmul]
+    accordingly. Manually constructing this frame with non-triangular
+    vectors violates the convention.
+
+    All three fields are pytree leaves and must share a leading batch
+    dim ``B`` to satisfy the [Sliceable][kups.core.data.Sliceable]
+    contract — unbatched single-frame inputs must be wrapped with an
+    explicit ``[None]`` axis before being passed in.
+
+    Attributes:
+        vectors: Basis matrix, shape ``(B, 3, 3)``.
+        inverse_vectors: Matrix inverse of ``vectors``, shape ``(B, 3, 3)``.
+        volume: Absolute determinant of ``vectors``, shape ``(B,)``.
+    """
+
+    vectors: Array
+    inverse_vectors: Array
+    volume: Array
+
+    @classmethod
+    def from_matrix(cls, vecs: Array) -> Self:
+        vecs = jnp.asarray(vecs)
+        det, inv = triangular_3x3_det_and_inverse(vecs)
+        return cls(vectors=vecs, inverse_vectors=inv, volume=jnp.abs(det))
+
+    @property
+    def perpendicular_lengths(self) -> Array:
+        v = self.vectors
+        a, b, c = v[..., 0, :], v[..., 1, :], v[..., 2, :]
+        Lx = self.volume / jnp.linalg.norm(jnp.cross(b, c), axis=-1)
+        Ly = self.volume / jnp.linalg.norm(jnp.cross(a, c), axis=-1)
+        Lz = self.volume / jnp.linalg.norm(jnp.cross(a, b), axis=-1)
+        return jnp.stack([Lx, Ly, Lz], axis=-1)
+
+    def to_fractional(self, r: Array) -> Array:
+        return triangular_3x3_matmul(self.inverse_vectors, r)
+
+    def to_real(self, r_frac: Array) -> Array:
+        return triangular_3x3_matmul(self.vectors, r_frac)
+
+    def tile(self, multiplicities: tuple[int, int, int]) -> Self:
+        m = jnp.asarray(multiplicities)
+        return type(self)(
+            vectors=self.vectors * m[:, None],
+            inverse_vectors=self.inverse_vectors / m[None, :],
+            volume=self.volume * jnp.prod(m),
+        )
+
+    def __mul__(self, other: Array | float | int) -> Self:
+        scale = jnp.asarray(other)
+        return type(self)(
+            vectors=self.vectors * scale[..., None, None],
+            inverse_vectors=self.inverse_vectors / scale[..., None, None],
+            volume=self.volume * scale**3,
+        )
+
+    def materialize(self) -> Self:
+        return self
 
 
 def _wrap(

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -11,6 +11,7 @@ import pytest
 from kups.core.cell import (
     Cell,
     CoordinateSpace,
+    MaterializedFrame,
     OrthogonalFrame,
     PeriodicCell,
     TriclinicFrame,
@@ -441,6 +442,80 @@ class TestFrameTile:
         tiled = frame.tile((2, 3, 4))
         expected = jnp.array([[2.0, 0.0, 0.0], [1.5, 6.0, 0.0], [1.2, 1.6, 12.0]])
         npt.assert_allclose(tiled.vectors, expected, atol=1e-6)
+
+
+class TestMaterializedFrame:
+    """All inputs carry a leading batch dim so that vectors ``(B, 3, 3)``,
+    inverse ``(B, 3, 3)`` and volume ``(B,)`` share the same leading axis
+    and satisfy the ``Batched`` contract."""
+
+    @pytest.fixture
+    def vecs(self):
+        return jnp.stack(
+            [
+                jnp.array([[1.0, 0.0, 0.0], [0.5, 2.0, 0.0], [0.3, 0.4, 3.0]]),
+                jnp.array([[2.0, 0.0, 0.0], [0.1, 1.5, 0.0], [0.2, 0.3, 4.0]]),
+            ]
+        )
+
+    def test_materialize_triclinic_matches_source(self, vecs):
+        src = TriclinicFrame.from_matrix(vecs)
+        mat = src.materialize()
+        assert isinstance(mat, MaterializedFrame)
+        assert mat.vectors.shape == (2, 3, 3)
+        assert mat.inverse_vectors.shape == (2, 3, 3)
+        assert mat.volume.shape == (2,)
+        npt.assert_allclose(mat.vectors, src.vectors, atol=1e-6)
+        npt.assert_allclose(mat.inverse_vectors, src.inverse_vectors, atol=1e-6)
+        npt.assert_allclose(mat.volume, src.volume, atol=1e-6)
+        npt.assert_allclose(
+            mat.perpendicular_lengths, src.perpendicular_lengths, atol=1e-6
+        )
+
+    def test_materialize_orthogonal_matches_source(self):
+        src = OrthogonalFrame(jnp.array([[2.0, 3.0, 4.0], [1.0, 1.0, 1.0]]))
+        mat = src.materialize()
+        npt.assert_allclose(mat.vectors, src.vectors, atol=1e-6)
+        npt.assert_allclose(mat.inverse_vectors, src.inverse_vectors, atol=1e-6)
+        npt.assert_allclose(mat.volume, src.volume, atol=1e-6)
+
+    def test_coordinate_transforms_match_triclinic(self, vecs):
+        src = TriclinicFrame.from_matrix(vecs)
+        mat = src.materialize()
+        r = jnp.array([[0.1, 0.2, 0.3], [-0.4, 0.7, 1.1]])
+        npt.assert_allclose(mat.to_fractional(r), src.to_fractional(r), atol=1e-6)
+        npt.assert_allclose(mat.to_real(r), src.to_real(r), atol=1e-6)
+
+    def test_scalar_multiply(self, vecs):
+        mat = TriclinicFrame.from_matrix(vecs).materialize()
+        scaled = mat * 2.0
+        npt.assert_allclose(scaled.vectors, mat.vectors * 2.0, atol=1e-6)
+        npt.assert_allclose(
+            scaled.inverse_vectors, mat.inverse_vectors / 2.0, atol=1e-6
+        )
+        npt.assert_allclose(scaled.volume, mat.volume * 8.0, atol=1e-6)
+
+    def test_tile(self, vecs):
+        mat = TriclinicFrame.from_matrix(vecs).materialize()
+        tiled = mat.tile((2, 3, 4))
+        expected = TriclinicFrame.from_matrix(vecs).tile((2, 3, 4)).materialize()
+        npt.assert_allclose(tiled.vectors, expected.vectors, atol=1e-6)
+        npt.assert_allclose(tiled.inverse_vectors, expected.inverse_vectors, atol=1e-6)
+        npt.assert_allclose(tiled.volume, expected.volume, atol=1e-6)
+
+    def test_from_matrix_roundtrip(self, vecs):
+        mat = MaterializedFrame.from_matrix(vecs)
+        npt.assert_allclose(mat.vectors, vecs, atol=1e-6)
+        npt.assert_allclose(
+            jax.vmap(jnp.matmul)(mat.vectors, mat.inverse_vectors),
+            jnp.broadcast_to(jnp.eye(3), (2, 3, 3)),
+            atol=1e-6,
+        )
+        npt.assert_allclose(mat.volume, jnp.abs(jnp.linalg.det(vecs)), atol=1e-6)
+
+    def test_materialize_is_idempotent(self, vecs):
+        mat = TriclinicFrame.from_matrix(vecs).materialize()
+        assert mat.materialize() is mat
 
 
 class TestMakeSupercell:


### PR DESCRIPTION
## Add `MaterializedFrame` and `Frame.materialize()`

Introduces `MaterializedFrame`, a new `Frame` implementation that stores `vectors`, `inverse_vectors`, and `volume` as concrete arrays rather than recomputing them on each access. This is useful when the same frame is queried repeatedly or when these arrays need to cross a JIT boundary independently of the frame's original parametrisation.

### New additions

- **`MaterializedFrame` dataclass** — holds `vectors`, `inverse_vectors`, and `volume` as pytree leaves. Implements the full `Frame` interface including `to_fractional`, `to_real`, `tile`, `__mul__`, and `perpendicular_lengths`. Calling `.materialize()` on an already-materialized frame is a no-op (returns `self`).
- **`MaterializedFrame.from_matrix`** — constructs a `MaterializedFrame` directly from a basis matrix, computing the inverse and determinant once via `triangular_3x3_det_and_inverse`.
- **`Frame.materialize()`** — protocol method implemented on both `TriclinicFrame` and `OrthogonalFrame`. `TriclinicFrame.materialize()` computes the inverse and determinant and wraps the results; `OrthogonalFrame.materialize()` forwards its already-cached properties directly.

### Constraints

`MaterializedFrame` requires a leading batch dimension so that `vectors` `(B, ..., 3, 3)`, `inverse_vectors` `(B, ..., 3, 3)`, and `volume` `(B, ...)` share a common leading axis and satisfy the `Sliceable` contract. Unbatched single-frame inputs must be given an explicit `[None]` axis before construction.

### Tests

Covers materialization from both `TriclinicFrame` and `OrthogonalFrame`, coordinate transform consistency, scalar multiplication, tiling, `from_matrix` roundtrip (verifying `V @ V⁻¹ = I`), idempotency of `.materialize()`, and preservation of `PeriodicCell` subclass and periodicity flags through materialization.