### PR TITLE
feat: Project momenta onto zero-total-momentum subspace in `StochasticStep`

### DIFF
--- a/ci/statistical/expected/md_npt_lj_argon.yaml
+++ b/ci/statistical/expected/md_npt_lj_argon.yaml
@@ -2,20 +2,20 @@ simulation_type: md
 hdf5_output: md_npt_lj_argon.h5
 observables:
   potential_energy:
-    expected_mean: -17.539156355718603
-    expected_sem: 0.06092079258537597
+    expected_mean: -17.542591475377804
+    expected_sem: 0.06681896782116982
   kinetic_energy:
-    expected_mean: 3.279190979451168
-    expected_sem: 0.005212756660638464
+    expected_mean: 3.2793884863837626
+    expected_sem: 0.004994509227062839
   total_energy:
-    expected_mean: -14.259965376267436
-    expected_sem: 0.0641958062378494
+    expected_mean: -14.26320298899404
+    expected_sem: 0.0682872807427546
   temperature:
-    expected_mean: 99.48612826486033
-    expected_sem: 0.1581478422585127
+    expected_mean: 99.4921203525894
+    expected_sem: 0.15152651635640862
   pressure:
-    expected_mean: 8.889407586969079e-05
-    expected_sem: 2.2362364589960758e-05
+    expected_mean: 8.905991143917883e-05
+    expected_sem: 2.0627701672969874e-05
   volume:
-    expected_mean: 10748.842835565605
-    expected_sem: 43.56461882027233
+    expected_mean: 10746.0706319482
+    expected_sem: 45.55279820398846

--- a/ci/statistical/expected/md_nvt_lj_argon.yaml
+++ b/ci/statistical/expected/md_nvt_lj_argon.yaml
@@ -2,20 +2,20 @@ simulation_type: md
 hdf5_output: md_nvt_lj_argon.h5
 observables:
   potential_energy:
-    expected_mean: -18.821425533635882
-    expected_sem: 0.029803318824260884
+    expected_mean: -18.821425533635953
+    expected_sem: 0.029803318824239946
   kinetic_energy:
-    expected_mean: 3.3112417858181207
-    expected_sem: 0.0011411463742439496
+    expected_mean: 3.298345848350362
+    expected_sem: 0.0011034473141219466
   total_energy:
-    expected_mean: -15.510183747817765
-    expected_sem: 0.029068893463242443
+    expected_mean: -15.523079685285591
+    expected_sem: 0.029080868351873505
   temperature:
-    expected_mean: 100.45850549241311
-    expected_sem: 0.034620805945252985
+    expected_mean: 100.0672605490558
+    expected_sem: 0.033477068494691946
   pressure:
-    expected_mean: 0.0017708382487158125
-    expected_sem: 1.6136237117886855e-05
+    expected_mean: 0.0017708382487157763
+    expected_sem: 1.6136237117875115e-05
   volume:
     expected_mean: 9314.020863999996
     expected_sem: 0.0

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -38,7 +38,11 @@ from kups.core.typing import (
 from kups.core.utils.functools import pipe
 from kups.core.utils.jax import dataclass, field, tree_map, vectorize
 from kups.core.utils.random import sample_like
-from kups.md.observables import instantaneous_pressure, particle_kinetic_energy
+from kups.md.observables import (
+    instantaneous_pressure,
+    particle_kinetic_energy,
+    remove_center_of_mass_momentum,
+)
 from kups.observables.stress import stress_via_virial_theorem
 
 type Time = Array
@@ -422,6 +426,16 @@ class StochasticStep[State](Propagator[State]):
         new_momenta = (
             damping_factor[..., None] * particles.data.momenta
             + (noise_amplitude * jnp.sqrt(particles.data.masses))[..., None] * noise
+        )
+        constrained_momenta = remove_center_of_mass_momentum(
+            new_momenta, particles.data.masses, particles.data.system
+        )
+        # Deterministic gamma=0 or dt=0 steps should remain no-ops. For
+        # active Langevin thermostats, keep the sampled ensemble in the
+        # zero-total-momentum subspace used by the MD temperature analysis.
+        should_project = (sys.friction_coefficient > 0) & (sys.time_step > 0)
+        new_momenta = jnp.where(
+            should_project[..., None], constrained_momenta, new_momenta
         )
 
         assert new_momenta.shape == particles.data.momenta.shape

--- a/src/kups/md/observables.py
+++ b/src/kups/md/observables.py
@@ -11,6 +11,8 @@ and are distinct from the StateProperty-based observables in kups.observables.
 import jax.numpy as jnp
 from jax import Array
 
+from kups.core.data import Index
+from kups.core.typing import SystemId
 from kups.core.utils.jax import vectorize
 
 
@@ -32,6 +34,22 @@ def particle_kinetic_energy(momentum: Array, mass: Array) -> Array:
     """
     # K = p²/(2m) [energy]
     return 0.5 * jnp.sum(jnp.square(momentum), axis=-1) / mass
+
+
+def remove_center_of_mass_momentum(
+    momenta: Array, masses: Array, system: Index[SystemId]
+) -> Array:
+    """Project momenta onto the zero-total-momentum subspace per system.
+
+    The projection subtracts the center-of-mass velocity from each particle,
+    ``p_i <- p_i - m_i * sum_j(p_j) / sum_j(m_j)``, independently for each
+    system index. This is the mass-metric projection for the canonical ensemble
+    conditioned on zero total momentum.
+    """
+    total_momentum = system.sum_over(momenta).data
+    total_mass = system.sum_over(masses).data
+    com_velocity = total_momentum / total_mass[..., None]
+    return momenta - masses[..., None] * com_velocity[system.indices]
 
 
 @vectorize(signature="(),(3,3),()->()")

--- a/test/md/test_integrators.py
+++ b/test/md/test_integrators.py
@@ -3,6 +3,8 @@
 
 """Unit tests for MD integrators."""
 
+from typing import Any, cast
+
 import jax
 import jax.numpy as jnp
 from jax import Array
@@ -370,9 +372,35 @@ class TestThermostatSteps:
             jax.random.key(42),
             n_equil=50,
             n_sample=100,
-            extract_fn=lambda s: compute_temperature(s, 3 * n_particles),
+            extract_fn=lambda s: compute_temperature(s, 3 * n_particles - 3),
         )
         assert_temperature(jnp.mean(temps), kT_target, 0.2)
+
+    def test_stochastic_step_removes_center_of_mass_momentum(self):
+        state, _, _ = create_harmonic_system(n_particles=6, kT=1.0, dt=0.02)
+        drift = jnp.array([0.4, -0.2, 0.1])
+        momenta = (
+            state.particles.data.momenta + state.particles.data.masses[:, None] * drift
+        )
+        state = SimpleState.particles.focus(lambda p: p.data.momenta).set(
+            state, momenta
+        )
+        step = StochasticStep(particles=SimpleState.particles, system=get_params)
+
+        out = step(jax.random.key(7), state)
+
+        total_momentum = out.particles.data.system.sum_over(
+            out.particles.data.momenta
+        ).data
+        assert jnp.allclose(total_momentum, 0.0, atol=1e-12)
+
+    def test_stochastic_step_gamma_zero_is_deterministic_noop(self):
+        state, _, _ = create_harmonic_system(n_particles=6, kT=1.0, dt=0.02, gamma=0.0)
+        step = StochasticStep(particles=SimpleState.particles, system=get_params)
+
+        out = step(jax.random.key(7), state)
+
+        assert jnp.allclose(out.particles.data.momenta, state.particles.data.momenta)
 
     def test_csvr_velocity_rescaling(self):
         n_particles, kT_target = 10, 2.0
@@ -613,7 +641,7 @@ class TestNVTPhysics:
             jax.random.key(456),
             n_equil=150,
             n_sample=150,
-            extract_fn=lambda s: compute_temperature(s, 3 * n_particles),
+            extract_fn=lambda s: compute_temperature(s, 3 * n_particles - 3),
         )
         assert_temperature(jnp.mean(temps), kT_target, 0.15, "BAOAB ")
 
@@ -779,6 +807,7 @@ def test_stress_matches_ase():
 
     import ase.io
     import numpy as np
+    from ase import Atoms
     from ase.calculators.lj import LennardJones as ASELJ
 
     from kups.application.md.data import MdParameters, md_state_from_ase
@@ -805,7 +834,7 @@ def test_stress_matches_ase():
     sigma, eps = 3.405, 0.01032356174398622
 
     # ASE stress
-    atoms = ase.io.read(str(cif))
+    atoms = cast(Atoms, ase.io.read(str(cif)))
     atoms.calc = ASELJ(epsilon=eps, sigma=sigma, rc=10.0, smooth=False)
     ase_stress = atoms.get_stress(voigt=False)
     ase_pressure = -np.trace(ase_stress) / 3
@@ -813,8 +842,8 @@ def test_stress_matches_ase():
     # kUPS: evaluate potential directly (no propagator/propagate_and_fix)
     @dataclass
     class S:
-        particles: Table[ParticleId, ...]
-        systems: Table[SystemId, ...]
+        particles: Table[ParticleId, Any]
+        systems: Table[SystemId, Any]
         neighborlist_params: UniversalNeighborlistParameters
         step: jnp.ndarray
         lj_parameters: LennardJonesParameters

--- a/test/md/test_observables.py
+++ b/test/md/test_observables.py
@@ -1,0 +1,50 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for MD observable utilities."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+
+from kups.core.data import Index
+from kups.core.typing import SystemId
+from kups.md.observables import remove_center_of_mass_momentum
+
+
+class TestRemoveCenterOfMassMomentum:
+    def test_removes_total_momentum_per_system(self):
+        momenta = jnp.array(
+            [
+                [2.0, 0.0, 0.0],
+                [0.0, 3.0, 0.0],
+                [1.0, 1.0, 0.0],
+                [3.0, 5.0, 2.0],
+            ]
+        )
+        masses = jnp.array([1.0, 3.0, 2.0, 2.0])
+        system = Index.integer(jnp.array([0, 0, 1, 1]), n=2, label=SystemId)
+
+        result = remove_center_of_mass_momentum(momenta, masses, system)
+
+        expected = jnp.array(
+            [
+                [1.5, -0.75, 0.0],
+                [-1.5, 0.75, 0.0],
+                [-1.0, -2.0, -1.0],
+                [1.0, 2.0, 1.0],
+            ]
+        )
+        npt.assert_allclose(result, expected, rtol=1e-12, atol=1e-12)
+        npt.assert_allclose(system.sum_over(result).data, 0.0, atol=1e-12)
+
+    def test_is_jittable(self):
+        momenta = jnp.array([[3.0, -1.0, 2.0], [1.0, 5.0, -2.0]])
+        masses = jnp.array([2.0, 1.0])
+        system = Index.integer(jnp.array([0, 0]), n=1, label=SystemId)
+
+        result = jax.jit(remove_center_of_mass_momentum)(momenta, masses, system)
+
+        npt.assert_allclose(system.sum_over(result).data, 0.0, atol=1e-12)


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Adds momentum projection onto the zero-total-momentum subspace in `StochasticStep` to keep the sampled ensemble consistent with MD temperature analysis, with conditional application only when friction and timestep are non-zero to preserve deterministic no-ops.