### PR TITLE
refactor: Rename `NearestNeighborList` to `NeighborList[D]`

### DIFF
--- a/src/kups/application/simulations/mcmc_rigid.py
+++ b/src/kups/application/simulations/mcmc_rigid.py
@@ -41,7 +41,7 @@ from kups.core.lens import bind, identity_lens, lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
     Edges,
-    NearestNeighborList,
+    NeighborList,
     RefineMaskNeighborList,
     UniversalNeighborlistParameters,
     neighborlist_changes,
@@ -188,7 +188,7 @@ class MCMCState:
         return FixedCapacity(motif_size * len(self.systems))
 
     @property
-    def neighborlist(self) -> NearestNeighborList:
+    def neighborlist(self) -> NeighborList[Literal[2]]:
         return DenseNearestNeighborList.from_state(self)
 
     @property
@@ -196,7 +196,7 @@ class MCMCState:
         return bind(self, lambda x: x.particles.data).apply(MCMCParticles.guest_only)
 
     @property
-    def blocking_spheres_neighborlist(self) -> NearestNeighborList:
+    def blocking_spheres_neighborlist(self) -> NeighborList[Literal[2]]:
         return DenseNearestNeighborList.new(
             self, lens(lambda x: x.blocking_spheres_neighborlist_params)
         )

--- a/src/kups/application/simulations/md_lj.py
+++ b/src/kups/application/simulations/md_lj.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -26,7 +27,7 @@ from kups.core.data import Table
 from kups.core.lens import identity_lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
-    NearestNeighborList,
+    NeighborList,
     UniversalNeighborlistParameters,
 )
 from kups.core.typing import ParticleId, SystemId
@@ -64,7 +65,7 @@ class LjMdState:
     lj_parameters: LennardJonesParameters
 
     @property
-    def neighborlist(self) -> NearestNeighborList:
+    def neighborlist(self) -> NeighborList[Literal[2]]:
         return DenseNearestNeighborList.from_state(self)
 
 

--- a/src/kups/application/simulations/md_mlff.py
+++ b/src/kups/application/simulations/md_mlff.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -31,7 +32,7 @@ from kups.core.data import Table
 from kups.core.lens import identity_lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
-    NearestNeighborList,
+    NeighborList,
     UniversalNeighborlistParameters,
 )
 from kups.core.typing import ParticleId, SystemId
@@ -69,7 +70,7 @@ class MlffMdState:
     jaxified_model: TojaxedMliap
 
     @property
-    def neighborlist(self) -> NearestNeighborList:
+    def neighborlist(self) -> NeighborList[Literal[2]]:
         return DenseNearestNeighborList.from_state(self)
 
 

--- a/src/kups/application/simulations/relax_lj.py
+++ b/src/kups/application/simulations/relax_lj.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -34,7 +35,7 @@ from kups.core.data import Table
 from kups.core.lens import identity_lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
-    NearestNeighborList,
+    NeighborList,
     UniversalNeighborlistParameters,
 )
 from kups.core.typing import ParticleId, SystemId
@@ -80,7 +81,7 @@ class RelaxLjState:
     lj_parameters: LennardJonesParameters
 
     @property
-    def neighborlist(self) -> NearestNeighborList:
+    def neighborlist(self) -> NeighborList[Literal[2]]:
         return DenseNearestNeighborList.from_state(self)
 
 

--- a/src/kups/application/simulations/relax_mlff.py
+++ b/src/kups/application/simulations/relax_mlff.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -36,7 +37,7 @@ from kups.core.data import Table
 from kups.core.lens import identity_lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
-    NearestNeighborList,
+    NeighborList,
     UniversalNeighborlistParameters,
 )
 from kups.core.typing import ParticleId, SystemId
@@ -72,7 +73,7 @@ class RelaxMlffState:
     jaxified_model: TojaxedMliap
 
     @property
-    def neighborlist(self) -> NearestNeighborList:
+    def neighborlist(self) -> NeighborList[Literal[2]]:
         return DenseNearestNeighborList.from_state(self)
 
 

--- a/src/kups/application/simulations/relax_torch.py
+++ b/src/kups/application/simulations/relax_torch.py
@@ -37,7 +37,7 @@ from kups.core.data import Table
 from kups.core.lens import identity_lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
-    NearestNeighborList,
+    NeighborList,
     UniversalNeighborlistParameters,
 )
 from kups.core.typing import ParticleId, SystemId
@@ -106,7 +106,7 @@ class RelaxTorchState:
     torch_mliap_model: TorchMliap
 
     @property
-    def neighborlist(self) -> NearestNeighborList:
+    def neighborlist(self) -> NeighborList[Literal[2]]:
         return DenseNearestNeighborList.from_state(self)
 
 

--- a/src/kups/core/neighborlist/__init__.py
+++ b/src/kups/core/neighborlist/__init__.py
@@ -10,7 +10,7 @@ accuracy trade-offs.
 ## Core Components
 
 - **[Edges][kups.core.neighborlist.Edges]**: Represents connections between particles with periodic shifts
-- **[NearestNeighborList][kups.core.neighborlist.NearestNeighborList]**: Protocol for neighbor search implementations
+- **[NeighborList][kups.core.neighborlist.NeighborList]**: Protocol for neighbor search implementations
 - **[Pipeline][kups.core.neighborlist.Pipeline]**: Selector → mask sequence → compactor
 
 ## Neighbor List Implementations
@@ -95,7 +95,7 @@ from kups.core.neighborlist.types import (
     IsNeighborListState,
     IsUniversalNeighborlistParams,
     Mask,
-    NearestNeighborList,
+    NeighborList,
     NeighborListPoints,
     NeighborListSystems,
     PipelineContext,
@@ -124,7 +124,7 @@ __all__ = [
     "IsUniversalNeighborlistParams",
     "Mask",
     "MaskOnlyCompactor",
-    "NearestNeighborList",
+    "NeighborList",
     "NeighborListChangesResult",
     "NeighborListPoints",
     "NeighborListSystems",

--- a/src/kups/core/neighborlist/changes.py
+++ b/src/kups/core/neighborlist/changes.py
@@ -23,7 +23,7 @@ from kups.core.data import Index, Table
 from kups.core.data.wrappers import WithIndices
 from kups.core.neighborlist.edges import Edges
 from kups.core.neighborlist.types import (
-    NearestNeighborList,
+    NeighborList,
     NeighborListPoints,
     NeighborListSystems,
 )
@@ -39,7 +39,7 @@ class NeighborListChangesResult(NamedTuple):
 
 @partial(jit, static_argnames=("compaction",))
 def neighborlist_changes(
-    neighborlist: NearestNeighborList,
+    neighborlist: NeighborList[Literal[2]],
     lh: Table[ParticleId, NeighborListPoints],
     rh: WithIndices[ParticleId, Table[ParticleId, NeighborListPoints]],
     systems: Table[SystemId, NeighborListSystems],

--- a/src/kups/core/neighborlist/types.py
+++ b/src/kups/core/neighborlist/types.py
@@ -4,7 +4,7 @@
 """Protocols for the neighbor list module.
 
 Defines the core
-[`NearestNeighborList`][kups.core.neighborlist.types.NearestNeighborList]
+[`NeighborList`][kups.core.neighborlist.types.NeighborList]
 call signature, the particle and system trait protocols expected by every
 implementation, the
 [`Mask`][kups.core.neighborlist.types.Mask] /
@@ -20,7 +20,7 @@ protocol used by the ``from_state`` constructors.
 
 from __future__ import annotations
 
-from typing import Literal, NamedTuple, Protocol
+from typing import NamedTuple, Protocol
 
 from jax import Array
 
@@ -50,11 +50,12 @@ class NeighborListPoints(
 class NeighborListSystems(HasCell, Protocol): ...
 
 
-class NearestNeighborList(Protocol):
+class NeighborList[D: int](Protocol):
     """Protocol for neighbor list construction algorithms.
 
-    Implementations find pairs of particles within a cutoff distance, handling
-    periodic boundary conditions and inclusion/exclusion masks.
+    Implementations find groups of particles within a cutoff distance, handling
+    periodic boundary conditions and inclusion/exclusion masks. The degree
+    parameter tracks the arity of the emitted edge tuples.
     """
 
     def __call__[P: NeighborListPoints](
@@ -64,8 +65,8 @@ class NearestNeighborList(Protocol):
         systems: Table[SystemId, NeighborListSystems],
         cutoffs: Table[SystemId, Array],
         rh_index_remap: Index[ParticleId] | None = None,
-    ) -> Edges[Literal[2]]:
-        """Find all particle pairs within the cutoff distance.
+    ) -> Edges[D]:
+        """Find all particle groups within the cutoff distance.
 
         Args:
             lh: Left-hand particles to find neighbors for
@@ -77,7 +78,7 @@ class NearestNeighborList(Protocol):
                 rh is treated as disjoint from lh.
 
         Returns:
-            Edges connecting particle pairs within cutoff
+            Edges connecting particle groups within cutoff
         """
         ...
 

--- a/src/kups/observables/radial_distribution_function.py
+++ b/src/kups/observables/radial_distribution_function.py
@@ -35,7 +35,7 @@ and solvation structure.
 """
 
 from collections import namedtuple
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import jax
 import jax.numpy as jnp
@@ -46,7 +46,7 @@ from kups.core.data import Index, Table
 from kups.core.lens import View, lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
-    NearestNeighborList,
+    NeighborList,
     NeighborListSystems,
 )
 from kups.core.propagator import StateProperty
@@ -90,7 +90,7 @@ def radial_distribution_function(
     systems: Table[SystemId, NeighborListSystems],
     rmax: float,
     bins: int,
-    neighborlist: NearestNeighborList,
+    neighborlist: NeighborList[Literal[2]],
     cutoffs: Table[SystemId, Array] | None = None,
 ) -> Array:
     """Compute radial distribution function $g(r)$ from particle positions.
@@ -181,7 +181,7 @@ class RadialDistributionFunction[State](StateProperty[State, Array]):
     systems: View[State, Table[SystemId, NeighborListSystems]] = field(static=True)
     rmax: View[State, float] = field(static=True)
     bins: View[State, int] = field(static=True)
-    neighborlist: NearestNeighborList = field(static=True)
+    neighborlist: NeighborList[Literal[2]] = field(static=True)
 
     def __call__(self, key: Array, state: State) -> Array:
         """Compute RDF from current state.

--- a/src/kups/potential/classical/blocking.py
+++ b/src/kups/potential/classical/blocking.py
@@ -20,7 +20,7 @@ from jax import Array
 from kups.core.cell import Cell
 from kups.core.data import Index, Table
 from kups.core.lens import Lens, View
-from kups.core.neighborlist import Edges, NearestNeighborList
+from kups.core.neighborlist import Edges, NeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY_LENS,
@@ -140,7 +140,7 @@ class IsBlockingSpheresProbe(Protocol):
     @property
     def changed_particle_idx(self) -> Array: ...
     @property
-    def neighborlist(self) -> NearestNeighborList: ...
+    def neighborlist(self) -> NeighborList[Literal[2]]: ...
 
 
 @dataclass
@@ -218,7 +218,7 @@ class BlockingSpheresSumComposer[State, Ptch: Patch](
     groups_view: View[State, Table[GroupId, HasMotifIndex]] = field(static=True)
     systems_view: View[State, Table[SystemId, HasCell]] = field(static=True)
     parameters_view: View[State, BlockingSpheresParameters] = field(static=True)
-    neighborlist_view: View[State, NearestNeighborList] = field(static=True)
+    neighborlist_view: View[State, NeighborList[Literal[2]]] = field(static=True)
     probe: Probe[State, Ptch, IsBlockingSpheresProbe] | None = field(static=True)
 
     def __call__(self, state: State, patch: Ptch | None):  # type: ignore[reportReturnType]
@@ -283,7 +283,7 @@ def make_blocking_spheres_potential[State, Gradients, Hessians, Ptch: Patch](
     groups_view: View[State, Table[GroupId, HasMotifIndex]],
     systems_view: View[State, Table[SystemId, HasCell]],
     parameters_view: View[State, BlockingSpheresParameters],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     probe: Probe[State, Ptch, IsBlockingSpheresProbe] | None,
     gradient_lens: Lens[BlockingSpheresPotentialInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
@@ -339,7 +339,7 @@ class IsBlockingSpheresState(Protocol):
     @property
     def blocking_spheres_parameters(self) -> BlockingSpheresParameters: ...
     @property
-    def blocking_spheres_neighborlist(self) -> NearestNeighborList: ...
+    def blocking_spheres_neighborlist(self) -> NeighborList[Literal[2]]: ...
 
 
 @overload

--- a/src/kups/potential/classical/coulomb.py
+++ b/src/kups/potential/classical/coulomb.py
@@ -19,7 +19,7 @@ from kups.core.cell import Vacuum
 from kups.core.constants import BOHR, HARTREE
 from kups.core.data import Table
 from kups.core.lens import Lens, SimpleLens, View
-from kups.core.neighborlist import NearestNeighborList
+from kups.core.neighborlist import NeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY_LENS,
@@ -106,7 +106,7 @@ def make_coulomb_vacuum_potential[
     particles_view: View[State, Table[ParticleId, IsCoulombGraphParticles]],
     systems_view: View[State, Table[SystemId, HasCell[Vacuum]]],
     cutoffs_view: View[State, Table[SystemId, Array]],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     probe: Probe[State, Ptch, IsRadiusGraphProbe[IsCoulombGraphParticles]] | None,
     gradient_lens: Lens[CoulombVacuumInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
@@ -167,7 +167,7 @@ class IsCoulombVacuumState(Protocol):
     @property
     def systems(self) -> Table[SystemId, HasCell[Vacuum]]: ...
     @property
-    def neighborlist(self) -> NearestNeighborList: ...
+    def neighborlist(self) -> NeighborList[Literal[2]]: ...
     @property
     def coulomb_cutoff(self) -> Table[SystemId, Array]: ...
 

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -33,7 +33,7 @@ from kups.core.cell import Cell, Periodic3D
 from kups.core.constants import BOHR, HARTREE
 from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import Lens, NestedLens, SimpleLens, View, bind
-from kups.core.neighborlist import NearestNeighborList, all_connected_neighborlist
+from kups.core.neighborlist import NeighborList, all_connected_neighborlist
 from kups.core.patch import Accept, IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY,
@@ -689,7 +689,7 @@ def make_ewald_short_range_potential[
 ](
     particles_view: View[State, Table[ParticleId, IsEwaldPointData]],
     systems_view: View[State, Table[SystemId, HasCell[Periodic3D]]],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     parameter_view: View[State, EwaldParameters],
     probe: Probe[State, Ptch, IsRadiusGraphProbe[IsEwaldPointData]] | None,
     gradient_lens: Lens[PointCloud[IsEwaldPointData, HasCell[Periodic3D]], Gradients],
@@ -812,7 +812,7 @@ def make_ewald_potential[
 ](
     particles_view: View[State, Table[ParticleId, IsEwaldPointData]],
     systems_view: View[State, Table[SystemId, HasCell[Periodic3D]]],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     parameter_lens: Lens[State, EwaldParameters],
     cache_lens: Lens[State, EwaldCache] | None,
     probe: Probe[State, Ptch, IsRadiusGraphProbe[IsEwaldPointData]] | None,
@@ -888,7 +888,7 @@ def make_ewald_potential[
 
     def _make_probe(
         inclusion_fn: Callable[[IsEwaldPointData], Index[Any]],
-        neighborlist_override: NearestNeighborList | None = None,
+        neighborlist_override: NeighborList[Literal[2]] | None = None,
     ) -> Probe[State, Ptch, IsRadiusGraphProbe[_ParticleData]] | None:
         """Wrap `probe` to convert particle data with `inclusion_fn`.
 
@@ -904,8 +904,8 @@ def make_ewald_potential[
         @dataclass
         class _ProbeResult:
             particles: WithIndices[ParticleId, _ParticleData]
-            neighborlist_after: NearestNeighborList
-            neighborlist_before: NearestNeighborList
+            neighborlist_after: NeighborList[Literal[2]]
+            neighborlist_before: NeighborList[Literal[2]]
 
         def _wrapper(state: State, patch: Ptch) -> _ProbeResult:
             result = _p(state, patch)
@@ -1028,7 +1028,7 @@ class IsEwaldState[Params](Protocol):
     @property
     def systems(self) -> Table[SystemId, HasCell[Periodic3D]]: ...
     @property
-    def neighborlist(self) -> NearestNeighborList: ...
+    def neighborlist(self) -> NeighborList[Literal[2]]: ...
     @property
     def ewald_parameters(self) -> Params: ...
 

--- a/src/kups/potential/classical/lennard_jones.py
+++ b/src/kups/potential/classical/lennard_jones.py
@@ -31,7 +31,7 @@ from jax import Array
 
 from kups.core.data import Table
 from kups.core.lens import Lens, SimpleLens, View, identity_lens
-from kups.core.neighborlist import NearestNeighborList
+from kups.core.neighborlist import NeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY_LENS,
@@ -360,7 +360,7 @@ def make_lennard_jones_potential[
 ](
     particles_view: View[State, Table[ParticleId, IsLJGraphParticles]],
     systems_view: View[State, Table[SystemId, HasCell]],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     parameter_view: View[State, LennardJonesParameters],
     probe: Probe[State, Ptch, IsRadiusGraphProbe[IsLJGraphParticles]] | None,
     gradient_lens: Lens[LJRadiusInp, Gradients],
@@ -405,7 +405,7 @@ class IsLJState[Params](HasLJParticlesAndSystems, Protocol):
     """State with particles, systems, neighbor list, and LJ parameters."""
 
     @property
-    def neighborlist(self) -> NearestNeighborList: ...
+    def neighborlist(self) -> NeighborList[Literal[2]]: ...
     @property
     def lj_parameters(self) -> Params: ...
 
@@ -523,7 +523,7 @@ def make_pair_tail_corrected_lennard_jones_potential[
 ](
     particles_view: View[State, Table[ParticleId, IsLJGraphParticles]],
     systems_view: View[State, Table[SystemId, HasCell]],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     parameter_view: View[State, PairTailCorrectedLennardJonesParameters],
     probe: Probe[State, Ptch, IsRadiusGraphProbe[IsLJGraphParticles]] | None,
     gradient_lens: Lens[PCLJInp, Gradients],

--- a/src/kups/potential/common/evaluation.py
+++ b/src/kups/potential/common/evaluation.py
@@ -22,7 +22,7 @@ from kups.core.lens import Lens, View, lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
     Edges,
-    NearestNeighborList,
+    NeighborList,
     UniversalNeighborlistParameters,
 )
 from kups.core.patch import Patch, WithPatch
@@ -154,7 +154,7 @@ class _RadiusGraphEvalState:
     neighborlist_params: UniversalNeighborlistParameters
 
     @property
-    def neighborlist(self) -> NearestNeighborList:
+    def neighborlist(self) -> NeighborList[Literal[2]]:
         return DenseNearestNeighborList.from_state(self)
 
 

--- a/src/kups/potential/common/graph.py
+++ b/src/kups/potential/common/graph.py
@@ -38,7 +38,7 @@ from jax import Array
 from kups.core.capacity import Capacity
 from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import View, bind
-from kups.core.neighborlist import Edges, NearestNeighborList
+from kups.core.neighborlist import Edges, NeighborList
 from kups.core.patch import Patch, Probe
 from kups.core.typing import (
     HasCell,
@@ -207,9 +207,9 @@ class IsRadiusGraphProbe[P: IsRadiusGraphPoints](Protocol):
     @property
     def particles(self) -> WithIndices[ParticleId, P]: ...
     @property
-    def neighborlist_after(self) -> NearestNeighborList: ...
+    def neighborlist_after(self) -> NeighborList[Literal[2]]: ...
     @property
-    def neighborlist_before(self) -> NearestNeighborList: ...
+    def neighborlist_before(self) -> NeighborList[Literal[2]]: ...
 
 
 @dataclass
@@ -225,14 +225,14 @@ class RadiusGraphConstructor[
         particles: View extracting ``Indexed[ParticleId, P]`` from state.
         systems: View extracting ``Indexed[SystemId, S]`` (cell).
         cutoffs: View extracting ``Indexed[SystemId, Array]`` from state.
-        neighborlist: View extracting the ``NearestNeighborList`` from state.
+        neighborlist: View extracting the ``NeighborList`` from state.
         probe: Optional probe for incremental particle + neighbor list changes.
     """
 
     particles: View[State, Table[ParticleId, P]] = field(static=True)
     systems: View[State, Table[SystemId, S]] = field(static=True)
     cutoffs: View[State, Table[SystemId, Array]] = field(static=True)
-    neighborlist: View[State, NearestNeighborList] = field(static=True)
+    neighborlist: View[State, NeighborList[Literal[2]]] = field(static=True)
     probe: Probe[State, Ptch, IsRadiusGraphProbe[P]] | None = field(static=True)
 
     @jit(static_argnames=("old_graph",))

--- a/src/kups/potential/mliap/direct.py
+++ b/src/kups/potential/mliap/direct.py
@@ -34,7 +34,7 @@ from jax import Array
 
 from kups.core.data import Table
 from kups.core.lens import Lens, View
-from kups.core.neighborlist import NearestNeighborList
+from kups.core.neighborlist import NeighborList
 from kups.core.patch import Patch, WithPatch
 from kups.core.potential import Potential, PotentialOut
 from kups.core.typing import (
@@ -95,7 +95,7 @@ def make_direct_mliap_potential[
     model_fn: DirectMliapFn[Model, Gradients, Hessians, P, S, Ptch],
     particles_view: View[State, Table[ParticleId, P]],
     systems_view: View[State, Table[SystemId, S]],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     model_view: View[State, Model],
     cutoffs_view: View[State, Table[SystemId, Array]],
     *,

--- a/src/kups/potential/mliap/local.py
+++ b/src/kups/potential/mliap/local.py
@@ -49,7 +49,7 @@ from jax import Array
 
 from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import Lens, View, bind
-from kups.core.neighborlist import Edges, NearestNeighborList
+from kups.core.neighborlist import Edges, NeighborList
 from kups.core.patch import Accept, Patch, Probe, WithPatch
 from kups.core.potential import EMPTY_LENS, Energy, Potential, PotentialOut
 from kups.core.typing import (
@@ -482,7 +482,7 @@ class LocalMLIAPComposer[
     particles: View[State, Table[ParticleId, P]] = field(static=True)
     systems: View[State, Table[SystemId, S]] = field(static=True)
     cutoffs: View[State, Table[SystemId, Array]] = field(static=True)
-    neighborlist: View[State, NearestNeighborList] = field(static=True)
+    neighborlist: View[State, NeighborList[Literal[2]]] = field(static=True)
     model: Lens[State, LocalMLIAPData] = field(static=True)
     probe: Probe[State, Ptch, IsRadiusGraphProbe[P]] | None = field(static=True)
 
@@ -538,7 +538,7 @@ def make_local_mliap_potential[
     particles_view: View[State, Table[ParticleId, P]],
     systems_view: View[State, Table[SystemId, S]],
     cutoffs_view: View[State, Table[SystemId, Array]],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     model_lens: Lens[State, LocalMLIAPData],
     probe: Probe[State, Ptch, IsRadiusGraphProbe[P]] | None,
     gradient_lens: Lens[LocalMLIAPInput[State, P, S], Gradients],
@@ -598,7 +598,7 @@ class IsLocalMLIAPState[Model](Protocol):
     @property
     def systems(self) -> Table[SystemId, HasCell]: ...
     @property
-    def neighborlist(self) -> NearestNeighborList: ...
+    def neighborlist(self) -> NeighborList[Literal[2]]: ...
     @property
     def local_mliap_model(self) -> Model: ...
 

--- a/src/kups/potential/mliap/tojax.py
+++ b/src/kups/potential/mliap/tojax.py
@@ -19,7 +19,7 @@ from jax import Array, export
 
 from kups.core.data import Table
 from kups.core.lens import Lens, SimpleLens, View
-from kups.core.neighborlist import NearestNeighborList
+from kups.core.neighborlist import NeighborList
 from kups.core.patch import IdPatch, WithPatch
 from kups.core.potential import EMPTY_LENS, EmptyType, Energy, Potential, PotentialOut
 from kups.core.typing import HasAtomicNumbers, HasCell, ParticleId, SystemId
@@ -171,7 +171,7 @@ def tojaxed_energy(
 def make_tojaxed_potential[State, Gradients, Hessians](
     particles_view: View[State, Table[ParticleId, IsTojaxedParticles]],
     systems_view: View[State, Table[SystemId, HasCell]],
-    neighborlist_view: View[State, NearestNeighborList],
+    neighborlist_view: View[State, NeighborList[Literal[2]]],
     model: View[State, TojaxedMliap] | TojaxedMliap,
     cutoffs_view: View[State, Table[SystemId, Array]],
     gradient_lens: Lens[JaxifiedInput, Gradients],
@@ -225,7 +225,7 @@ class IsTojaxedState(Protocol):
     @property
     def systems(self) -> Table[SystemId, HasCell]: ...
     @property
-    def neighborlist(self) -> NearestNeighborList: ...
+    def neighborlist(self) -> NeighborList[Literal[2]]: ...
     @property
     def jaxified_model(self) -> TojaxedMliap: ...
 

--- a/src/kups/potential/mliap/torch/interface.py
+++ b/src/kups/potential/mliap/torch/interface.py
@@ -40,7 +40,7 @@ from jax import Array
 
 from kups.core.data import Table
 from kups.core.lens import Lens, View, bind
-from kups.core.neighborlist import NearestNeighborList
+from kups.core.neighborlist import NeighborList
 from kups.core.patch import IdPatch, Patch, WithPatch
 from kups.core.potential import EMPTY, EmptyType, Potential, PotentialOut
 from kups.core.typing import (
@@ -363,7 +363,7 @@ def make_torch_mliap_potential[
     State,
     P: IsTorchMliapParticles,
     S: HasCell,
-    NNList: NearestNeighborList,
+    NNList: NeighborList[Literal[2]],
 ](
     particles_view: View[State, Table[ParticleId, P]],
     systems_view: View[State, Table[SystemId, S]],
@@ -381,7 +381,7 @@ def make_torch_mliap_potential[
     State,
     P: IsTorchMliapParticles,
     S: HasCell,
-    NNList: NearestNeighborList,
+    NNList: NeighborList[Literal[2]],
 ](
     particles_view: View[State, Table[ParticleId, P]],
     systems_view: View[State, Table[SystemId, S]],
@@ -456,7 +456,7 @@ class IsTorchMliapState(Protocol):
     @property
     def systems(self) -> Table[SystemId, HasCell]: ...
     @property
-    def neighborlist(self) -> NearestNeighborList: ...
+    def neighborlist(self) -> NeighborList[Literal[2]]: ...
     @property
     def torch_mliap_model(self) -> TorchMliap: ...
 

--- a/test/md/test_integrators.py
+++ b/test/md/test_integrators.py
@@ -3,7 +3,7 @@
 
 """Unit tests for MD integrators."""
 
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import jax
 import jax.numpy as jnp
@@ -825,7 +825,7 @@ def test_stress_matches_ase():
     from kups.core.lens import identity_lens
     from kups.core.neighborlist import (
         DenseNearestNeighborList,
-        NearestNeighborList,
+        NeighborList,
         UniversalNeighborlistParameters,
     )
     from kups.observables.stress import stress_via_virial_theorem
@@ -860,7 +860,7 @@ def test_stress_matches_ase():
         lj_parameters: LennardJonesParameters
 
         @property
-        def neighborlist(self) -> NearestNeighborList:
+        def neighborlist(self) -> NeighborList[Literal[2]]:
             return DenseNearestNeighborList.from_state(self)
 
     lj = LennardJonesParameters.from_dict(


### PR DESCRIPTION
Rename `NearestNeighborList` to `NeighborList[D]` throughout the codebase, making the protocol generic over the edge arity `D: int`. This better reflects that the protocol describes neighbor list construction in general, not just nearest-neighbor pair searches, and makes the degree of the emitted edge tuples explicit in the type signature. All existing call sites are updated to use `NeighborList[Literal[2]]`, preserving the current pairwise behavior while opening the door for higher-arity edge implementations in the future. Documentation strings are updated accordingly to refer to "groups" rather than "pairs" where appropriate.

Part of #129.