### PR TITLE
feat: Compute internal temperature by removing COM momentum

### DIFF
--- a/src/kups/application/md/analysis.py
+++ b/src/kups/application/md/analysis.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass as plain_dataclass
 from pathlib import Path
 from typing import Protocol
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
@@ -18,6 +19,8 @@ from kups.core.constants import BOLTZMANN_CONSTANT
 from kups.core.data import Index, Table
 from kups.core.storage import HDF5StorageReader
 from kups.core.typing import (
+    HasMasses,
+    HasMomenta,
     HasPositions,
     HasPotentialEnergy,
     HasStressTensor,
@@ -29,11 +32,18 @@ from kups.core.utils.block_average import (
     block_average,
     optimal_block_average,
 )
+from kups.md.observables import (
+    particle_kinetic_energy,
+    remove_center_of_mass_momentum,
+)
 
 
 class _IsMDAtoms(HasPositions, Protocol):
     @property
     def system(self) -> Index[SystemId]: ...
+
+
+class _IsMDStepAtoms(HasMomenta, HasMasses, Protocol): ...
 
 
 class IsMDInitData(Protocol):
@@ -45,6 +55,9 @@ class IsMDInitData(Protocol):
 
 class IsMDStepData(HasPotentialEnergy, HasStressTensor, Protocol):
     """Contract for the step reader group."""
+
+    @property
+    def atoms(self) -> Table[ParticleId, _IsMDStepAtoms]: ...
 
     @property
     def kinetic_energy(self) -> Array: ...
@@ -89,6 +102,7 @@ def _analyze_single_system(
     volume: Array,
     n_atoms: int,
     n_blocks: int | None,
+    internal_kinetic_energy: Array,
 ) -> MDAnalysisResult:
     """Run block-averaging analysis for one system.
 
@@ -99,12 +113,17 @@ def _analyze_single_system(
         volume: Cell volume time series, shape ``(n_steps,)``.
         n_atoms: Number of atoms in this system.
         n_blocks: Number of blocks, or ``None`` for automatic selection.
+        internal_kinetic_energy: Center-of-mass-projected kinetic energy time
+            series to use when computing internal temperature. The logged
+            ``kinetic_energy`` and ``total_energy`` are left unchanged.
     """
     degrees_of_freedom = 3 * n_atoms - 3
     total_energy = potential_energy + kinetic_energy
     n_steps = len(total_energy)
 
-    temperature = 2 * kinetic_energy / (BOLTZMANN_CONSTANT * degrees_of_freedom)
+    temperature = (
+        2 * internal_kinetic_energy / (BOLTZMANN_CONSTANT * degrees_of_freedom)
+    )
     pressure = jnp.trace(stress_tensor, axis1=-2, axis2=-1) / 3
 
     if n_blocks is None:
@@ -137,6 +156,24 @@ def _analyze_single_system(
     )
 
 
+def _internal_kinetic_energy(
+    atoms: Table[ParticleId, _IsMDStepAtoms],
+    system: Index[SystemId],
+    system_number: int,
+) -> Array:
+    """Compute per-step internal kinetic energy for one system."""
+    mask = system.indices == system_number
+    momenta = atoms.data.momenta[:, mask, :]
+    masses = atoms.data.masses[:, mask]
+    local_system = Index.zeros(momenta.shape[1], label=SystemId)
+    projected_momenta = jax.vmap(
+        remove_center_of_mass_momentum,
+        in_axes=(0, 0, None),
+    )(momenta, masses, local_system)
+
+    return jnp.sum(particle_kinetic_energy(projected_momenta, masses), axis=-1)
+
+
 def analyze_md(
     init_data: IsMDInitData,
     step_data: IsMDStepData,
@@ -161,13 +198,17 @@ def analyze_md(
 
     results: dict[SystemId, MDAnalysisResult] = {}
     for i, sys_id in enumerate(system_index.keys):
+        kinetic_energy = step_data.kinetic_energy[:, i]
+        internal_ke = kinetic_energy
+        internal_ke = _internal_kinetic_energy(step_data.atoms, system_index, i)
         results[sys_id] = _analyze_single_system(
             potential_energy=step_data.potential_energy[:, i],
-            kinetic_energy=step_data.kinetic_energy[:, i],
+            kinetic_energy=kinetic_energy,
             stress_tensor=step_data.stress_tensor[:, i],
             volume=step_data.volume[:, i],
             n_atoms=int(n_atoms_per_system[i]),
             n_blocks=n_blocks,
+            internal_kinetic_energy=internal_ke,
         )
 
     return results

--- a/test/application/test_md_analysis.py
+++ b/test/application/test_md_analysis.py
@@ -14,6 +14,7 @@ from kups.application.md.analysis import analyze_md
 from kups.core.constants import BOLTZMANN_CONSTANT
 from kups.core.data import Index, Table
 from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import no_post_init
 
 
 @dataclass
@@ -24,7 +25,16 @@ class MockAtomData:
     system: Index[SystemId]
 
 
+@dataclass
+class MockStepAtomData:
+    """Mock satisfying per-step atom momenta and masses."""
+
+    momenta: Array
+    masses: Array
+
+
 jax.tree_util.register_dataclass(MockAtomData)
+jax.tree_util.register_dataclass(MockStepAtomData)
 
 
 @dataclass
@@ -42,6 +52,7 @@ class MockStepData:
     kinetic_energy: Array
     stress_tensor: Array
     volume: Array
+    atoms: Table[ParticleId, MockStepAtomData]
 
 
 def _make_init(n_atoms: int = 10, n_systems: int = 1) -> MockInitData:
@@ -55,20 +66,54 @@ def _make_init(n_atoms: int = 10, n_systems: int = 1) -> MockInitData:
     return MockInitData(atoms=Table(keys=keys, data=data))
 
 
+def _make_step_atoms_from_kinetic_energy(
+    ke: Array,
+    n_atoms: int = 10,
+) -> Table[ParticleId, MockStepAtomData]:
+    """Create per-step atoms whose internal kinetic energy matches ``ke``."""
+    n_steps, n_systems = ke.shape
+    dtype = jnp.result_type(ke, jnp.float32)
+    momenta = jnp.zeros((n_steps, n_atoms, 3), dtype=dtype)
+    masses = jnp.ones((n_steps, n_atoms), dtype=dtype)
+
+    for system_number in range(n_systems):
+        atom_indices = [i for i in range(n_atoms) if i % n_systems == system_number]
+        if len(atom_indices) < 2:
+            raise ValueError(
+                "At least two atoms per system are needed for mock momenta"
+            )
+
+        amplitude = jnp.sqrt(ke[:, system_number].astype(dtype))
+        momenta = momenta.at[:, atom_indices[0], 0].set(amplitude)
+        momenta = momenta.at[:, atom_indices[1], 0].set(-amplitude)
+
+    with no_post_init():
+        return Table(
+            keys=tuple(ParticleId(i) for i in range(n_atoms)),
+            data=MockStepAtomData(momenta=momenta, masses=masses),
+        )
+
+
 def _make_step(
     pe: Array,
     ke: Array,
     stress: Array,
     volume: Array | None = None,
+    atoms: Table[ParticleId, MockStepAtomData] | None = None,
+    *,
+    n_atoms: int = 10,
 ) -> MockStepData:
-    """Create mock step data."""
+    """Create mock step data with per-step atoms."""
     if volume is None:
         volume = jnp.ones(pe.shape)
+    if atoms is None:
+        atoms = _make_step_atoms_from_kinetic_energy(ke, n_atoms=n_atoms)
     return MockStepData(
         potential_energy=pe,
         kinetic_energy=ke,
         stress_tensor=stress,
         volume=volume,
+        atoms=atoms,
     )
 
 
@@ -105,12 +150,58 @@ class TestAnalyzeMD:
         stress = jnp.zeros((n_steps, 1, 3, 3))
 
         results = analyze_md(
-            _make_init(n_atoms), _make_step(pe, ke, stress), n_blocks=10
+            _make_init(n_atoms),
+            _make_step(pe, ke, stress, n_atoms=n_atoms),
+            n_blocks=10,
         )
         r = results[SystemId(0)]
 
         assert r.temperature.mean == pytest.approx(expected_temp, rel=1e-6)
         assert r.n_atoms == n_atoms
+
+    def test_temperature_subtracts_center_of_mass_kinetic_energy(self):
+        """Internal temperature excludes COM drift when per-step momenta are logged."""
+        n_steps = 100
+        n_atoms = 2
+        dof = 3 * n_atoms - 3
+        momenta = jnp.tile(
+            jnp.array([[[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]]),
+            (n_steps, 1, 1),
+        )
+        masses = jnp.ones((n_steps, n_atoms))
+        with no_post_init():
+            atoms = Table(
+                keys=tuple(ParticleId(i) for i in range(n_atoms)),
+                data=MockStepAtomData(momenta=momenta, masses=masses),
+            )
+        pe = jnp.zeros((n_steps, 1))
+        ke = jnp.full((n_steps, 1), 1.0)
+        stress = jnp.zeros((n_steps, 1, 3, 3))
+
+        results = analyze_md(
+            _make_init(n_atoms), _make_step(pe, ke, stress, atoms=atoms), n_blocks=10
+        )
+
+        expected_temp = 2.0 / (BOLTZMANN_CONSTANT * dof)
+        assert results[SystemId(0)].temperature.mean == pytest.approx(
+            expected_temp, rel=1e-6
+        )
+
+        com_momenta = jnp.tile(
+            jnp.array([[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]]),
+            (n_steps, 1, 1),
+        )
+        with no_post_init():
+            com_atoms = Table(
+                keys=tuple(ParticleId(i) for i in range(n_atoms)),
+                data=MockStepAtomData(momenta=com_momenta, masses=masses),
+            )
+        com_results = analyze_md(
+            _make_init(n_atoms),
+            _make_step(pe, ke, stress, atoms=com_atoms),
+            n_blocks=10,
+        )
+        assert com_results[SystemId(0)].temperature.mean == pytest.approx(0.0)
 
     def test_pressure(self):
         """Pressure equals trace of diagonal stress / 3."""


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Added internal temperature computation that excludes center-of-mass momentum when per-step momenta data is available, allowing more accurate thermal analysis by removing artificial kinetic energy from system drift.