### PR TITLE
refactor: Decompose neighbor list into Pipeline of selector → masks → compactor

### DIFF
--- a/src/kups/core/neighborlist/__init__.py
+++ b/src/kups/core/neighborlist/__init__.py
@@ -11,7 +11,7 @@ accuracy trade-offs.
 
 - **[Edges][kups.core.neighborlist.Edges]**: Represents connections between particles with periodic shifts
 - **[NearestNeighborList][kups.core.neighborlist.NearestNeighborList]**: Protocol for neighbor search implementations
-- **[RefineMaskNeighborList][kups.core.neighborlist.RefineMaskNeighborList]**: Applies inclusion/exclusion masks for selective interactions
+- **[Pipeline][kups.core.neighborlist.Pipeline]**: Selector → mask sequence → compactor
 
 ## Neighbor List Implementations
 
@@ -21,13 +21,10 @@ accuracy trade-offs.
     - O(N) complexity using spatial hashing
     - Best when cutoff / box_size < 0.3 (cutoff much smaller than box)
     - Honors the cell's per-axis ``periodic`` mask (bulk and bounded non-periodic)
-    - Efficiency improves as cutoff/box ratio decreases
 
 2. **[DenseNearestNeighborList][kups.core.neighborlist.DenseNearestNeighborList]**
     - O(N²/K) complexity (K = number of systems)
     - Best when cutoff / box_size ~ 1 (cutoff comparable to box)
-    - Works with or without periodic boundaries
-    - More efficient when few cells would fit in box
 
 3. **[AllDenseNearestNeighborList][kups.core.neighborlist.AllDenseNearestNeighborList]**
     - O(N²) complexity across all systems
@@ -36,85 +33,109 @@ accuracy trade-offs.
 
 ### Refinement Implementations
 
-These allow sharing a single base neighbor list across multiple potentials
-with different cutoffs or interaction rules (e.g., Lennard-Jones and Coulomb).
+These let one expensive base neighbor list be shared across multiple potentials.
 
-4. **[RefineMaskNeighborList][kups.core.neighborlist.RefineMaskNeighborList]**
-    - Applies inclusion/exclusion masks to precomputed edges
-    - Use for bonded exclusions or group-specific interactions
-    - No distance recalculation
-    - Share one neighbor list, apply different masks per potential
+4. **[RefineMaskNeighborList][kups.core.neighborlist.RefineMaskNeighborList]**:
+   apply different inclusion/exclusion masks to precomputed edges.
+5. **[RefineCutoffNeighborList][kups.core.neighborlist.RefineCutoffNeighborList]**:
+   refine precomputed edges with new cutoff distances.
 
-5. **[RefineCutoffNeighborList][kups.core.neighborlist.RefineCutoffNeighborList]**
-    - Refines precomputed edges with new cutoff distances
-    - Use for multi-stage construction or adaptive cutoffs
-    - Recalculates distances
-    - Share one conservative neighbor list, apply different cutoffs per potential
+## Pipeline Primitives
 
-## Features
-
-All neighbor lists handle:
-- Per-axis periodic / non-periodic boundaries via the cell's ``periodic`` mask
-  (shift vectors are zero on non-periodic axes)
-- Multiple systems in parallel with segmentation
-- Automatic capacity management for variable neighbor counts
-- Integration with JAX transformations (JIT, vmap, etc.)
+Every neighbor list above is a [`Pipeline`][kups.core.neighborlist.Pipeline]
+of a [`CandidateSelector`][kups.core.neighborlist.CandidateSelector], a
+``tuple`` of [`Mask`][kups.core.neighborlist.Mask] criteria, and a
+[`Compactor`][kups.core.neighborlist.Compactor]. Users wanting custom
+behavior can compose their own pipeline directly.
 """
 
-from kups.core.neighborlist.all_connected import all_connected_neighborlist
+from kups.core.neighborlist.all_connected import (
+    InclusionGroupSelector,
+    all_connected_neighborlist,
+)
 from kups.core.neighborlist.all_dense import (
     AllDenseNearestNeighborList,
+    AllDenseSelector,
     IsAllDenseNeighborListParams,
 )
 from kups.core.neighborlist.cell_list import (
     CellListNeighborList,
+    CellListSelector,
     IsCellListParams,
 )
 from kups.core.neighborlist.changes import (
     NeighborListChangesResult,
     neighborlist_changes,
 )
-from kups.core.neighborlist.common import (
-    CandidateSelector,
-    basic_neighborlist,
-)
+from kups.core.neighborlist.compact import MaskOnlyCompactor, ReduceCompactor
 from kups.core.neighborlist.dense import (
     DenseNearestNeighborList,
+    DenseSelector,
     IsDenseNeighborlistParams,
 )
 from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.masks import (
+    DistanceCutoffMask,
+    ExclusionMask,
+    InBoundsMask,
+    InclusionMatchMask,
+    RemapDedupMask,
+)
 from kups.core.neighborlist.parameters import UniversalNeighborlistParameters
+from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.refine import (
+    PrecomputedEdgesSelector,
     RefineCutoffNeighborList,
     RefineMaskNeighborList,
 )
 from kups.core.neighborlist.types import (
+    CandidateBatch,
+    CandidateSelector,
+    Compactor,
     IsNeighborListState,
     IsUniversalNeighborlistParams,
+    Mask,
     NearestNeighborList,
     NeighborListPoints,
     NeighborListSystems,
+    PipelineContext,
 )
 
 __all__ = [
     "AllDenseNearestNeighborList",
+    "AllDenseSelector",
+    "CandidateBatch",
     "CandidateSelector",
     "CellListNeighborList",
+    "CellListSelector",
+    "Compactor",
     "DenseNearestNeighborList",
+    "DenseSelector",
+    "DistanceCutoffMask",
     "Edges",
+    "ExclusionMask",
+    "InBoundsMask",
+    "InclusionGroupSelector",
+    "InclusionMatchMask",
     "IsAllDenseNeighborListParams",
     "IsCellListParams",
     "IsDenseNeighborlistParams",
     "IsNeighborListState",
     "IsUniversalNeighborlistParams",
+    "Mask",
+    "MaskOnlyCompactor",
     "NearestNeighborList",
     "NeighborListChangesResult",
     "NeighborListPoints",
     "NeighborListSystems",
+    "Pipeline",
+    "PipelineContext",
+    "PrecomputedEdgesSelector",
+    "ReduceCompactor",
     "RefineCutoffNeighborList",
     "RefineMaskNeighborList",
+    "RemapDedupMask",
     "UniversalNeighborlistParameters",
     "all_connected_neighborlist",
-    "basic_neighborlist",
     "neighborlist_changes",
 ]

--- a/src/kups/core/neighborlist/all_connected.py
+++ b/src/kups/core/neighborlist/all_connected.py
@@ -16,13 +16,56 @@ from typing import Literal
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.capacity import FixedCapacity
+from kups.core.capacity import Capacity, FixedCapacity
 from kups.core.data import Index, Table, subselect
-from kups.core.neighborlist.common import _Candidates, _compact_edges
+from kups.core.neighborlist.common import Candidates, candidates_to_batch
+from kups.core.neighborlist.compact import ReduceCompactor
 from kups.core.neighborlist.edges import Edges
-from kups.core.neighborlist.types import NeighborListPoints, NeighborListSystems
+from kups.core.neighborlist.masks import ExclusionMask, RemapDedupMask
+from kups.core.neighborlist.pipeline import Pipeline
+from kups.core.neighborlist.types import (
+    CandidateBatch,
+    NeighborListPoints,
+    NeighborListSystems,
+    PipelineContext,
+)
 from kups.core.typing import ParticleId, SystemId
-from kups.core.utils.math import triangular_3x3_matmul
+from kups.core.utils.jax import dataclass
+
+
+@dataclass
+class InclusionGroupSelector:
+    """Pairs every particle with every other in the same inclusion segment.
+
+    Ignores the cutoff entirely. Shifts are int-typed minimum-image
+    fractional rounds — matches today's ``all_connected_neighborlist``
+    (which is Ewald-only and assumed fully periodic).
+    """
+
+    capacity: Capacity[int]
+
+    def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
+        ngraphs = ctx.lh.data.inclusion.num_labels
+        selection_result = subselect(
+            ctx.lh.data.inclusion.indices,
+            ctx.rh.data.inclusion.indices,
+            output_buffer_size=self.capacity,
+            num_segments=ngraphs,
+        )
+        candidates = Candidates(
+            lhs=Index(ctx.lh.keys, selection_result.scatter_idxs),
+            rhs=Index(ctx.rh.keys, selection_result.gather_idxs),
+        )
+        deltas = (
+            ctx.lh.data.positions[candidates.lhs.indices]
+            - ctx.rh.data.positions[candidates.rhs.indices]
+        )
+        shifts = jnp.round(deltas).astype(int)
+        return candidates_to_batch(
+            candidates,
+            shifts,
+            jnp.ones((candidates.lhs.size,), dtype=bool),
+        )
 
 
 def all_connected_neighborlist(
@@ -44,41 +87,13 @@ def all_connected_neighborlist(
         rh = lh
         rh_index_remap = Index.arange(len(lh), label=ParticleId)
 
-    ngraphs = lh.data.inclusion.num_labels
     max_count = lh.data.inclusion.max_count
     assert max_count is not None, "inclusion.max_count must be set"
     capacity = FixedCapacity(max_count).multiply(min(lh.size, rh.size))
-    out_of_bounds = max(lh.size, rh.size)
 
-    lh_sys = systems[lh.data.system]
-    rh_sys = systems[rh.data.system]
-
-    selection_result = subselect(
-        lh.data.inclusion.indices,
-        rh.data.inclusion.indices,
-        output_buffer_size=capacity,
-        num_segments=ngraphs,
+    pipeline = Pipeline[Literal[2]](
+        selector=InclusionGroupSelector(capacity=capacity),
+        masks=(ExclusionMask(), RemapDedupMask()),
+        compactor=ReduceCompactor(avg_edges=capacity),
     )
-    candidates = _Candidates(
-        lhs=Index(lh.keys, selection_result.scatter_idxs),
-        rhs=Index(rh.keys, selection_result.gather_idxs),
-    )
-    lh_idx, rh_idx = candidates.lhs, candidates.rhs
-    lh_data, rh_data = lh[lh_idx], rh[rh_idx]
-    lh_excl, rh_excl = Index.match(lh_data.exclusion, rh_data.exclusion)
-    mask = lh_excl != rh_excl
-    if rh_index_remap is not None:
-        lh_i, rh_i = Index.match(lh_idx, rh.set_data(rh_index_remap)[rh_idx])
-        mask &= ~lh_idx.isin(rh_index_remap) | (lh_i >= rh_i)
-
-    lh_frac = triangular_3x3_matmul(lh_sys.cell.inverse_vectors, lh.data.positions)
-    rh_frac = triangular_3x3_matmul(rh_sys.cell.inverse_vectors, rh.data.positions)
-    shifts = jnp.round(lh_frac[lh_idx.indices] - rh_frac[rh_idx.indices]).astype(int)
-    return _compact_edges(
-        candidates,
-        mask,
-        shifts,
-        rh_index_remap.indices_in(lh.keys) if rh_index_remap is not None else None,
-        capacity,
-        out_of_bounds,
-    )
+    return pipeline(lh, rh, systems, rh_index_remap)

--- a/src/kups/core/neighborlist/all_dense.py
+++ b/src/kups/core/neighborlist/all_dense.py
@@ -14,12 +14,23 @@ from jax import Array
 from kups.core.capacity import Capacity, LensCapacity
 from kups.core.data import Index, Table
 from kups.core.lens import Lens, lens
-from kups.core.neighborlist.common import _Candidates, basic_neighborlist
+from kups.core.neighborlist.common import Candidates, replicate_for_images
+from kups.core.neighborlist.compact import ReduceCompactor
 from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.masks import (
+    DistanceCutoffMask,
+    ExclusionMask,
+    InBoundsMask,
+    InclusionMatchMask,
+    RemapDedupMask,
+)
+from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.types import (
+    CandidateBatch,
     IsNeighborListState,
     NeighborListPoints,
     NeighborListSystems,
+    PipelineContext,
 )
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass, jit
@@ -38,9 +49,28 @@ def _all_subselect(
     lh: Table[ParticleId, NeighborListPoints],
     rh: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
-) -> _Candidates:
+) -> Candidates:
     lh_indices, rh_indices = jnp.indices((len(lh), len(rh))).reshape(2, -1)
-    return _Candidates(lhs=Index(lh.keys, lh_indices), rhs=Index(rh.keys, rh_indices))
+    return Candidates(lhs=Index(lh.keys, lh_indices), rhs=Index(rh.keys, rh_indices))
+
+
+@dataclass
+class AllDenseSelector:
+    """Selector that emits every ``(i, j)`` pair across all systems."""
+
+    cutoffs: Table[SystemId, Array]
+    max_image_candidates: Capacity[int]
+
+    def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
+        candidates = _all_subselect(ctx.lh, ctx.rh, ctx.systems)
+        return replicate_for_images(
+            candidates,
+            ctx.lh,
+            ctx.rh,
+            ctx.systems,
+            self.cutoffs,
+            self.max_image_candidates,
+        )
 
 
 @dataclass
@@ -111,15 +141,19 @@ class AllDenseNearestNeighborList:
                 "Consider using DenseNearestNeighborList or CellListNeighborList instead."
             )
         rh_size = rh.size if rh is not None else lh.size
-        return basic_neighborlist(
-            lh,
-            rh,
-            systems,
-            cutoffs,
-            rh_index_remap,
-            candidate_selector=_all_subselect,
-            max_num_edges=self.avg_edges.multiply(rh_size),
-            max_image_candidates=self.avg_image_candidates.multiply(rh_size)
-            if self.avg_image_candidates
-            else None,
+        cutoffs = Table.broadcast_to(cutoffs, systems)
+        pipeline = Pipeline[Literal[2]](
+            selector=AllDenseSelector(
+                cutoffs=cutoffs,
+                max_image_candidates=self.avg_image_candidates.multiply(rh_size),
+            ),
+            masks=(
+                InBoundsMask(),
+                InclusionMatchMask(),
+                RemapDedupMask(),
+                DistanceCutoffMask(cutoffs=cutoffs),
+                ExclusionMask(),
+            ),
+            compactor=ReduceCompactor(avg_edges=self.avg_edges.multiply(rh_size)),
         )
+        return pipeline(lh, rh, systems, rh_index_remap)

--- a/src/kups/core/neighborlist/cell_list.py
+++ b/src/kups/core/neighborlist/cell_list.py
@@ -15,12 +15,27 @@ from jax import Array
 from kups.core.capacity import Capacity, LensCapacity
 from kups.core.data import Index, Table, subselect
 from kups.core.lens import Lens, lens
-from kups.core.neighborlist.common import _Candidates, _num_cells, basic_neighborlist
+from kups.core.neighborlist.common import (
+    Candidates,
+    num_cells,
+    replicate_for_images,
+)
+from kups.core.neighborlist.compact import ReduceCompactor
 from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.masks import (
+    DistanceCutoffMask,
+    ExclusionMask,
+    InBoundsMask,
+    InclusionMatchMask,
+    RemapDedupMask,
+)
+from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.types import (
+    CandidateBatch,
     IsNeighborListState,
     NeighborListPoints,
     NeighborListSystems,
+    PipelineContext,
 )
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass, jit
@@ -64,14 +79,14 @@ def _cell_list_subselect(
     cutoffs: Array,
     max_num_cells: Capacity[int],
     max_num_candidates: Capacity[int],
-) -> _Candidates:
+) -> Candidates:
     cell = systems.data.cell
     key_positions, _ = cell.fold(lh.data.positions)
     query_positions, _ = cell.fold(rh.data.positions)
 
-    num_cells = systems.map_data(partial(_num_cells, cutoff=cutoffs))
+    bins = systems.map_data(partial(num_cells, cutoff=cutoffs))
     max_num_cells = max_num_cells.generate_assertion(
-        jnp.max(jnp.prod(num_cells.data, axis=-1))
+        jnp.max(jnp.prod(bins.data, axis=-1))
     )
     num_systems = systems.size
     cell_oob = max_num_cells.size * num_systems
@@ -87,21 +102,21 @@ def _cell_list_subselect(
     rh_system_ids = rh.data.system.indices
 
     key_hashes = (
-        _cell_hash(key_positions, num_cells[lh.data.system])
+        _cell_hash(key_positions, bins[lh.data.system])
         + lh_system_ids * max_num_cells.size
     )
 
     # Expand neighborhood around query points: for each query, tile across stencil
     stencil = _cell_stencil(dim)
-    raw_shifted = jax.vmap(
-        lambda s: query_positions + s[None] / num_cells[rh.data.system]
-    )(stencil).reshape(-1, dim)
+    raw_shifted = jax.vmap(lambda s: query_positions + s[None] / bins[rh.data.system])(
+        stencil
+    ).reshape(-1, dim)
     query_original = Index(rh.keys, jnp.tile(jnp.arange(len(rh)), len(stencil)))
     query_system = rh.data.system[query_original.indices]
 
     shifted, in_cell = cell.fold(raw_shifted)
     hashes = (
-        _cell_hash(shifted, num_cells[query_system])
+        _cell_hash(shifted, bins[query_system])
         + rh_system_ids[query_original.indices] * max_num_cells.size
     )
     # Stencil offsets that left the box on a non-periodic axis route to
@@ -133,7 +148,39 @@ def _cell_list_subselect(
             **query_original.scatter_args
         ),
     )
-    return _Candidates(lhs=lhs, rhs=rhs)
+    return Candidates(lhs=lhs, rhs=rhs)
+
+
+@dataclass
+class CellListSelector:
+    """Selector for the cell-list algorithm.
+
+    Calls the raw spatial-hash candidate emission, then replicates per image
+    multiplicity when ``max(cutoff/perp) > 0.5``.
+    """
+
+    cutoffs: Table[SystemId, Array]
+    max_cells: Capacity[int]
+    max_candidates: Capacity[int]
+    max_image_candidates: Capacity[int]
+
+    def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
+        candidates = _cell_list_subselect(
+            ctx.lh,
+            ctx.rh,
+            ctx.systems,
+            cutoffs=self.cutoffs.data,
+            max_num_cells=self.max_cells,
+            max_num_candidates=self.max_candidates,
+        )
+        return replicate_for_images(
+            candidates,
+            ctx.lh,
+            ctx.rh,
+            ctx.systems,
+            self.cutoffs,
+            self.max_image_candidates,
+        )
 
 
 @dataclass
@@ -220,18 +267,21 @@ class CellListNeighborList:
         rh_index_remap: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
         rh_size = rh.size if rh is not None else lh.size
-        return basic_neighborlist(
-            lh,
-            rh,
-            systems,
-            cutoffs,
-            rh_index_remap,
-            candidate_selector=partial(
-                _cell_list_subselect,
-                cutoffs=cutoffs.data,
-                max_num_cells=self.cells,
-                max_num_candidates=self.avg_candidates.multiply(rh_size),
+        cutoffs = Table.broadcast_to(cutoffs, systems)
+        pipeline = Pipeline[Literal[2]](
+            selector=CellListSelector(
+                cutoffs=cutoffs,
+                max_cells=self.cells,
+                max_candidates=self.avg_candidates.multiply(rh_size),
+                max_image_candidates=self.avg_image_candidates.multiply(rh_size),
             ),
-            max_num_edges=self.avg_edges.multiply(rh_size),
-            max_image_candidates=self.avg_image_candidates.multiply(rh_size),
+            masks=(
+                InBoundsMask(),
+                InclusionMatchMask(),
+                RemapDedupMask(),
+                DistanceCutoffMask(cutoffs=cutoffs),
+                ExclusionMask(),
+            ),
+            compactor=ReduceCompactor(avg_edges=self.avg_edges.multiply(rh_size)),
         )
+        return pipeline(lh, rh, systems, rh_index_remap)

--- a/src/kups/core/neighborlist/common.py
+++ b/src/kups/core/neighborlist/common.py
@@ -1,23 +1,30 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
-"""Algorithmic core of the neighbor list module.
+"""Shared algorithmic helpers for neighbor list selectors and masks.
 
-Provides the [`basic_neighborlist`][kups.core.neighborlist.common.basic_neighborlist]
-engine and the shared helpers (candidate selection, distance/PBC filtering,
-periodic-image expansion, edge compaction) that every concrete neighbor list
-implementation composes.
+Contains:
 
-The public-facing implementations (``CellListNeighborList``,
-``DenseNearestNeighborList``, ``AllDenseNearestNeighborList``,
-``RefineCutoffNeighborList``) all delegate to ``basic_neighborlist`` with
-different
-[`CandidateSelector`][kups.core.neighborlist.common.CandidateSelector] strategies.
+- ``num_cells`` — per-axis spatial bin counts (used by the cell-list
+  selector and by ``parameters.estimate``).
+- ``Candidates`` — private intermediate struct used inside individual
+  selector algorithms while raw ``(lhs, rhs)`` index arrays are being built.
+  Not the pipeline carrier (see
+  [`CandidateBatch`][kups.core.neighborlist.types.CandidateBatch]).
+- ``_generate_image_offsets``, ``_get_candidate_images`` — image-expansion
+  primitives.
+- ``replicate_for_images`` — adapts raw ``Candidates`` into a
+  ``CandidateBatch`` with shifts and ``is_minimum_image`` set, replicating
+  per image multiplicity when ``cutoff > perp/2``.
+- ``make_batch_with_mic`` — pack raw candidates with minimum-image shifts
+  and ``is_minimum_image=all-True`` (used by selectors that don't replicate).
+- ``real_distance_sq`` — squared real-space distance between candidate
+  pairs given fractional shifts; used by ``DistanceCutoffMask``.
 """
 
 from __future__ import annotations
 
-from typing import Literal, Protocol
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -27,13 +34,16 @@ from kups.core.capacity import Capacity, FixedCapacity
 from kups.core.data import Index, Table
 from kups.core.lens import bind
 from kups.core.neighborlist.edges import Edges
-from kups.core.neighborlist.types import NeighborListPoints, NeighborListSystems
+from kups.core.neighborlist.types import (
+    CandidateBatch,
+    NeighborListPoints,
+    NeighborListSystems,
+)
 from kups.core.typing import ParticleId, SystemId
-from kups.core.utils.jax import dataclass, isin
-from kups.core.utils.math import triangular_3x3_matmul
+from kups.core.utils.jax import dataclass
 
 
-def _num_cells(
+def num_cells(
     systems: NeighborListSystems,
     cutoff: Array,
     *,
@@ -46,18 +56,16 @@ def _num_cells(
 
 
 @dataclass
-class _Candidates:
+class Candidates:
+    """Private intermediate produced inside selector algorithms.
+
+    Not the pipeline carrier — selectors convert ``Candidates`` into a
+    ``CandidateBatch`` (via ``replicate_for_images`` or
+    ``make_batch_with_mic``) before returning.
+    """
+
     lhs: Index[ParticleId]
     rhs: Index[ParticleId]
-
-
-class CandidateSelector(Protocol):
-    def __call__(
-        self,
-        lh: Table[ParticleId, NeighborListPoints],
-        rh: Table[ParticleId, NeighborListPoints],
-        systems: Table[SystemId, NeighborListSystems],
-    ) -> _Candidates: ...
 
 
 def _generate_image_offsets(images: jax.Array, out_size: Capacity[int]) -> jax.Array:
@@ -137,7 +145,7 @@ def _candidate_image_counts(cells, cutoffs: Array) -> Array:
 
 
 def _get_candidate_images(
-    candidates: _Candidates,
+    candidates: Candidates,
     lh: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
     cutoffs: Array,
@@ -169,141 +177,78 @@ def _get_candidate_images(
     return idx, offsets, has_been_replicated
 
 
-def _build_segmentation_mask(
-    candidates: _Candidates,
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints],
-    rh_index_remap: Array | None,
-    out_of_bounds: int,
-) -> Array:
-    """Build a mask based on segmentation constraints."""
-    ngraphs = lh.data.inclusion.num_labels
-    lh_idx = candidates.lhs.indices
-    rh_idx = candidates.rhs.indices
-    rh_idx_out = (
-        rh_index_remap.at[rh_idx].get(mode="fill", fill_value=out_of_bounds)
-        if rh_index_remap is not None
-        else rh_idx
-    )
-    lh_incl = lh.data.inclusion.indices[lh_idx]
-    rh_incl = rh.data.inclusion.indices[rh_idx]
-
-    mask = lh_incl == rh_incl
-    mask &= (
-        (lh.data.inclusion.indices < ngraphs)
-        .at[lh_idx]
-        .get(mode="fill", fill_value=False)
-    )
-    mask &= (
-        (rh.data.inclusion.indices < ngraphs)
-        .at[rh_idx]
-        .get(mode="fill", fill_value=False)
-    )
-
-    if rh_index_remap is not None:
-        mask &= ~isin(lh_idx, rh_index_remap, lh.size) | (lh_idx >= rh_idx_out)
-
-    return mask
-
-
-def _compute_distances_pbc_sq(
-    candidates: _Candidates,
+def _minimum_image_shifts(
+    candidates: Candidates,
     lh: Table[ParticleId, NeighborListPoints],
     rh: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
-    shifts: Array | None = None,
-) -> tuple[Array, Array]:
-    """Compute squared distances honoring the cell's per-axis periodicity.
-
-    If ``shifts`` is None, minimum-image shifts are computed via rounding on
-    periodic axes; non-periodic axes get a zero shift (no MIC fold).
-    """
-    lattice_vecs = systems.map_data(lambda s: s.cell.vectors)
-    vecs = lattice_vecs[lh.data.system[candidates.lhs.indices]]
+) -> Array:
+    """Compute minimum-image fractional shifts for each candidate pair."""
     deltas = (
         lh.data.positions[candidates.lhs.indices]
         - rh.data.positions[candidates.rhs.indices]
     )
-    if shifts is None:
-        shifts = systems.data.cell.minimum_image_shifts(deltas)
-    deltas -= shifts
-    real_deltas = triangular_3x3_matmul(vecs, deltas)
-    dist_sq = jnp.einsum("...d,...d->...", real_deltas, real_deltas)
-    return dist_sq, shifts
+    return systems.data.cell.minimum_image_shifts(deltas)
 
 
-@dataclass
-class _DistanceCutoffResult:
-    candidates: _Candidates
-    original_candidate_idx: Array
-    mask: Array
-    shifts: Array
-    is_minimum_interaction: Array
-
-
-def _apply_distance_cutoff_wo_images(
-    candidates: _Candidates,
+def make_batch_with_mic(
+    candidates: Candidates,
     lh: Table[ParticleId, NeighborListPoints],
     rh: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
-    cutoffs: Table[SystemId, Array],
-) -> _DistanceCutoffResult:
-    """Apply distance cutoff with periodic boundaries, without image generation."""
-    dist_sq, shifts = _compute_distances_pbc_sq(candidates, lh, rh, systems)
-    cand_sys = lh.data.system[candidates.lhs.indices]
-    return _DistanceCutoffResult(
+) -> CandidateBatch[Literal[2]]:
+    """Pack raw candidates with minimum-image shifts; ``is_minimum_image=all-True``."""
+    min_shifts = _minimum_image_shifts(candidates, lh, rh, systems)
+    return candidates_to_batch(
         candidates,
-        jnp.arange(candidates.lhs.size),
-        dist_sq < cutoffs[cand_sys] ** 2,
-        shifts,
+        min_shifts,
         jnp.ones((candidates.lhs.size,), dtype=bool),
     )
 
 
-def _apply_distance_cutoff_w_images(
-    candidates: _Candidates,
+def candidates_to_batch(
+    candidates: Candidates,
+    shifts: Array,
+    is_minimum_image: Array,
+) -> CandidateBatch[Literal[2]]:
+    """Pack ``(candidates, flat shifts, is_min)`` into a ``CandidateBatch[2]``."""
+    indices_2d = jnp.stack([candidates.lhs.indices, candidates.rhs.indices], axis=-1)
+    edges: Edges[Literal[2]] = Edges(
+        Index(candidates.lhs.keys, indices_2d),
+        jnp.expand_dims(shifts, axis=-2),
+    )
+    return CandidateBatch(edges=edges, is_minimum_image=is_minimum_image)
+
+
+def replicate_for_images(
+    candidates: Candidates,
     lh: Table[ParticleId, NeighborListPoints],
     rh: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
     cutoffs: Table[SystemId, Array],
-    max_image_candidates: Capacity[int],
-) -> _DistanceCutoffResult:
-    """Apply distance cutoff with periodic boundaries and image generation."""
-    idx, shifts, has_been_replicated = _get_candidate_images(
-        candidates, lh, systems, cutoffs.data, max_image_candidates
-    )
-    if idx.size == candidates.lhs.size:
-        return _apply_distance_cutoff_wo_images(candidates, lh, rh, systems, cutoffs)
-
-    min_dist_sq, min_shifts = _compute_distances_pbc_sq(candidates, lh, rh, systems)
-    candidates_w_images = bind(candidates).at(idx).get()
-    dist_sq, shifts = _compute_distances_pbc_sq(
-        candidates_w_images, lh, rh, systems, shifts
-    )
-    shifts = jnp.where(has_been_replicated[:, None], shifts, min_shifts[idx])
-    dist_sq = jnp.where(has_been_replicated, dist_sq, min_dist_sq[idx])
-    cand_sys = lh.data.system[candidates_w_images.lhs.indices]
-    return _DistanceCutoffResult(
-        candidates_w_images,
-        idx,
-        dist_sq < cutoffs[cand_sys] ** 2,
-        shifts,
-        (min_shifts[idx] == shifts).all(axis=-1),
-    )
-
-
-def _compute_distances_and_apply_cutoff(
-    candidates: _Candidates,
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints],
-    systems: Table[SystemId, NeighborListSystems],
-    cutoffs: Table[SystemId, Array],
-    consider_images: bool,
     max_image_candidates: Capacity[int] | None,
-) -> _DistanceCutoffResult:
-    """Compute distances and apply cutoff filter."""
-    if not consider_images:
-        return _apply_distance_cutoff_wo_images(candidates, lh, rh, systems, cutoffs)
+) -> CandidateBatch[Literal[2]]:
+    """Replicate candidates by image multiplicity, attaching shifts and is-min flag.
+
+    For each candidate pair:
+    - If ``max(cutoff[sys] / perp_axes) <= 0.5``: emit 1 copy with MIC shifts.
+    - Otherwise: emit per-image copies with replicated shifts; the
+      ``is_minimum_image`` flag is set per copy so ``ExclusionMask`` can keep
+      non-minimum image periodic copies of excluded pairs.
+
+    Args:
+        candidates: Raw candidate pair indices.
+        lh, rh, systems: Pipeline tables (fractional coords).
+        cutoffs: Per-system cutoff.
+        max_image_candidates: Capacity for replicated-candidates buffer.
+            When ``None``, falls back to ``FixedCapacity(candidates.lhs.size)``
+            with an error message — pass an editable capacity if image
+            replication is expected.
+
+    Returns:
+        ``CandidateBatch`` with shifts populated and ``is_minimum_image`` set.
+    """
+    cutoffs_t = Table.broadcast_to(cutoffs, systems)
     if max_image_candidates is None:
         max_image_candidates = FixedCapacity(
             candidates.lhs.size,
@@ -311,144 +256,46 @@ def _compute_distances_and_apply_cutoff(
             "we need to generate additional images. "
             "Please provide a editable max_candidates.",
         )
-    return _apply_distance_cutoff_w_images(
-        candidates, lh, rh, systems, cutoffs, max_image_candidates
-    )
 
+    idx, image_shifts, has_been_replicated = _get_candidate_images(
+        candidates, lh, systems, cutoffs_t.data, max_image_candidates
+    )
+    min_shifts = _minimum_image_shifts(candidates, lh, rh, systems)
 
-def _compact_edges(
-    candidates: _Candidates,
-    mask: Array,
-    shifts: Array,
-    rh_index_remap: Array | None,
-    max_num_edges: Capacity[int],
-    out_of_bounds: int,
-) -> Edges[Literal[2]]:
-    """Compact valid edges and format output."""
-    num_edges = mask.sum()
-    max_num_edges = max_num_edges.generate_assertion(num_edges)
-    sort_idxs = jnp.where(mask, size=max_num_edges.size, fill_value=mask.size)[0]
-    shifts = shifts.at[sort_idxs].get(
-        mode="fill", fill_value=0, indices_are_sorted=True
-    )
-    rh_idx_out = (
-        rh_index_remap.at[candidates.rhs.indices].get(
-            mode="fill", fill_value=out_of_bounds
-        )
-        if rh_index_remap is not None
-        else candidates.rhs.indices
-    )
-    lh_edge, rh_edge = (
-        c.at[sort_idxs].get(
-            mode="fill", fill_value=out_of_bounds, indices_are_sorted=True
-        )
-        for c in (candidates.lhs.indices, rh_idx_out)
-    )
-
-    if rh_index_remap is not None:
-        shifts = jnp.concatenate([shifts, -shifts], axis=0)
-        lh_edge, rh_edge = (
-            jnp.concatenate([lh_edge, rh_edge], axis=0),
-            jnp.concatenate([rh_edge, lh_edge], axis=0),
+    if idx.size == candidates.lhs.size:
+        # No replication needed — MIC shifts cover everything.
+        return candidates_to_batch(
+            candidates, min_shifts, jnp.ones((candidates.lhs.size,), dtype=bool)
         )
 
-    shifts = jnp.expand_dims(shifts, axis=-2)
-    edge_indices = Index(candidates.lhs.keys, jnp.stack([lh_edge, rh_edge], axis=-1))
-    return Edges(edge_indices, shifts)
+    replicated = bind(candidates).at(idx).get()
+    final_shifts = jnp.where(
+        has_been_replicated[:, None], image_shifts, min_shifts[idx]
+    )
+    is_min = (min_shifts[idx] == final_shifts).all(axis=-1)
+    return candidates_to_batch(replicated, final_shifts, is_min)
 
 
-def _filter_candidates(
-    candidates: _Candidates,
+def real_distance_sq(
     lh: Table[ParticleId, NeighborListPoints],
     rh: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
-    cutoffs: Table[SystemId, Array],
-    rh_index_remap: Index[ParticleId] | None,
-    *,
-    max_num_edges: Capacity[int],
-    max_image_candidates: Capacity[int] | None,
-    consider_images: bool,
-) -> Edges[Literal[2]]:
-    out_of_bounds = max(rh.data.positions.shape[0], lh.data.positions.shape[0])
+    lh_idx: Array,
+    rh_idx: Array,
+    shifts: Array,
+) -> Array:
+    """Squared real-space distance between candidate pairs.
 
-    # Convert Index[ParticleId] to raw array for leaf functions
-    rh_remap_raw: Array | None = (
-        rh_index_remap.indices_in(lh.keys) if rh_index_remap is not None else None
-    )
-    if rh_remap_raw is not None and rh_remap_raw.size == 0:
-        rh_remap_raw = jnp.full((1,), out_of_bounds, dtype=int)
+    Args:
+        lh, rh, systems: Pipeline tables (positions in fractional coords).
+        lh_idx, rh_idx: ``(n,)`` raw index arrays.
+        shifts: ``(n, 3)`` fractional shifts.
 
-    mask = _build_segmentation_mask(candidates, lh, rh, rh_remap_raw, out_of_bounds)
-
-    distance_result = _compute_distances_and_apply_cutoff(
-        candidates,
-        lh,
-        rh,
-        systems,
-        cutoffs,
-        consider_images,
-        max_image_candidates,
-    )
-    mask = mask.at[distance_result.original_candidate_idx].get(
-        mode="fill", fill_value=False
-    )
-    mask &= distance_result.mask
-    shifts = distance_result.shifts
-    candidates = distance_result.candidates
-
-    # Exclusion mask: drop edges where exclusion segments match on minimum image
-    lh_excl, rh_excl = Index.match(
-        lh[candidates.lhs].exclusion, rh[candidates.rhs].exclusion
-    )
-    mask &= (lh_excl != rh_excl) | ~distance_result.is_minimum_interaction
-
-    result = _compact_edges(
-        candidates, mask, shifts, rh_remap_raw, max_num_edges, out_of_bounds
-    )
-    return result
-
-
-def basic_neighborlist(
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints] | None,
-    systems: Table[SystemId, NeighborListSystems],
-    cutoffs: Table[SystemId, Array],
-    rh_index_remap: Index[ParticleId] | None,
-    *,
-    candidate_selector: CandidateSelector,
-    max_num_edges: Capacity[int],
-    max_image_candidates: Capacity[int] | None = None,
-    consider_images: bool = True,
-) -> Edges[Literal[2]]:
-    """Core neighbor list construction algorithm with pluggable candidate selection."""
-    cutoffs = Table.broadcast_to(cutoffs, systems)
-    if rh is None:
-        rh = lh
-
-    # Transform coordinates to fractional using per-particle system data
-    lh_inv = systems[lh.data.system].cell.inverse_vectors
-    lh = (
-        bind(lh)
-        .focus(lambda x: x.data.positions)
-        .apply(lambda r: triangular_3x3_matmul(lh_inv, r))
-    )
-    rh_inv = systems[rh.data.system].cell.inverse_vectors
-    rh = (
-        bind(rh)
-        .focus(lambda x: x.data.positions)
-        .apply(lambda r: triangular_3x3_matmul(rh_inv, r))
-    )
-
-    candidates = candidate_selector(lh, rh, systems)
-
-    return _filter_candidates(
-        candidates,
-        lh,
-        rh,
-        systems,
-        cutoffs,
-        rh_index_remap,
-        max_num_edges=max_num_edges,
-        max_image_candidates=max_image_candidates,
-        consider_images=consider_images,
-    )
+    Returns:
+        ``(n,)`` array of squared distances in real coordinates.
+    """
+    frames = systems.map_data(lambda s: s.cell.frame.materialize())
+    frames = frames[lh.data.system[lh_idx]]
+    deltas = lh.data.positions[lh_idx] - rh.data.positions[rh_idx] - shifts
+    real_deltas = frames.to_real(deltas)
+    return jnp.einsum("...d,...d->...", real_deltas, real_deltas)

--- a/src/kups/core/neighborlist/compact.py
+++ b/src/kups/core/neighborlist/compact.py
@@ -1,0 +1,114 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compactors for the neighbor list pipeline.
+
+Two flavors:
+
+- [`ReduceCompactor`][kups.core.neighborlist.compact.ReduceCompactor] —
+  compresses survivors via ``jnp.where(keep, size=k)`` with a capacity
+  assertion; mirrors edges when ``ctx.rh_index_remap`` is set.
+- [`MaskOnlyCompactor`][kups.core.neighborlist.compact.MaskOnlyCompactor] —
+  preserves the candidate count, replacing failing entries with OOB indices
+  and zero shifts. Used by ``RefineMaskNeighborList``.
+
+Both compactors share the rh→lh remap (``remap_rh_to_lh``) so that the
+final ``Edges`` indices live in lh-space regardless of which compactor ran.
+Mirroring (doubling each edge with its reverse) is specific to
+``ReduceCompactor`` — it pairs with ``RemapDedupMask`` which removed one
+direction of each pair upstream.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.capacity import Capacity
+from kups.core.data import Index
+from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.types import CandidateBatch, PipelineContext
+from kups.core.utils.jax import dataclass
+from kups.core.utils.ops import where_broadcast_last
+
+
+def remap_rh_to_lh(rh_idx: Array, ctx: PipelineContext) -> Array:
+    """Map rh-space indices to lh-space via ``ctx.rh_index_remap``.
+
+    Returns ``rh_idx`` unchanged when no remap is in effect. Out-of-bounds
+    rh positions (e.g., padding) resolve to ``max(ctx.lh.size, ctx.rh.size)``.
+    """
+    if ctx.rh_index_remap is None:
+        return rh_idx
+    oob = max(ctx.lh.size, ctx.rh.size)
+    return ctx.rh_index_remap.at[rh_idx].get(mode="fill", fill_value=oob)
+
+
+@dataclass
+class ReduceCompactor:
+    """Compacts surviving candidates to a size-bounded ``Edges[2]``.
+
+    Applies the shared rh→lh remap, then — when ``ctx.rh_index_remap`` is
+    set — mirrors each surviving edge with its reverse (concatenating shifts
+    with their negatives). The mirror restores the symmetry that the paired
+    ``RemapDedupMask`` removed upstream.
+    """
+
+    avg_edges: Capacity[int]
+
+    def __call__(
+        self,
+        keep: Array,
+        batch: CandidateBatch[Literal[2]],
+        ctx: PipelineContext,
+    ) -> Edges[Literal[2]]:
+        oob = max(ctx.lh.size, ctx.rh.size)
+        max_edges = self.avg_edges.generate_assertion(keep.sum())
+        sort_idxs = jnp.where(keep, size=max_edges.size, fill_value=keep.size)[0]
+        shifts = batch.edges.shifts.at[sort_idxs].get(
+            mode="fill", fill_value=0, indices_are_sorted=True
+        )
+        rh_idx_remapped = remap_rh_to_lh(batch.rh_idx, ctx)
+        lh_edge = batch.lh_idx.at[sort_idxs].get(
+            mode="fill", fill_value=oob, indices_are_sorted=True
+        )
+        rh_edge = rh_idx_remapped.at[sort_idxs].get(
+            mode="fill", fill_value=oob, indices_are_sorted=True
+        )
+
+        if ctx.rh_index_remap is not None:
+            shifts = jnp.concatenate([shifts, -shifts], axis=0)
+            lh_edge, rh_edge = (
+                jnp.concatenate([lh_edge, rh_edge], axis=0),
+                jnp.concatenate([rh_edge, lh_edge], axis=0),
+            )
+
+        return Edges(
+            Index(batch.edges.indices.keys, jnp.stack([lh_edge, rh_edge], axis=-1)),
+            shifts,
+        )
+
+
+@dataclass
+class MaskOnlyCompactor:
+    """In-place compaction: failing entries become OOB indices and zero shifts.
+
+    No size change; preserves the candidate count from the selector. Applies
+    the shared rh→lh remap so the output indices live in lh-space — matching
+    ``ReduceCompactor``'s contract.
+    """
+
+    def __call__(
+        self,
+        keep: Array,
+        batch: CandidateBatch[Literal[2]],
+        ctx: PipelineContext,
+    ) -> Edges[Literal[2]]:
+        oob = ctx.lh.size
+        rh_idx_remapped = remap_rh_to_lh(batch.rh_idx, ctx)
+        indices_in = jnp.stack([batch.lh_idx, rh_idx_remapped], axis=-1)
+        indices = where_broadcast_last(keep, indices_in, oob)
+        shifts = where_broadcast_last(keep, batch.edges.shifts, 0)
+        return Edges(Index(batch.edges.indices.keys, indices), shifts)

--- a/src/kups/core/neighborlist/dense.py
+++ b/src/kups/core/neighborlist/dense.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-from functools import partial
 from typing import Literal, Protocol
 
 from jax import Array
@@ -13,12 +12,23 @@ from jax import Array
 from kups.core.capacity import Capacity, LensCapacity
 from kups.core.data import Index, Table, subselect
 from kups.core.lens import Lens, lens
-from kups.core.neighborlist.common import _Candidates, basic_neighborlist
+from kups.core.neighborlist.common import Candidates, replicate_for_images
+from kups.core.neighborlist.compact import ReduceCompactor
 from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.masks import (
+    DistanceCutoffMask,
+    ExclusionMask,
+    InBoundsMask,
+    InclusionMatchMask,
+    RemapDedupMask,
+)
+from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.types import (
+    CandidateBatch,
     IsNeighborListState,
     NeighborListPoints,
     NeighborListSystems,
+    PipelineContext,
 )
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass
@@ -40,17 +50,39 @@ def _dense_subselect(
     rh: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
     max_num_candidates: Capacity[int],
-) -> _Candidates:
+) -> Candidates:
     selection_result = subselect(
         lh.data.system.indices,
         rh.data.system.indices,
         output_buffer_size=max_num_candidates,
         num_segments=systems.size,
     )
-    return _Candidates(
+    return Candidates(
         lhs=Index(lh.keys, selection_result.scatter_idxs),
         rhs=Index(rh.keys, selection_result.gather_idxs),
     )
+
+
+@dataclass
+class DenseSelector:
+    """Selector for the per-system dense ``O(N²/K²)`` algorithm."""
+
+    cutoffs: Table[SystemId, Array]
+    max_candidates: Capacity[int]
+    max_image_candidates: Capacity[int]
+
+    def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
+        candidates = _dense_subselect(
+            ctx.lh, ctx.rh, ctx.systems, max_num_candidates=self.max_candidates
+        )
+        return replicate_for_images(
+            candidates,
+            ctx.lh,
+            ctx.rh,
+            ctx.systems,
+            self.cutoffs,
+            self.max_image_candidates,
+        )
 
 
 @dataclass
@@ -120,17 +152,20 @@ class DenseNearestNeighborList:
         rh_index_remap: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
         rh_size = rh.size if rh is not None else lh.size
-        selector = partial(
-            _dense_subselect,
-            max_num_candidates=self.avg_candidates.multiply(rh_size),
+        cutoffs = Table.broadcast_to(cutoffs, systems)
+        pipeline = Pipeline[Literal[2]](
+            selector=DenseSelector(
+                cutoffs=cutoffs,
+                max_candidates=self.avg_candidates.multiply(rh_size),
+                max_image_candidates=self.avg_image_candidates.multiply(rh_size),
+            ),
+            masks=(
+                InBoundsMask(),
+                InclusionMatchMask(),
+                RemapDedupMask(),
+                DistanceCutoffMask(cutoffs=cutoffs),
+                ExclusionMask(),
+            ),
+            compactor=ReduceCompactor(avg_edges=self.avg_edges.multiply(rh_size)),
         )
-        return basic_neighborlist(
-            lh,
-            rh,
-            systems,
-            cutoffs,
-            rh_index_remap,
-            candidate_selector=selector,
-            max_num_edges=self.avg_edges.multiply(rh_size),
-            max_image_candidates=self.avg_image_candidates.multiply(rh_size),
-        )
+        return pipeline(lh, rh, systems, rh_index_remap)

--- a/src/kups/core/neighborlist/masks.py
+++ b/src/kups/core/neighborlist/masks.py
@@ -1,0 +1,112 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mask classes for the neighbor list pipeline.
+
+Each [`Mask`][kups.core.neighborlist.types.Mask] is a pure function of
+``(batch, ctx)`` returning a fresh boolean array for its own criterion; the
+[`Pipeline`][kups.core.neighborlist.pipeline.Pipeline] conjuncts all returned
+masks via ``&``. Masks cannot change ``batch.edges`` or
+``batch.is_minimum_image``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.data import Index, Table
+from kups.core.neighborlist.common import real_distance_sq
+from kups.core.neighborlist.types import CandidateBatch, PipelineContext
+from kups.core.typing import SystemId
+from kups.core.utils.jax import dataclass, isin
+
+
+@dataclass
+class InBoundsMask:
+    """Drops candidates whose lh/rh indices fall outside the valid inclusion-segment range.
+
+    Implements the per-side ``inclusion.indices < num_labels`` check used to
+    guard scatter/gather lookups when the candidate buffer is padded.
+    """
+
+    def __call__(self, batch: CandidateBatch, ctx: PipelineContext) -> Array:
+        ngraphs = ctx.lh.data.inclusion.num_labels
+        lh_in = (
+            (ctx.lh.data.inclusion.indices < ngraphs)
+            .at[batch.lh_idx]
+            .get(mode="fill", fill_value=False)
+        )
+        rh_in = (
+            (ctx.rh.data.inclusion.indices < ngraphs)
+            .at[batch.rh_idx]
+            .get(mode="fill", fill_value=False)
+        )
+        return lh_in & rh_in
+
+
+@dataclass
+class InclusionMatchMask:
+    """Drops candidates whose lh/rh inclusion segments differ."""
+
+    def __call__(self, batch: CandidateBatch, ctx: PipelineContext) -> Array:
+        lh_incl = ctx.lh.data.inclusion.indices[batch.lh_idx]
+        rh_incl = ctx.rh.data.inclusion.indices[batch.rh_idx]
+        return lh_incl == rh_incl
+
+
+@dataclass
+class RemapDedupMask:
+    """Deduplicate the rh→lh remapped subset.
+
+    When ``ctx.rh_index_remap`` is set, ``rh`` is a subset of ``lh`` and each
+    rh-position maps to an lh-position via ``rh_index_remap``. We then keep
+    only one direction per pair: edges where ``lh_idx`` is **not** in the
+    remap (i.e., the pair is lh-only) or where ``lh_idx >= remapped_rh``.
+
+    Returns all-True when no remap is in effect.
+    """
+
+    def __call__(self, batch: CandidateBatch, ctx: PipelineContext) -> Array:
+        if ctx.rh_index_remap is None:
+            return jnp.ones((batch.lh_idx.size,), dtype=bool)
+        oob = max(ctx.lh.size, ctx.rh.size)
+        rh_remapped = ctx.rh_index_remap.at[batch.rh_idx].get(
+            mode="fill", fill_value=oob
+        )
+        return ~isin(batch.lh_idx, ctx.rh_index_remap, ctx.lh.size) | (
+            batch.lh_idx >= rh_remapped
+        )
+
+
+@dataclass
+class DistanceCutoffMask:
+    """Drops candidates whose squared real-space distance exceeds ``cutoff²``."""
+
+    cutoffs: Table[SystemId, Array]
+
+    def __call__(self, batch: CandidateBatch, ctx: PipelineContext) -> Array:
+        cutoffs = Table.broadcast_to(self.cutoffs, ctx.systems)
+        shifts = batch.edges.shifts[:, 0, :]
+        dist_sq = real_distance_sq(
+            ctx.lh, ctx.rh, ctx.systems, batch.lh_idx, batch.rh_idx, shifts
+        )
+        cand_sys = ctx.lh.data.system[batch.lh_idx]
+        return dist_sq < cutoffs[cand_sys] ** 2
+
+
+@dataclass
+class ExclusionMask:
+    """Drops minimum-image pairs that share an exclusion segment.
+
+    Non-minimum-image periodic copies of excluded pairs survive (allowed when
+    ``batch.is_minimum_image`` is False for that copy).
+    """
+
+    def __call__(self, batch: CandidateBatch, ctx: PipelineContext) -> Array:
+        # batch.edges.indices carries a single set of keys; rebuild a rh-keyed
+        # Index so Table indexing aligns when ctx.lh and ctx.rh have distinct keys.
+        lh_view = ctx.lh[Index(ctx.lh.keys, batch.lh_idx)]
+        rh_view = ctx.rh[Index(ctx.rh.keys, batch.rh_idx)]
+        lh_excl, rh_excl = Index.match(lh_view.exclusion, rh_view.exclusion)
+        return (lh_excl != rh_excl) | ~batch.is_minimum_image

--- a/src/kups/core/neighborlist/parameters.py
+++ b/src/kups/core/neighborlist/parameters.py
@@ -17,7 +17,7 @@ import jax.numpy as jnp
 from jax import Array
 
 from kups.core.data import Table
-from kups.core.neighborlist.common import _num_cells
+from kups.core.neighborlist.common import num_cells
 from kups.core.neighborlist.types import NeighborListSystems
 from kups.core.typing import SystemId
 from kups.core.utils.jax import dataclass, field, no_jax_tracing
@@ -105,12 +105,12 @@ class UniversalNeighborlistParameters:
         sys = Table.join(systems, particles_per_system, cutoffs)
         total_candidates = total_edges = max_cells = 0
         for _, (s, n_p, c) in sys:
-            num_cells = _num_cells(s, c).prod()
-            total_candidates += min(n_p / num_cells * (3**3), n_p)
+            n_bins = num_cells(s, c).prod()
+            total_candidates += min(n_p / n_bins * (3**3), n_p)
             total_edges += _estimate_avg_num_edges(
                 n_p, s.cell.volume, c, base, multiplier
             )
-            max_cells = max(num_cells, max_cells)
+            max_cells = max(n_bins, max_cells)
         total_candidates = next_higher_power(
             jnp.array(total_candidates * multiplier / sys.size), base=base
         )

--- a/src/kups/core/neighborlist/pipeline.py
+++ b/src/kups/core/neighborlist/pipeline.py
@@ -1,0 +1,90 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pipeline runner: selector → mask sequence → compactor.
+
+A [`Pipeline[D]`][kups.core.neighborlist.pipeline.Pipeline] is the
+modularized form of a neighbor list. Concrete public NL classes
+(``CellListNeighborList``, ``DenseNearestNeighborList``, etc.) build and run
+a ``Pipeline`` internally inside their ``__call__``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.data import Index, Table
+from kups.core.lens import bind
+from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.types import (
+    CandidateSelector,
+    Compactor,
+    Mask,
+    NeighborListPoints,
+    NeighborListSystems,
+    PipelineContext,
+)
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass, field
+
+
+@dataclass
+class Pipeline[D: int]:
+    """Selector → mask sequence → compactor.
+
+    Attributes:
+        selector: Produces a ``CandidateBatch[D]`` (handles PBC replication).
+        masks: Tuple of mask criteria over ``CandidateBatch[D]``; results
+            are conjuncted via ``&``.
+        compactor: Produces the final ``Edges[D]`` from the accumulated mask.
+    """
+
+    selector: CandidateSelector[D]
+    masks: tuple[Mask, ...] = field(static=True)
+    compactor: Compactor[D]
+
+    def __call__(
+        self,
+        lh: Table[ParticleId, NeighborListPoints],
+        rh: Table[ParticleId, NeighborListPoints] | None,
+        systems: Table[SystemId, NeighborListSystems],
+        rh_index_remap: Index[ParticleId] | None = None,
+    ) -> Edges[D]:
+        ctx = _prepare(lh, rh, systems, rh_index_remap)
+        batch = self.selector(ctx)
+        keep = jnp.ones((batch.lh_idx.size,), dtype=bool)
+        for mask in self.masks:
+            keep &= mask(batch, ctx)
+        return self.compactor(keep, batch, ctx)
+
+
+def _prepare(
+    lh: Table[ParticleId, NeighborListPoints],
+    rh: Table[ParticleId, NeighborListPoints] | None,
+    systems: Table[SystemId, NeighborListSystems],
+    rh_index_remap: Index[ParticleId] | None,
+) -> PipelineContext:
+    """Transform lh/rh positions to fractional coords, resolve the remap, build ctx."""
+    if rh is None:
+        rh = lh
+
+    frames = systems.map_data(lambda s: s.cell.frame.materialize())
+    lh_frame = frames[lh.data.system]
+    lh = bind(lh, lambda x: x.data.positions).apply(lh_frame.to_fractional)
+    rh_frame = frames[rh.data.system]
+    rh = bind(rh, lambda x: x.data.positions).apply(rh_frame.to_fractional)
+
+    rh_remap_raw: Array | None = (
+        rh_index_remap.indices_in(lh.keys) if rh_index_remap is not None else None
+    )
+    if rh_remap_raw is not None and rh_remap_raw.size == 0:
+        oob = max(lh.size, rh.size)
+        rh_remap_raw = jnp.full((1,), oob, dtype=int)
+
+    return PipelineContext(
+        lh=lh,
+        rh=rh,
+        systems=systems,
+        rh_index_remap=rh_remap_raw,
+    )

--- a/src/kups/core/neighborlist/refine.py
+++ b/src/kups/core/neighborlist/refine.py
@@ -19,12 +19,84 @@ from jax import Array
 
 from kups.core.capacity import Capacity
 from kups.core.data import Index, Table
-from kups.core.neighborlist.common import _Candidates, basic_neighborlist
+from kups.core.neighborlist.common import Candidates, make_batch_with_mic
+from kups.core.neighborlist.compact import MaskOnlyCompactor, ReduceCompactor
 from kups.core.neighborlist.edges import Edges
-from kups.core.neighborlist.types import NeighborListPoints, NeighborListSystems
+from kups.core.neighborlist.masks import (
+    DistanceCutoffMask,
+    ExclusionMask,
+    InBoundsMask,
+    InclusionMatchMask,
+)
+from kups.core.neighborlist.pipeline import Pipeline
+from kups.core.neighborlist.types import (
+    CandidateBatch,
+    NeighborListPoints,
+    NeighborListSystems,
+    PipelineContext,
+)
 from kups.core.typing import ParticleId, SystemId
-from kups.core.utils.jax import dataclass, jit
-from kups.core.utils.ops import where_broadcast_last
+from kups.core.utils.jax import dataclass, field, jit
+
+
+@dataclass
+class PrecomputedEdgesSelector:
+    """Selector that wraps precomputed ``Edges`` for both refine variants.
+
+    Precomputed edges use the same index convention as the call that produced
+    them: public lh-space edges when an ``rh`` remap is supplied, and raw
+    rh-space indices for a disjoint ``rh`` without a remap. Remapped ``rh``
+    rows are overlaid onto ``lh`` before this selector runs.
+
+    Attributes:
+        candidates: Precomputed edges (indices in lh-space).
+        recompute_mic_shifts: When ``True``, drop the precomputed shifts and
+            recompute minimum-image shifts on the current positions
+            (``RefineCutoffNeighborList`` — the precomputed shifts may be
+            stale relative to the current cell). When ``False``, reuse
+            ``candidates.shifts`` directly (``RefineMaskNeighborList``).
+            ``is_minimum_image`` is always all-True (no image replication).
+    """
+
+    candidates: Edges[Literal[2]]
+    recompute_mic_shifts: bool = field(static=True, default=False)
+
+    def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
+        if self.recompute_mic_shifts:
+            indices = self.candidates.indices.indices
+            raw_candidates = Candidates(
+                lhs=Index(ctx.lh.keys, indices[:, 0]),
+                rhs=Index(ctx.rh.keys, indices[:, 1]),
+            )
+            return make_batch_with_mic(raw_candidates, ctx.lh, ctx.rh, ctx.systems)
+        indices = self.candidates.indices.indices
+        edges = Edges(Index(ctx.lh.keys, indices), self.candidates.shifts)
+        return CandidateBatch(
+            edges=edges,
+            is_minimum_image=jnp.ones((len(self.candidates),), dtype=bool),
+        )
+
+
+def _resolve_precomputed_inputs(
+    lh: Table[ParticleId, NeighborListPoints],
+    rh: Table[ParticleId, NeighborListPoints] | None,
+    rh_index_remap: Index[ParticleId] | None,
+) -> tuple[
+    Table[ParticleId, NeighborListPoints],
+    Table[ParticleId, NeighborListPoints] | None,
+]:
+    """Return the tables that precomputed refine candidates address.
+
+    With a remap, refine candidates are public ``Edges`` outputs, so both
+    columns are in lh-space. Overlay rh rows onto the corresponding lh slots
+    and run the pipeline as a self-refinement. Without a remap, rh is disjoint
+    and the candidate right column is already in rh-space.
+    """
+    if rh is None:
+        return lh, None
+    if rh_index_remap is None:
+        return lh, rh
+    return lh.update(rh_index_remap, rh.data), None
 
 
 @dataclass
@@ -74,16 +146,13 @@ class RefineMaskNeighborList:
         cutoffs: Table[SystemId, Array],
         rh_index_remap: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
-        lh_c = self.candidates.indices[:, 0]
-        rh_c = self.candidates.indices[:, 1]
-        lh_d, rh_d = lh[lh_c], lh[rh_c]
-        lh_incl, rh_incl = Index.match(lh_d.inclusion, rh_d.inclusion)
-        lh_excl, rh_excl = Index.match(lh_d.exclusion, rh_d.exclusion)
-        mask = lh_incl == rh_incl
-        mask &= lh_excl != rh_excl
-        indices = where_broadcast_last(mask, self.candidates.indices.indices, lh.size)
-        shifts = where_broadcast_last(mask, self.candidates.shifts, 0)
-        return Edges(Index(self.candidates.indices.keys, indices), shifts)
+        resolved_lh, resolved_rh = _resolve_precomputed_inputs(lh, rh, rh_index_remap)
+        pipeline = Pipeline[Literal[2]](
+            selector=PrecomputedEdgesSelector(self.candidates),
+            masks=(InBoundsMask(), InclusionMatchMask(), ExclusionMask()),
+            compactor=MaskOnlyCompactor(),
+        )
+        return pipeline(resolved_lh, resolved_rh, systems, None)
 
 
 @dataclass
@@ -136,37 +205,19 @@ class RefineCutoffNeighborList:
         cutoffs: Table[SystemId, Array],
         rh_index_remap: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
-        rh_remap_raw = (
-            rh_index_remap.indices_in(lh.keys) if rh_index_remap is not None else None
-        )
-
-        if rh_remap_raw is not None:
-            assert rh is not None
-            inv_rh_index_remap = jnp.full(lh.size, rh.size, dtype=int)
-            inv_rh_index_remap = inv_rh_index_remap.at[rh_remap_raw].set(
-                jnp.arange(rh.size, dtype=int)
-            )
-        else:
-            inv_rh_index_remap = None
-
-        def _cand_selector(
-            lh: Table[ParticleId, NeighborListPoints],
-            rh: Table[ParticleId, NeighborListPoints],
-            systems: Table[SystemId, NeighborListSystems],
-        ) -> _Candidates:
-            rh_c = self.candidates.indices[:, 1].indices
-            if inv_rh_index_remap is not None:
-                rh_c = inv_rh_index_remap.at[rh_c].get(mode="fill", fill_value=len(lh))
-            return _Candidates(self.candidates.indices[:, 0], Index(rh.keys, rh_c))
-
+        resolved_lh, resolved_rh = _resolve_precomputed_inputs(lh, rh, rh_index_remap)
         rh_size = rh.size if rh is not None else lh.size
-        return basic_neighborlist(
-            lh,
-            rh,
-            systems,
-            cutoffs,
-            rh_index_remap,
-            candidate_selector=_cand_selector,
-            max_num_edges=self.avg_edges.multiply(rh_size),
-            consider_images=False,
+        cutoffs = Table.broadcast_to(cutoffs, systems)
+        pipeline = Pipeline[Literal[2]](
+            selector=PrecomputedEdgesSelector(
+                self.candidates, recompute_mic_shifts=True
+            ),
+            masks=(
+                InBoundsMask(),
+                InclusionMatchMask(),
+                DistanceCutoffMask(cutoffs=cutoffs),
+                ExclusionMask(),
+            ),
+            compactor=ReduceCompactor(avg_edges=self.avg_edges.multiply(rh_size)),
         )
+        return pipeline(resolved_lh, resolved_rh, systems, None)

--- a/src/kups/core/neighborlist/types.py
+++ b/src/kups/core/neighborlist/types.py
@@ -4,16 +4,23 @@
 """Protocols for the neighbor list module.
 
 Defines the core
-[`NearestNeighborList`][kups.core.neighborlist.protocol.NearestNeighborList]
+[`NearestNeighborList`][kups.core.neighborlist.types.NearestNeighborList]
 call signature, the particle and system trait protocols expected by every
-implementation, the parameter protocols for capacity hints, and the
-[`IsNeighborListState`][kups.core.neighborlist.protocol.IsNeighborListState]
+implementation, the
+[`Mask`][kups.core.neighborlist.types.Mask] /
+[`Compactor`][kups.core.neighborlist.types.Compactor] /
+[`CandidateSelector`][kups.core.neighborlist.types.CandidateSelector]
+protocols that compose into a
+[`Pipeline`][kups.core.neighborlist.pipeline.Pipeline], the
+[`CandidateBatch`][kups.core.neighborlist.types.CandidateBatch]
+NamedTuple carried between phases, and the
+[`IsNeighborListState`][kups.core.neighborlist.types.IsNeighborListState]
 protocol used by the ``from_state`` constructors.
 """
 
 from __future__ import annotations
 
-from typing import Literal, Protocol
+from typing import Literal, NamedTuple, Protocol
 
 from jax import Array
 
@@ -28,6 +35,7 @@ from kups.core.typing import (
     ParticleId,
     SystemId,
 )
+from kups.core.utils.jax import dataclass
 
 
 class NeighborListPoints(
@@ -72,6 +80,98 @@ class NearestNeighborList(Protocol):
             Edges connecting particle pairs within cutoff
         """
         ...
+
+
+class CandidateBatch[D: int](NamedTuple):
+    """Candidate set of degree ``D`` carried through the pipeline.
+
+    Reuses [`Edges[D]`][kups.core.neighborlist.edges.Edges] for the
+    `(indices, shifts)` layout (`indices` shape `(n, D)`,
+    `shifts` shape `(n, D-1, 3)`); adds the
+    ``is_minimum_image`` flag that
+    [`ExclusionMask`][kups.core.neighborlist.masks.ExclusionMask] needs to
+    keep non-minimum periodic copies of excluded pairs.
+
+    Auto-registered as a JAX PyTree because it is a NamedTuple.
+
+    Attributes:
+        edges: Candidate edges (indices + fractional shifts).
+        is_minimum_image: ``(n,)`` bool — True where the candidate's shift
+            equals the minimum-image shift; False for non-MIC replicated
+            copies emitted by selectors that handle PBC image expansion.
+    """
+
+    edges: Edges[D]
+    is_minimum_image: Array
+
+    @property
+    def lh_idx(self) -> Array:
+        """Pair-specific: raw lh-side index array of shape ``(n,)``. Only meaningful for ``D == 2``."""
+        return self.edges.indices.indices[:, 0]
+
+    @property
+    def rh_idx(self) -> Array:
+        """Pair-specific: raw rh-side index array of shape ``(n,)``. Only meaningful for ``D == 2``."""
+        return self.edges.indices.indices[:, 1]
+
+
+@dataclass
+class PipelineContext:
+    """Read-only inputs shared by every mask and the compactor.
+
+    Positions in ``lh`` and ``rh`` are in **fractional** coordinates
+    (transformed by [`_prepare`][kups.core.neighborlist.pipeline._prepare]).
+    There is no ``out_of_bounds`` field — masks/compactors that need an
+    OOB sentinel compute ``max(ctx.lh.size, ctx.rh.size)`` locally.
+
+    Attributes:
+        lh: Left-hand particle table in fractional coords.
+        rh: Right-hand particle table in fractional coords (== ``lh`` when
+            the caller passed ``rh=None``).
+        systems: Indexed system data with cell information.
+        rh_index_remap: Raw remap array mapping rh-positions to lh-space
+            particle IDs, or ``None`` when no remap was supplied. Empty
+            remaps are replaced with a one-element OOB-sentinel array by
+            ``_prepare`` so downstream lookups never see a zero-length array.
+    """
+
+    lh: Table[ParticleId, NeighborListPoints]
+    rh: Table[ParticleId, NeighborListPoints]
+    systems: Table[SystemId, NeighborListSystems]
+    rh_index_remap: Array | None
+
+
+class CandidateSelector[D: int](Protocol):
+    """Produces a ``CandidateBatch[D]`` from the pipeline context.
+
+    Owns all candidate-set construction, including any PBC image
+    replication required when ``max(cutoff/perp_axis) > 0.5``.
+    """
+
+    def __call__(self, ctx: PipelineContext) -> CandidateBatch[D]: ...
+
+
+class Mask(Protocol):
+    """Returns this criterion's bool array; pipeline conjuncts the results.
+
+    Degree-agnostic at the type level — the pair-only masks shipped here
+    annotate ``batch: CandidateBatch`` (any ``D``) and internally assume
+    ``D == 2`` via ``batch.lh_idx`` / ``batch.rh_idx``. Higher-degree masks
+    would not use those properties.
+
+    Cannot change ``batch.edges``, ``batch.is_minimum_image``, or the
+    candidate count. Pure ``(batch, ctx) -> Array``.
+    """
+
+    def __call__(self, batch: CandidateBatch, ctx: PipelineContext) -> Array: ...
+
+
+class Compactor[D: int](Protocol):
+    """Produces final ``Edges[D]`` from the accumulated ``keep`` mask."""
+
+    def __call__(
+        self, keep: Array, batch: CandidateBatch[D], ctx: PipelineContext
+    ) -> Edges[D]: ...
 
 
 class IsUniversalNeighborlistParams(Protocol):

--- a/test/core/test_neighborlist.py
+++ b/test/core/test_neighborlist.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import gc
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -27,14 +28,31 @@ from kups.core.neighborlist import (
     DenseNearestNeighborList,
     Edges,
     RefineCutoffNeighborList,
+    RefineMaskNeighborList,
     neighborlist_changes,
 )
 from kups.core.neighborlist.cell_list import _cell_hash
 from kups.core.neighborlist.common import (
+    Candidates,
     _candidate_image_counts,
-    _Candidates,
     _get_candidate_images,
+    make_batch_with_mic,
 )
+from kups.core.neighborlist.compact import (
+    MaskOnlyCompactor,
+    ReduceCompactor,
+    remap_rh_to_lh,
+)
+from kups.core.neighborlist.masks import (
+    DistanceCutoffMask,
+    ExclusionMask,
+    InBoundsMask,
+    InclusionMatchMask,
+    RemapDedupMask,
+)
+from kups.core.neighborlist.pipeline import Pipeline
+from kups.core.neighborlist.refine import PrecomputedEdgesSelector
+from kups.core.neighborlist.types import CandidateBatch, PipelineContext
 from kups.core.result import as_result_function
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass
@@ -152,6 +170,35 @@ def _call_nl(nl_instance, lh, systems, cutoffs, rh=None, rh_index_remap=None):
     )
 
 
+def _make_pipeline_ctx(lh, rh=None, cell=None, rh_index_remap=None):
+    """Build a ``PipelineContext`` directly for unit-level mask/compactor tests.
+
+    Positions are taken as-is — caller is responsible for the fractional
+    convention. Using a unit cell (``eye(3)``) keeps real == fractional so
+    ``DistanceCutoffMask`` produces the same numbers either way.
+    """
+    if rh is None:
+        rh = lh
+    if cell is None:
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None]))
+    systems, _ = _systems_from_cell(cell, jnp.array([1.0]))
+    return PipelineContext(lh=lh, rh=rh, systems=systems, rh_index_remap=rh_index_remap)
+
+
+def _make_batch(lh_keys, lh_idx, rh_idx, shifts=None, is_minimum_image=None):
+    """Build a ``CandidateBatch`` with one Index keys for both sides."""
+    n = lh_idx.shape[0]
+    if shifts is None:
+        shifts = jnp.zeros((n, 1, 3))
+    if is_minimum_image is None:
+        is_minimum_image = jnp.ones((n,), dtype=bool)
+    indices_2d = jnp.stack([lh_idx, rh_idx], axis=-1)
+    return CandidateBatch(
+        edges=Edges(Index(lh_keys, indices_2d), shifts),
+        is_minimum_image=is_minimum_image,
+    )
+
+
 class TestEdges:
     """Test cases for the Edges dataclass."""
 
@@ -264,7 +311,7 @@ class TestImageCountIsFiniteGuard:
             ),
         )
         systems = Table(sys_keys, SampleSystems(cell=cell))
-        candidates = _Candidates(
+        candidates = Candidates(
             lhs=Index(pi_keys, jnp.array([0])),
             rhs=Index(pi_keys, jnp.array([0])),
         )
@@ -1467,6 +1514,124 @@ class TestRefineCutoffNeighborList:
         assert edges.degree == 2
         # Should handle remapping correctly
 
+    def test_rh_remap_uses_rh_positions_for_cutoff(self):
+        """Precomputed edges are in public lh-space, but the remapped rh data
+        may carry positions that differ from lh. RefineCutoff must evaluate
+        distances after overlaying rh onto those lh rows.
+        """
+        lh_positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [100.0, 0.0, 0.0],
+                [105.0, 0.0, 0.0],
+            ]
+        )
+        lh = self._create_test_pointset(lh_positions)
+        rh, rh_remap = _make_rh(
+            lh,
+            jnp.array([[100.4, 0.0, 0.0]]),
+            jnp.zeros(1, dtype=int),
+            jnp.array([2]),
+            exclusion_ids=jnp.array([20]),
+        )
+        candidates = self._create_candidate_edges(
+            jnp.array([1]), jnp.array([2]), n_particles=3
+        )
+        refinement_nl = RefineCutoffNeighborList(
+            candidates=candidates, avg_edges=FixedCapacity(4)
+        )
+
+        systems, cutoffs = _systems_from_lvecs(
+            jnp.eye(3)[None] * 1000.0, jnp.array([1.0])
+        )
+        edges = refinement_nl(
+            lh=lh,
+            rh=rh,
+            systems=systems,
+            cutoffs=cutoffs,
+            rh_index_remap=rh_remap,
+        )
+
+        npt.assert_array_equal(
+            np.asarray(edges.indices.indices[edges.indices.indices[:, 0] < lh.size]),
+            np.array([[1, 2]]),
+        )
+
+    def test_disjoint_rh_uses_rh_positions_for_cutoff(self):
+        """Without a remap, the precomputed candidate right column is in
+        rh-space and distance checks must use the separate rh table.
+        """
+        lh_positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [100.0, 0.0, 0.0],
+            ]
+        )
+        lh = self._create_test_pointset(lh_positions)
+        rh, _ = _make_rh(
+            lh,
+            jnp.array([[100.4, 0.0, 0.0]]),
+            jnp.zeros(1, dtype=int),
+            jnp.array([0]),
+            exclusion_ids=jnp.array([20]),
+        )
+        candidates = self._create_candidate_edges(
+            jnp.array([1]), jnp.array([0]), n_particles=2
+        )
+        refinement_nl = RefineCutoffNeighborList(
+            candidates=candidates, avg_edges=FixedCapacity(4)
+        )
+        systems, cutoffs = _systems_from_lvecs(
+            jnp.eye(3)[None] * 1000.0, jnp.array([1.0])
+        )
+
+        edges = refinement_nl(
+            lh=lh, rh=rh, systems=systems, cutoffs=cutoffs, rh_index_remap=None
+        )
+
+        npt.assert_array_equal(
+            np.asarray(edges.indices.indices[edges.indices.indices[:, 0] < lh.size]),
+            np.array([[1, 0]]),
+        )
+
+    def test_rh_remap_uses_rh_exclusion_for_cutoff_refinement(self):
+        """The cutoff refiner still applies exclusion masks after distance
+        filtering, so remapped rh metadata must be used there too.
+        """
+        lh_positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+            ]
+        )
+        lh = self._create_test_pointset(lh_positions, exclusion_offset=0)
+        rh, rh_remap = _make_rh(
+            lh,
+            jnp.array([[1.0, 0.0, 0.0]]),
+            jnp.zeros(1, dtype=int),
+            jnp.array([1]),
+            exclusion_ids=jnp.array([0]),
+        )
+        candidates = self._create_candidate_edges(
+            jnp.array([0]), jnp.array([1]), n_particles=2
+        )
+        refinement_nl = RefineCutoffNeighborList(
+            candidates=candidates, avg_edges=FixedCapacity(4)
+        )
+        systems, cutoffs = _systems_from_lvecs(
+            jnp.eye(3)[None] * 1000.0, jnp.array([2.0])
+        )
+
+        edges = refinement_nl(
+            lh=lh,
+            rh=rh,
+            systems=systems,
+            cutoffs=cutoffs,
+            rh_index_remap=rh_remap,
+        )
+
+        assert not np.any(np.asarray(edges.indices.indices[:, 0] < lh.size))
+
     def test_empty_candidates(self):
         """Test refinement with no candidate edges."""
         lh_positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
@@ -1632,6 +1797,504 @@ class TestRefineCutoffNeighborList:
                             npt.assert_allclose(
                                 diff_vectors[i, 0], expected_diff, rtol=1e-10
                             )
+
+
+class TestRefineMaskNeighborList:
+    """Test cases for RefineMaskNeighborList.
+
+    RefineMask is the post-filter used by MCMC. Its precomputed edges carry
+    indices in **lh-space** (the output of any base NL +
+    ``neighborlist_changes``). When a non-trivial ``rh`` subset plus a remap is
+    provided, those rows are overlaid onto the lh table before filtering so
+    public lh-space edge indices remain valid while rh metadata is honored.
+    Without a remap, the right column remains in raw rh-space.
+    """
+
+    def test_mcmc_patch_pattern_with_partial_overlap(self):
+        """Mirror the MCMC patch flow: precomputed edges contain pairs where
+        only some indices are inside the move subset. Concrete check:
+        5-particle ``lh``, ``rh`` = 2-particle subset (move particles),
+        precomputed edges include a pair that touches a non-move particle.
+        All edges must survive (distinct exclusion segments) and the output
+        must be in lh-space.
+        """
+        lh = _make_lh(
+            jnp.zeros((5, 3)),
+            jnp.zeros(5, dtype=int),
+            exclusion_ids=jnp.array([0, 1, 2, 3, 4]),
+        )
+        # Move subset = particles 1 and 3 (typical MCMC small move).
+        rh_positions = jnp.zeros((2, 3))
+        rh_remap_arr = jnp.array([1, 3])
+        rh, rh_remap = _make_rh(lh, rh_positions, jnp.zeros(2, dtype=int), rh_remap_arr)
+        # Precomputed edges: (0, 1), (2, 3), (1, 4). The last touches a
+        # particle NOT in the move subset; overlaying rh into lh keeps that
+        # public lh-space edge valid.
+        candidates = _make_edges(
+            jnp.array([0, 2, 1]), jnp.array([1, 3, 4]), n_particles=5
+        )
+
+        refine_nl = RefineMaskNeighborList(candidates=candidates)
+        sys, cut = _systems_from_lvecs(jnp.eye(3)[None] * 100.0, jnp.array([10.0]))
+        edges = refine_nl(
+            lh=lh, rh=rh, systems=sys, cutoffs=cut, rh_index_remap=rh_remap
+        )
+
+        raw = edges.indices.indices
+        oob = lh.size
+        valid_mask = (raw[:, 0] < oob) & (raw[:, 1] < oob)
+        valid = np.asarray(raw[valid_mask])
+        valid = valid[np.lexsort((valid[:, 1], valid[:, 0]))]
+
+        npt.assert_array_equal(valid, np.array([[0, 1], [1, 4], [2, 3]]))
+
+    def test_full_overlap_with_rh_subset(self):
+        """RefineMask called with a non-trivial ``rh`` subset where every
+        precomputed rh-side index is in the move subset.
+
+        The rh rows are overlaid into the lh table and the precomputed
+        lh-space edges stay in lh-space directly. Output: edges (0, 1) and
+        (2, 3).
+        """
+        lh_positions = jnp.array(
+            [
+                [0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [2.0, 0.0, 0.0],
+                [3.0, 0.0, 0.0],
+            ]
+        )
+        lh = _make_lh(lh_positions, jnp.zeros(4, dtype=int), jnp.arange(4))
+
+        # rh is the subset {lh[1], lh[3]}; remap takes rh-positions → lh-positions.
+        rh_positions = lh_positions[jnp.array([1, 3])]
+        rh_remap_arr = jnp.array([1, 3])
+        rh, rh_remap = _make_rh(lh, rh_positions, jnp.zeros(2, dtype=int), rh_remap_arr)
+
+        # Precomputed edges with rh-side in lh-space (1, 3 — both are lh-positions
+        # that happen to correspond to rh positions 0 and 1 respectively).
+        candidates = _make_edges(jnp.array([0, 2]), jnp.array([1, 3]), n_particles=4)
+
+        refine_nl = RefineMaskNeighborList(candidates=candidates)
+        sys, cut = _systems_from_lvecs(jnp.eye(3)[None] * 100.0, jnp.array([10.0]))
+        edges = refine_nl(
+            lh=lh, rh=rh, systems=sys, cutoffs=cut, rh_index_remap=rh_remap
+        )
+
+        raw = edges.indices.indices
+        oob = lh.size  # MaskOnlyCompactor's OOB sentinel
+        valid_mask = (raw[:, 0] < oob) & (raw[:, 1] < oob)
+        valid = np.asarray(raw[valid_mask])
+        valid = valid[np.lexsort((valid[:, 1], valid[:, 0]))]
+
+        npt.assert_array_equal(valid, np.array([[0, 1], [2, 3]]))
+
+    def test_disjoint_rh_uses_rh_inclusion(self):
+        """Without a remap, the precomputed candidate right column is in
+        rh-space and masks must read inclusion/exclusion from rh.
+        """
+        lh = _make_lh(
+            jnp.zeros((2, 3)),
+            jnp.zeros(2, dtype=int),
+            exclusion_ids=jnp.array([0, 1]),
+        )
+        rh, _ = _make_rh(
+            lh,
+            jnp.zeros((2, 3)),
+            jnp.array([0, 1]),
+            jnp.array([0, 1]),
+            exclusion_ids=jnp.array([2, 3]),
+        )
+        candidates = _make_edges(jnp.array([0]), jnp.array([1]), n_particles=2)
+        refine_nl = RefineMaskNeighborList(candidates=candidates)
+        systems, cutoffs = _systems_from_lvecs(
+            jnp.eye(3)[None].repeat(2, axis=0) * 100.0,
+            jnp.array([10.0, 10.0]),
+        )
+
+        edges = refine_nl(
+            lh=lh, rh=rh, systems=systems, cutoffs=cutoffs, rh_index_remap=None
+        )
+
+        npt.assert_array_equal(np.asarray(edges.indices.indices), np.array([[2, 2]]))
+
+    def test_rh_remap_uses_rh_inclusion(self):
+        """A remapped rh row can belong to a different inclusion segment than
+        the lh row it replaces. RefineMask must use that rh metadata.
+        """
+        lh = _make_lh(
+            jnp.zeros((2, 3)),
+            jnp.zeros(2, dtype=int),
+            exclusion_ids=jnp.array([0, 1]),
+        )
+        rh, rh_remap = _make_rh(
+            lh,
+            jnp.zeros((1, 3)),
+            jnp.ones(1, dtype=int),
+            jnp.array([1]),
+            exclusion_ids=jnp.array([1]),
+        )
+        candidates = _make_edges(jnp.array([0]), jnp.array([1]), n_particles=2)
+        refine_nl = RefineMaskNeighborList(candidates=candidates)
+        systems, cutoffs = _systems_from_lvecs(
+            jnp.eye(3)[None] * 100.0, jnp.array([10.0, 10.0])
+        )
+
+        edges = refine_nl(
+            lh=lh,
+            rh=rh,
+            systems=systems,
+            cutoffs=cutoffs,
+            rh_index_remap=rh_remap,
+        )
+
+        npt.assert_array_equal(np.asarray(edges.indices.indices), np.array([[2, 2]]))
+
+    def test_rh_remap_uses_rh_exclusion(self):
+        """A remapped rh row can introduce an exclusion that is not present in
+        the lh table at the same public edge index.
+        """
+        lh = _make_lh(
+            jnp.zeros((2, 3)),
+            jnp.zeros(2, dtype=int),
+            exclusion_ids=jnp.array([0, 1]),
+        )
+        rh, rh_remap = _make_rh(
+            lh,
+            jnp.zeros((1, 3)),
+            jnp.zeros(1, dtype=int),
+            jnp.array([1]),
+            exclusion_ids=jnp.array([0]),
+        )
+        candidates = _make_edges(jnp.array([0]), jnp.array([1]), n_particles=2)
+        refine_nl = RefineMaskNeighborList(candidates=candidates)
+        systems, cutoffs = _systems_from_lvecs(
+            jnp.eye(3)[None] * 100.0, jnp.array([10.0])
+        )
+
+        edges = refine_nl(
+            lh=lh,
+            rh=rh,
+            systems=systems,
+            cutoffs=cutoffs,
+            rh_index_remap=rh_remap,
+        )
+
+        npt.assert_array_equal(np.asarray(edges.indices.indices), np.array([[2, 2]]))
+
+
+class TestInBoundsMask:
+    """``InBoundsMask`` drops candidates whose raw index is out of range on
+    either side. The mode='fill' lookup turns OOB indices into ``False``;
+    valid indices return whatever the per-particle ``inclusion < num_labels``
+    check evaluates to (always True in well-formed states)."""
+
+    def test_drops_oob_indices_on_either_side(self):
+        lh = _make_lh(jnp.zeros((3, 3)), jnp.zeros(3, dtype=int))
+        ctx = _make_pipeline_ctx(lh)
+        # Edge 0: both in bounds. Edge 1: rh OOB. Edge 2: lh OOB.
+        batch = _make_batch(
+            lh.keys,
+            jnp.array([0, 1, 100]),
+            jnp.array([1, 100, 2]),
+        )
+        result = InBoundsMask()(batch, ctx)
+        assert result.tolist() == [True, False, False]
+
+
+class TestInclusionMatchMask:
+    def test_matches_inclusion_segments(self):
+        # Two inclusion groups: 0 and 1.
+        lh = _make_lh(jnp.zeros((4, 3)), jnp.array([0, 0, 1, 1]))
+        rh = _make_lh(jnp.zeros((4, 3)), jnp.array([0, 1, 0, 1]))
+        ctx = _make_pipeline_ctx(lh, rh)
+        # lh.incl[lh_idx] = [0, 0, 1, 1]; rh.incl[rh_idx] = [0, 1, 0, 1].
+        batch = _make_batch(
+            lh.keys,
+            jnp.array([0, 1, 2, 3]),
+            jnp.array([0, 1, 0, 3]),
+        )
+        result = InclusionMatchMask()(batch, ctx)
+        assert result.tolist() == [True, False, False, True]
+
+
+class TestRemapDedupMask:
+    def test_no_remap_returns_all_true(self):
+        lh = _make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
+        ctx = _make_pipeline_ctx(lh, rh_index_remap=None)
+        batch = _make_batch(lh.keys, jnp.array([0, 1, 2]), jnp.array([1, 2, 3]))
+        result = RemapDedupMask()(batch, ctx)
+        assert result.tolist() == [True, True, True]
+
+    def test_drops_self_pair_with_remap(self):
+        """When ``rh`` is a remapped subset of ``lh``, dedup keeps an edge only
+        when its lh-side ID is **outside** the remap *or* is not less than the
+        remapped-rh ID."""
+        lh = _make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
+        rh = _make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
+        # rh-pos 0 maps to lh-pos 1; rh-pos 1 maps to lh-pos 3.
+        remap = jnp.array([1, 3])
+        ctx = _make_pipeline_ctx(lh, rh, rh_index_remap=remap)
+        # Cases:
+        #   (lh=0, rh=0): rh_remapped=1, isin(0,[1,3])=False → ~isin=True → keep.
+        #   (lh=1, rh=1): rh_remapped=3, isin(1,[1,3])=True  → ~isin=False;
+        #                 1 >= 3 = False → drop.
+        #   (lh=3, rh=0): rh_remapped=1, isin(3,[1,3])=True  → ~isin=False;
+        #                 3 >= 1 = True → keep.
+        batch = _make_batch(
+            lh.keys,
+            jnp.array([0, 1, 3]),
+            jnp.array([0, 1, 0]),
+        )
+        result = RemapDedupMask()(batch, ctx)
+        assert result.tolist() == [True, False, True]
+
+
+class TestDistanceCutoffMask:
+    def test_filters_by_distance_squared(self):
+        # Unit cell: real == fractional.
+        positions = jnp.array([[0.0, 0.0, 0.0], [0.3, 0.0, 0.0], [0.8, 0.0, 0.0]])
+        lh = _make_lh(positions, jnp.zeros(3, dtype=int))
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None]))
+        ctx = _make_pipeline_ctx(lh, cell=cell)
+        batch = _make_batch(
+            lh.keys,
+            jnp.array([0, 0, 1]),
+            jnp.array([1, 2, 2]),
+        )
+        # Distances: 0.3, 0.8, 0.5. cutoff² = 0.55² = 0.3025 → keep [T, F, T].
+        cutoffs = Table(ctx.systems.keys, jnp.array([0.55]))
+        result = DistanceCutoffMask(cutoffs=cutoffs)(batch, ctx)
+        assert result.tolist() == [True, False, True]
+
+
+class TestExclusionMask:
+    def test_drops_matching_exclusion_at_min_image(self):
+        # Exclusion ids: lh = [0, 1, 0, 2]; rh = [0, 1, 2, 3].
+        lh = _make_lh(
+            jnp.zeros((4, 3)),
+            jnp.zeros(4, dtype=int),
+            exclusion_ids=jnp.array([0, 1, 0, 2]),
+        )
+        rh = _make_lh(
+            jnp.zeros((4, 3)),
+            jnp.zeros(4, dtype=int),
+            exclusion_ids=jnp.array([0, 1, 2, 3]),
+        )
+        ctx = _make_pipeline_ctx(lh, rh)
+        # lh.excl[lh_idx=[0,1,2,3]] = [0, 1, 0, 2].
+        # rh.excl[rh_idx=[0,1,0,1]] = [0, 1, 0, 1]. All min-image.
+        # Mismatches: [F, F, F, T]. ~is_min: all False → final [F, F, F, T].
+        batch = _make_batch(
+            lh.keys,
+            jnp.array([0, 1, 2, 3]),
+            jnp.array([0, 1, 0, 1]),
+        )
+        result = ExclusionMask()(batch, ctx)
+        assert result.tolist() == [False, False, False, True]
+
+    def test_keeps_non_min_image_periodic_copy_of_excluded_pair(self):
+        """Periodic copies of an excluded pair survive ExclusionMask because
+        ``~is_minimum_image`` short-circuits the drop."""
+        lh = _make_lh(
+            jnp.zeros((2, 3)),
+            jnp.zeros(2, dtype=int),
+            exclusion_ids=jnp.array([0, 0]),  # both share exclusion segment
+        )
+        ctx = _make_pipeline_ctx(lh)
+        # Same lh-rh pair, one MIC and one non-MIC copy.
+        batch = _make_batch(
+            lh.keys,
+            jnp.array([0, 0]),
+            jnp.array([1, 1]),
+            is_minimum_image=jnp.array([True, False]),
+        )
+        result = ExclusionMask()(batch, ctx)
+        # MIC copy: same excl → drop. Non-MIC copy: kept regardless of excl.
+        assert result.tolist() == [False, True]
+
+
+class TestReduceCompactor:
+    def test_compacts_to_capacity_size(self):
+        lh = _make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
+        ctx = _make_pipeline_ctx(lh)
+        # 5 candidates, 3 surviving. Capacity 6.
+        keep = jnp.array([True, False, True, False, True])
+        batch = _make_batch(
+            lh.keys,
+            jnp.array([0, 1, 2, 3, 0]),
+            jnp.array([1, 2, 3, 0, 2]),
+        )
+        compactor = ReduceCompactor(avg_edges=FixedCapacity(6))
+        edges = compactor(keep, batch, ctx)
+        # jnp.where selects the survivor positions (0, 2, 4) in order. Then
+        # the remaining 3 slots are filled with OOB = lh.size = 4.
+        npt.assert_array_equal(
+            np.asarray(edges.indices.indices[:, 0]),
+            np.array([0, 2, 0, 4, 4, 4]),
+        )
+        npt.assert_array_equal(
+            np.asarray(edges.indices.indices[:, 1]),
+            np.array([1, 3, 2, 4, 4, 4]),
+        )
+
+    def test_mirrors_each_edge_with_reverse_when_remap_set(self):
+        """When ``rh_index_remap`` is set, ``ReduceCompactor`` doubles each
+        surviving edge with its (rh→lh) reverse, restoring symmetry that
+        ``RemapDedupMask`` removed upstream."""
+        lh = _make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
+        rh = _make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
+        # rh-pos 0 → lh-pos 1; rh-pos 1 → lh-pos 3.
+        remap = jnp.array([1, 3])
+        ctx = _make_pipeline_ctx(lh, rh, rh_index_remap=remap)
+        # One candidate: lh-pos 0, rh-pos 0 (= lh-pos 1).
+        keep = jnp.array([True])
+        shifts = jnp.array([[[0.5, 0.0, 0.0]]])
+        batch = _make_batch(lh.keys, jnp.array([0]), jnp.array([0]), shifts=shifts)
+        compactor = ReduceCompactor(avg_edges=FixedCapacity(1))
+        edges = compactor(keep, batch, ctx)
+        # Output has 2 entries: (0, 1) with shift +s and (1, 0) with shift -s.
+        npt.assert_array_equal(
+            np.asarray(edges.indices.indices),
+            np.array([[0, 1], [1, 0]]),
+        )
+        npt.assert_allclose(
+            np.asarray(edges.shifts),
+            np.array([[[0.5, 0.0, 0.0]], [[-0.5, -0.0, -0.0]]]),
+        )
+
+
+class TestMaskOnlyCompactor:
+    def test_stamps_oob_on_dropped_entries_and_remaps_rh(self):
+        lh = _make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
+        rh = _make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
+        remap = jnp.array([1, 3])
+        ctx = _make_pipeline_ctx(lh, rh, rh_index_remap=remap)
+        # 3 candidates with rh-side in rh-space; middle one is dropped.
+        keep = jnp.array([True, False, True])
+        batch = _make_batch(
+            lh.keys,
+            jnp.array([0, 1, 2]),
+            jnp.array([0, 1, 1]),
+        )
+        edges = MaskOnlyCompactor()(keep, batch, ctx)
+        # Survivors: (lh=0, rh=0→lh1) and (lh=2, rh=1→lh3). Dropped → (oob, oob).
+        oob = lh.size  # MaskOnlyCompactor uses ctx.lh.size
+        npt.assert_array_equal(
+            np.asarray(edges.indices.indices),
+            np.array([[0, 1], [oob, oob], [2, 3]]),
+        )
+
+
+class TestRemapRhToLh:
+    def test_passthrough_without_remap(self):
+        lh = _make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
+        ctx = _make_pipeline_ctx(lh, rh_index_remap=None)
+        rh_idx = jnp.array([0, 1, 2])
+        npt.assert_array_equal(
+            np.asarray(remap_rh_to_lh(rh_idx, ctx)), np.array([0, 1, 2])
+        )
+
+    def test_translates_rh_to_lh_space_and_fills_oob(self):
+        lh = _make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
+        rh = _make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
+        remap = jnp.array([1, 3])
+        ctx = _make_pipeline_ctx(lh, rh, rh_index_remap=remap)
+        oob = max(lh.size, rh.size)  # 4
+        result = remap_rh_to_lh(jnp.array([0, 1, 5]), ctx)
+        npt.assert_array_equal(np.asarray(result), np.array([1, 3, oob]))
+
+
+class TestMakeBatchWithMic:
+    def test_round_fractional_delta_as_shift(self):
+        """``make_batch_with_mic`` sets shifts via ``cell.minimum_image_shifts``
+        which on periodic axes rounds the fractional delta to the nearest int."""
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None]))
+        positions = jnp.array([[0.1, 0.0, 0.0], [0.9, 0.0, 0.0]])
+        lh = _make_lh(positions, jnp.zeros(2, dtype=int))
+        systems, _ = _systems_from_cell(cell, jnp.array([1.0]))
+        candidates = Candidates(
+            lhs=Index(lh.keys, jnp.array([0])),
+            rhs=Index(lh.keys, jnp.array([1])),
+        )
+        batch = make_batch_with_mic(candidates, lh, lh, systems)
+        # delta = 0.1 - 0.9 = -0.8; round(-0.8) = -1.0 on the periodic axis.
+        npt.assert_allclose(
+            np.asarray(batch.edges.shifts),
+            np.array([[[-1.0, 0.0, 0.0]]]),
+        )
+        assert batch.is_minimum_image.tolist() == [True]
+
+
+class TestPrecomputedEdgesSelectorModes:
+    """The unified selector has two modes: reuse precomputed shifts (default,
+    for ``RefineMaskNeighborList``) or recompute MIC shifts (for
+    ``RefineCutoffNeighborList``). Remapped rh data is handled by overlaying
+    it onto lh before this selector runs; disjoint rh data is passed through as
+    the pipeline right-hand table."""
+
+    def test_default_mode_reuses_precomputed_shifts(self):
+        lh = _make_lh(
+            jnp.array([[0.1, 0.0, 0.0], [0.9, 0.0, 0.0]]),
+            jnp.zeros(2, dtype=int),
+        )
+        # Precomputed shift on the edge — a non-MIC value to see it preserved.
+        custom_shift = jnp.array([[[7.0, 7.0, 7.0]]])
+        candidates = _make_edges(
+            jnp.array([0]), jnp.array([1]), n_particles=2, shifts=custom_shift
+        )
+        ctx = _make_pipeline_ctx(lh)
+        selector = PrecomputedEdgesSelector(candidates)  # recompute_mic=False
+        batch = selector(ctx)
+        npt.assert_allclose(np.asarray(batch.edges.shifts), np.asarray(custom_shift))
+
+    def test_recompute_mic_mode_overrides_precomputed_shifts(self):
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None]))
+        lh = _make_lh(
+            jnp.array([[0.1, 0.0, 0.0], [0.9, 0.0, 0.0]]),
+            jnp.zeros(2, dtype=int),
+        )
+        # Garbage precomputed shift — should be ignored.
+        candidates = _make_edges(
+            jnp.array([0]),
+            jnp.array([1]),
+            n_particles=2,
+            shifts=jnp.array([[99.0, 99.0, 99.0]]),
+        )
+        ctx = _make_pipeline_ctx(lh, cell=cell)
+        selector = PrecomputedEdgesSelector(candidates, recompute_mic_shifts=True)
+        batch = selector(ctx)
+        npt.assert_allclose(
+            np.asarray(batch.edges.shifts),
+            np.array([[[-1.0, 0.0, 0.0]]]),
+        )
+
+
+class TestPipelineComposition:
+    """End-to-end test of the ``Pipeline`` runner with a custom mask set."""
+
+    def test_distance_only_pipeline(self):
+        # Precomputed candidates (lh, rh) = (0, 1) and (0, 2); only the close
+        # pair survives a distance cutoff of 1.5.
+        positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+        lh = _make_lh(positions, jnp.zeros(3, dtype=int))
+        candidates = _make_edges(jnp.array([0, 0]), jnp.array([1, 2]), n_particles=3)
+        # Large lattice so fractional ≠ real and _prepare's conversion is real.
+        systems, cutoffs = _systems_from_lvecs(
+            jnp.eye(3)[None] * 10.0, jnp.array([1.5])
+        )
+        pipeline = Pipeline[Literal[2]](
+            selector=PrecomputedEdgesSelector(candidates, recompute_mic_shifts=True),
+            masks=(DistanceCutoffMask(cutoffs=cutoffs),),
+            compactor=MaskOnlyCompactor(),
+        )
+        edges = pipeline(lh, None, systems, None)
+        # First edge survives, second is stamped OOB.
+        oob = lh.size
+        npt.assert_array_equal(
+            np.asarray(edges.indices.indices),
+            np.array([[0, 1], [oob, oob]]),
+        )
 
 
 def _extract_valid_edge_set(edges: Edges, n_particles: int) -> set[tuple[int, int]]:


### PR DESCRIPTION
##  

Refactor neighbor list internals into a composable Pipeline

Replaces the monolithic `basic_neighborlist` engine with an explicit three-phase `Pipeline[D]`: a `CandidateSelector` produces a `CandidateBatch`, a sequence of `Mask` callables filters it, and a `Compactor` emits the final `Edges[D]`.

### New public types

- **`Pipeline[D]`** — the runner that wires selector → masks → compactor; all concrete neighbor list classes now build and invoke one internally.
- **`CandidateBatch[D]`** — NamedTuple carrying `Edges[D]` plus an `is_minimum_image` flag between pipeline phases; auto-registered as a JAX PyTree.
- **`PipelineContext`** — read-only struct (lh/rh in fractional coords, systems, optional rh remap) shared by every mask and compactor.
- **`CandidateSelector[D]`**, **`Mask`**, **`Compactor[D]`** — protocols defining each phase's contract.

### New selector classes

Each concrete neighbor list now exposes its candidate-emission logic as a standalone, reusable selector:

- `CellListSelector` — spatial-hash candidate emission + image replication.
- `DenseSelector` — per-system dense O(N²/K²) candidate emission + image replication.
- `AllDenseSelector` — all-pairs candidate emission + image replication.
- `InclusionGroupSelector` — pairs every particle with every other in the same inclusion segment (used by `all_connected_neighborlist`).
- `PrecomputedEdgesSelector` — wraps precomputed `Edges` for both refine variants; a `recompute_mic_shifts` flag controls whether shifts are reused or recomputed from current positions.

### New mask classes (`masks.py`)

Logic previously inlined in `_filter_candidates` is now split into independent, testable masks:

- `InBoundsMask` — drops candidates whose indices fall outside the valid inclusion-segment range.
- `InclusionMatchMask` — drops candidates whose lh/rh inclusion segments differ.
- `RemapDedupMask` — deduplicates the rh→lh remapped subset, keeping only one direction per pair.
- `DistanceCutoffMask` — drops candidates whose squared real-space distance exceeds the cutoff.
- `ExclusionMask` — drops minimum-image pairs sharing an exclusion segment; non-MIC periodic copies survive.

### New compactor classes (`compact.py`)

- `ReduceCompactor` — compresses survivors via `jnp.where(keep, size=k)` with a capacity assertion; mirrors each surviving edge with its reverse when `rh_index_remap` is set, restoring the symmetry that `RemapDedupMask` removed.
- `MaskOnlyCompactor` — preserves candidate count, replacing failing entries with OOB indices and zero shifts; used by `RefineMaskNeighborList`.

### `_core.py` cleanup

Removes `basic_neighborlist`, `_filter_candidates`, `_compact_edges`, `_build_segmentation_mask`, `_apply_distance_cutoff_w/wo_images`, and `_compute_distances_and_apply_cutoff`. Retains and exposes the shared primitives that selectors and masks depend on:

- `num_cells` (renamed from `_num_cells`)
- `Candidates` (renamed from `_Candidates`, now public)
- `replicate_for_images` — replicates candidates by image multiplicity, attaching shifts and the `is_minimum_image` flag.
- `make_batch_with_mic` — packs raw candidates with minimum-image shifts.
- `candidates_to_batch` — packs `(candidates, shifts, is_min)` into a `CandidateBatch[2]`.
- `real_distance_sq` — squared real-space distance used by `DistanceCutoffMask`.

### `RefineMaskNeighborList` and `RefineCutoffNeighborList`

Both refine classes now delegate to `Pipeline` via `PrecomputedEdgesSelector`. A new `_resolve_precomputed_inputs` helper handles the rh-overlay pattern: when a remap is supplied, rh rows are overlaid onto the corresponding lh slots so public lh-space edge indices remain valid while rh metadata (inclusion, exclusion, positions) is honored during filtering.

### Tests

Unit tests added for each new mask, both compactors, `remap_rh_to_lh`, `make_batch_with_mic`, `PrecomputedEdgesSelector` modes, and end-to-end `Pipeline` composition. New integration tests for `RefineMaskNeighborList` cover the MCMC patch pattern, disjoint rh, remapped rh inclusion/exclusion, and partial-overlap scenarios. New integration tests for `RefineCutoffNeighborList` verify that remapped and disjoint rh positions and exclusions are correctly evaluated after the overlay.

Part of #129.