### PR TITLE
feat: Add `EmptyNeighborList` and `FixedEdgesNeighborList` implementations

### DIFF
--- a/src/kups/core/neighborlist/__init__.py
+++ b/src/kups/core/neighborlist/__init__.py
@@ -40,6 +40,18 @@ These let one expensive base neighbor list be shared across multiple potentials.
 5. **[RefineCutoffNeighborList][kups.core.neighborlist.RefineCutoffNeighborList]**:
    refine precomputed edges with new cutoff distances.
 
+### Cutoff-Free Implementations
+
+These cover non-cutoff cases under the same `NeighborList[D]` protocol.
+
+6. **[EmptyNeighborList][kups.core.neighborlist.EmptyNeighborList]**: emits a
+   zero-row ``Edges[D]`` for point-cloud constructions.
+7. **[FixedEdgesNeighborList][kups.core.neighborlist.FixedEdgesNeighborList]**:
+   stores fixed edge topology for bonded edge sets supplied by the state and
+   computes current periodic shifts during calls. Patch-shaped calls with
+   ``rh`` and ``rh_index_remap`` return only rows touched by the remapped
+   particle ids.
+
 ## Pipeline Primitives
 
 Every neighbor list above is a [`Pipeline`][kups.core.neighborlist.Pipeline]
@@ -80,8 +92,13 @@ from kups.core.neighborlist.dense import (
     IsDenseNeighborlistParams,
 )
 from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.fixed import (
+    EmptyNeighborList,
+    FixedEdgesNeighborList,
+)
 from kups.core.neighborlist.masks import (
     DistanceCutoffMask,
+    EdgeInRhMask,
     ExclusionMask,
     InBoundsMask,
     InclusionMatchMask,
@@ -122,7 +139,10 @@ __all__ = [
     "DenseSelector",
     "DistanceCutoffMask",
     "Edges",
+    "EmptyNeighborList",
     "ExclusionMask",
+    "EdgeInRhMask",
+    "FixedEdgesNeighborList",
     "InBoundsMask",
     "InclusionGroupSelector",
     "InclusionMatchMask",

--- a/src/kups/core/neighborlist/compact.py
+++ b/src/kups/core/neighborlist/compact.py
@@ -3,20 +3,22 @@
 
 """Compactors for the neighbor list pipeline.
 
-Two flavors:
+Compactor variants:
 
 - [`ReduceCompactor`][kups.core.neighborlist.compact.ReduceCompactor] —
   compresses survivors via ``jnp.where(keep, size=k)`` with a capacity
-  assertion; mirrors edges when ``ctx.rh_index_remap`` is set.
+  assertion. By default it applies pair rh→lh remapping and mirrors remapped
+  pairs; fixed-topology callers disable those pair-only options and reuse the
+  same row compaction.
 - [`MaskOnlyCompactor`][kups.core.neighborlist.compact.MaskOnlyCompactor] —
   preserves the candidate count, replacing failing entries with OOB indices
   and zero shifts. Used by ``RefineMaskNeighborList``.
 
-Both compactors share the rh→lh remap (``remap_rh_to_lh``) so that the
-final ``Edges`` indices live in lh-space regardless of which compactor ran.
-Mirroring (doubling each edge with its reverse) is specific to
-``ReduceCompactor`` — it pairs with ``RemapDedupMask`` which removed one
-direction of each pair upstream.
+The pair rh→lh remap (``remap_rh_to_lh``) lets final pair ``Edges`` indices
+live in lh-space regardless of which pair compactor ran. Mirroring (doubling
+each edge with its reverse) is specific to the default ``ReduceCompactor``
+configuration — it pairs with ``RemapDedupMask`` which removed one direction
+of each pair upstream.
 """
 
 from __future__ import annotations
@@ -28,7 +30,7 @@ from kups.core.capacity import Capacity
 from kups.core.data import Index
 from kups.core.neighborlist.edges import Edges
 from kups.core.neighborlist.types import CandidateBatch, Compactor, PipelineContext
-from kups.core.utils.jax import dataclass
+from kups.core.utils.jax import dataclass, field
 from kups.core.utils.ops import where_broadcast_last
 
 
@@ -46,15 +48,17 @@ def remap_rh_to_lh(rh_idx: Array, ctx: PipelineContext) -> Array:
 
 @dataclass
 class ReduceCompactor[D: int](Compactor[D]):
-    """Compacts surviving candidates to a size-bounded ``Edges[2]``.
+    """Compact surviving candidates to a size-bounded ``Edges[D]``.
 
-    Applies the shared rh→lh remap, then — when ``ctx.rh_index_remap`` is
-    set — mirrors each surviving edge with its reverse (concatenating shifts
-    with their negatives). The mirror restores the symmetry that the paired
-    ``RemapDedupMask`` removed upstream.
+    The default configuration is the existing pair-neighbor-list behavior:
+    remap the rhs column into lh-space and mirror each remapped pair. Fixed
+    topology reuses the same row compaction with both pair-only options
+    disabled, preserving arbitrary-degree edge columns as emitted.
     """
 
     avg_edges: Capacity[int]
+    remap_rh: bool = field(static=True, default=True)
+    mirror_on_remap: bool = field(static=True, default=True)
 
     def __call__(
         self,
@@ -68,25 +72,26 @@ class ReduceCompactor[D: int](Compactor[D]):
         shifts = batch.edges.shifts.at[sort_idxs].get(
             mode="fill", fill_value=0, indices_are_sorted=True
         )
-        rh_idx_remapped = remap_rh_to_lh(batch.rh_idx, ctx)
-        lh_edge = batch.lh_idx.at[sort_idxs].get(
-            mode="fill", fill_value=oob, indices_are_sorted=True
-        )
-        rh_edge = rh_idx_remapped.at[sort_idxs].get(
-            mode="fill", fill_value=oob, indices_are_sorted=True
-        )
 
-        if ctx.rh_index_remap is not None:
-            shifts = jnp.concatenate([shifts, -shifts], axis=0)
-            lh_edge, rh_edge = (
-                jnp.concatenate([lh_edge, rh_edge], axis=0),
-                jnp.concatenate([rh_edge, lh_edge], axis=0),
+        if self.remap_rh:
+            rh_idx_remapped = remap_rh_to_lh(batch.rh_idx, ctx)
+            lh_edge = batch.lh_idx.at[sort_idxs].get(
+                mode="fill", fill_value=oob, indices_are_sorted=True
+            )
+            rh_edge = rh_idx_remapped.at[sort_idxs].get(
+                mode="fill", fill_value=oob, indices_are_sorted=True
+            )
+            indices = jnp.stack([lh_edge, rh_edge], axis=-1)
+
+            if self.mirror_on_remap and ctx.rh_index_remap is not None:
+                shifts = jnp.concatenate([shifts, -shifts], axis=0)
+                indices = jnp.concatenate([indices, indices[:, ::-1]], axis=0)
+        else:
+            indices = batch.edges.indices.indices.at[sort_idxs].get(
+                mode="fill", fill_value=oob, indices_are_sorted=True
             )
 
-        return Edges(
-            Index(batch.edges.indices.keys, jnp.stack([lh_edge, rh_edge], axis=-1)),
-            shifts,
-        )
+        return Edges(Index(batch.edges.indices.keys, indices), shifts)
 
 
 @dataclass

--- a/src/kups/core/neighborlist/fixed.py
+++ b/src/kups/core/neighborlist/fixed.py
@@ -1,0 +1,137 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Empty and fixed-edge :class:`NeighborList` implementations.
+
+These cover the cases that live today inline inside
+:class:`PointCloudConstructor` (always-empty edge set) and
+:class:`EdgeSetGraphConstructor` (state-provided edge topology, optionally
+filtered to a patch-affected subset). They satisfy the standard
+:class:`NeighborList[D]` protocol so a unified graph constructor can ask
+any neighbor list for edges, regardless of how those edges were obtained.
+
+``FixedEdgesNeighborList`` also supports the patch-shaped neighbor-list call
+used by graph constructors: when ``rh`` is supplied it requires
+``rh_index_remap`` and returns only fixed topology rows touched by those
+remapped particle ids. Its implementation is a normal selector -> mask ->
+compactor pipeline over the fixed edge rows; shifts are computed from the
+current particle positions during selection.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from kups.core.capacity import Capacity, FixedCapacity
+from kups.core.data import Index, Table
+from kups.core.neighborlist.compact import ReduceCompactor
+from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.masks import EdgeInRhMask
+from kups.core.neighborlist.pipeline import Pipeline
+from kups.core.neighborlist.types import (
+    CandidateBatch,
+    NeighborListPoints,
+    NeighborListSystems,
+    PipelineContext,
+)
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass, field, jit
+
+
+@dataclass
+class _FixedEdgesSelector[D: int]:
+    """Selector that turns stored fixed topology into current edge candidates."""
+
+    indices: Index[ParticleId]
+
+    def __call__(self, ctx: PipelineContext) -> CandidateBatch[D]:
+        indices = self.indices.update_labels(ctx.lh.keys).indices
+        positions = ctx.lh.data.positions.at[indices].get(mode="fill", fill_value=0)
+        deltas = positions[:, :1] - positions[:, 1:]
+        shifts = ctx.systems.data.cell.minimum_image_shifts(deltas)
+        return CandidateBatch(
+            edges=Edges(Index(ctx.lh.keys, indices), shifts),
+            is_minimum_image=jnp.ones((len(self.indices),), dtype=bool),
+        )
+
+
+@dataclass
+class EmptyNeighborList[D: int]:
+    """Neighbor list that emits an :class:`Edges[D]` with zero rows.
+
+    Replaces the inline empty-edges construction inside
+    :class:`PointCloudConstructor`. The ``degree`` field is the runtime
+    arity carried by the emitted edges; it must match the type parameter
+    ``D``.
+
+    Attributes:
+        degree: Edge arity (``Literal[0]`` for point clouds, higher for
+            unified graph constructors that need a degree-aware empty NL).
+    """
+
+    degree: int = field(static=True, default=0)
+
+    @jit
+    def __call__(
+        self,
+        lh: Table[ParticleId, NeighborListPoints],
+        rh: Table[ParticleId, NeighborListPoints] | None,
+        systems: Table[SystemId, NeighborListSystems],
+        rh_index_remap: Index[ParticleId] | None = None,
+    ) -> Edges[D]:
+        del rh, systems, rh_index_remap
+        shift_inner = self.degree - 1 if self.degree > 1 else 0
+        return Edges(
+            indices=Index(lh.keys, jnp.zeros((0, self.degree), dtype=int)),
+            shifts=jnp.zeros((0, shift_inner, 3), dtype=int),
+        )
+
+
+@dataclass
+class FixedEdgesNeighborList[D: int]:
+    """Neighbor list for a fixed topology edge set.
+
+    Replaces the full-graph path of :class:`EdgeSetGraphConstructor` and can
+    also serve its patch path. Full calls return all fixed topology rows with
+    shifts computed from the current particle positions. Patch calls pass
+    ``rh`` and ``rh_index_remap``; the remap identifies changed particle ids,
+    and the neighbor list returns only fixed rows touched by those particles.
+
+    Attributes:
+        indices: Fixed edge topology. Shifts are intentionally not stored;
+            they are computed from the call's current particle positions.
+        avg_edges: Average affected-edge capacity per patched right-hand row.
+            If not provided, defaults to the full edge-buffer size.
+    """
+
+    indices: Index[ParticleId]
+    avg_edges: Capacity[int] | None = None
+
+    @jit
+    def __call__(
+        self,
+        lh: Table[ParticleId, NeighborListPoints],
+        rh: Table[ParticleId, NeighborListPoints] | None,
+        systems: Table[SystemId, NeighborListSystems],
+        rh_index_remap: Index[ParticleId] | None = None,
+    ) -> Edges[D]:
+        if rh is None:
+            max_edges = FixedCapacity(len(self.indices))
+            remap = None
+        else:
+            assert rh_index_remap is not None, (
+                "FixedEdgesNeighborList requires rh_index_remap when rh is provided."
+            )
+            max_edges = (
+                self.avg_edges.multiply(rh.size)
+                if self.avg_edges is not None
+                else FixedCapacity(len(self.indices))
+            )
+            remap = rh_index_remap
+
+        pipeline = Pipeline[D](
+            selector=_FixedEdgesSelector(self.indices),
+            masks=(EdgeInRhMask(),),
+            compactor=ReduceCompactor(max_edges, remap_rh=False, mirror_on_remap=False),
+        )
+        return pipeline(lh, rh, systems, remap)

--- a/src/kups/core/neighborlist/masks.py
+++ b/src/kups/core/neighborlist/masks.py
@@ -80,6 +80,22 @@ class RemapDedupMask:
 
 
 @dataclass
+class EdgeInRhMask:
+    """Keep fixed-topology rows touched by ``ctx.rh_index_remap``.
+
+    When no remap is active, every row is kept. This lets fixed topology use
+    the same pipeline for full and patch-shaped calls.
+    """
+
+    def __call__(self, batch: CandidateBatch, ctx: PipelineContext) -> Array:
+        if ctx.rh_index_remap is None:
+            return jnp.ones((len(batch.edges),), dtype=bool)
+        return isin(batch.edges.indices.indices, ctx.rh_index_remap, ctx.lh.size).any(
+            -1
+        )
+
+
+@dataclass
 class DistanceCutoffMask:
     """Drops candidates whose squared real-space distance exceeds ``cutoff²``."""
 

--- a/src/kups/core/neighborlist/pipeline.py
+++ b/src/kups/core/neighborlist/pipeline.py
@@ -53,7 +53,7 @@ class Pipeline[D: int]:
     ) -> Edges[D]:
         ctx = _prepare(lh, rh, systems, rh_index_remap)
         batch = self.selector(ctx)
-        keep = jnp.ones((batch.lh_idx.size,), dtype=bool)
+        keep = jnp.ones((len(batch.edges),), dtype=bool)
         for mask in self.masks:
             keep &= mask(batch, ctx)
         return self.compactor(keep, batch, ctx)

--- a/test/core/test_neighborlist.py
+++ b/test/core/test_neighborlist.py
@@ -29,6 +29,8 @@ from kups.core.neighborlist import (
     CutoffNeighborListStrategy,
     DenseNearestNeighborList,
     Edges,
+    EmptyNeighborList,
+    FixedEdgesNeighborList,
     RefineCutoffNeighborList,
     RefineMaskNeighborList,
     UniversalNeighborlistParameters,
@@ -2806,3 +2808,172 @@ class TestAdaptiveCutoffFactory:
         result.raise_assertion()
         # Sanity: emitted Edges have the expected pair-degree.
         assert result.value.indices.shape[-1] == 2
+
+
+def _make_simple_lh(n: int):
+    positions = jnp.zeros((n, 3))
+    return _make_lh(positions, jnp.zeros(n, dtype=int))
+
+
+def _make_simple_systems():
+    cell = PeriodicCell(OrthogonalFrame(jnp.array([10.0, 10.0, 10.0])[None]))
+    systems, _ = _systems_from_cell(cell, jnp.array([2.0]))
+    return systems
+
+
+class TestEmptyNeighborList:
+    """``EmptyNeighborList`` returns zero-row ``Edges[D]`` regardless of input."""
+
+    def test_degree_zero_returns_empty_pointcloud(self):
+        nl = EmptyNeighborList[Literal[0]](degree=0)
+        edges = nl(_make_simple_lh(4), None, _make_simple_systems())
+        assert edges.indices.indices.shape == (0, 0)
+        assert edges.shifts.shape == (0, 0, 3)
+
+    def test_degree_two_returns_pair_shaped_empty(self):
+        nl = EmptyNeighborList[Literal[2]](degree=2)
+        edges = nl(_make_simple_lh(4), None, _make_simple_systems())
+        assert edges.indices.indices.shape == (0, 2)
+        assert edges.shifts.shape == (0, 1, 3)
+
+    def test_degree_three_returns_triple_shaped_empty(self):
+        nl = EmptyNeighborList[Literal[3]](degree=3)
+        edges = nl(_make_simple_lh(4), None, _make_simple_systems())
+        assert edges.indices.indices.shape == (0, 3)
+        assert edges.shifts.shape == (0, 2, 3)
+
+    def test_rh_and_remap_arguments_are_ignored(self):
+        nl = EmptyNeighborList[Literal[2]](degree=2)
+        lh = _make_simple_lh(4)
+        rh = _make_simple_lh(2)
+        remap = Index(lh.keys, jnp.array([0, 2]))
+        edges = nl(lh, rh, _make_simple_systems(), rh_index_remap=remap)
+        assert edges.indices.indices.shape == (0, 2)
+
+    def test_keys_come_from_lh(self):
+        nl = EmptyNeighborList[Literal[2]](degree=2)
+        lh = _make_simple_lh(5)
+        edges = nl(lh, None, _make_simple_systems())
+        assert edges.indices.keys == lh.keys
+
+    def test_jit_compiles(self):
+        nl = EmptyNeighborList[Literal[2]](degree=2)
+        lh = _make_simple_lh(4)
+        systems = _make_simple_systems()
+        edges = jax.jit(lambda l, s: nl(l, None, s))(lh, systems)
+        assert edges.indices.indices.shape == (0, 2)
+
+
+class TestFixedEdgesNeighborList:
+    """``FixedEdgesNeighborList`` returns full or patch-affected fixed edges."""
+
+    def _make_edges(self):
+        return _make_edges(jnp.array([0, 1, 2]), jnp.array([1, 2, 3]), n_particles=4)
+
+    def test_full_call_roundtrip_indices(self):
+        stored = self._make_edges()
+        nl = FixedEdgesNeighborList[Literal[2]](indices=stored.indices)
+        out = nl(_make_simple_lh(4), None, _make_simple_systems())
+        npt.assert_array_equal(out.indices.indices, stored.indices.indices)
+        npt.assert_array_equal(out.shifts, jnp.zeros_like(stored.shifts))
+
+    def test_full_call_computes_shifts_from_current_positions(self):
+        indices = Index(
+            (ParticleId(0), ParticleId(1)),
+            jnp.array([[0, 1]]),
+        )
+        nl = FixedEdgesNeighborList[Literal[2]](indices=indices)
+        lh = _make_lh(
+            jnp.array([[9.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+            jnp.zeros(2, dtype=int),
+        )
+        systems = _make_simple_systems()
+        out = nl(lh, None, systems)
+        npt.assert_allclose(out.shifts, jnp.array([[[1.0, 0.0, 0.0]]]))
+        npt.assert_allclose(
+            out.difference_vectors(lh, systems),
+            jnp.array([[[2.0, 0.0, 0.0]]]),
+        )
+
+    def test_full_call_ignores_remap_without_rh(self):
+        stored = self._make_edges()
+        nl = FixedEdgesNeighborList[Literal[2]](indices=stored.indices)
+        lh = _make_simple_lh(4)
+        remap = Index(lh.keys, jnp.array([3, 2, 1, 0]))
+        out = nl(lh, None, _make_simple_systems(), rh_index_remap=remap)
+        npt.assert_array_equal(out.indices.indices, stored.indices.indices)
+
+    def test_patch_call_returns_edges_touched_by_remap(self):
+        stored = self._make_edges()
+        nl = FixedEdgesNeighborList[Literal[2]](
+            indices=stored.indices, avg_edges=FixedCapacity(2)
+        )
+        lh = _make_simple_lh(4)
+        rh = _make_simple_lh(1)
+        remap = Index(lh.keys, jnp.array([2]))
+        out = nl(lh, rh, _make_simple_systems(), rh_index_remap=remap)
+        npt.assert_array_equal(out.indices.indices, jnp.array([[1, 2], [2, 3]]))
+        npt.assert_array_equal(out.shifts, jnp.zeros((2, 1, 3), dtype=int))
+
+    def test_patch_call_uses_capacity_and_pads_with_oob_rows(self):
+        stored = self._make_edges()
+        nl = FixedEdgesNeighborList[Literal[2]](
+            indices=stored.indices, avg_edges=FixedCapacity(3)
+        )
+        lh = _make_simple_lh(4)
+        rh = _make_simple_lh(1)
+        remap = Index(lh.keys, jnp.array([2]))
+        out = nl(lh, rh, _make_simple_systems(), rh_index_remap=remap)
+        npt.assert_array_equal(out.indices.indices, jnp.array([[1, 2], [2, 3], [4, 4]]))
+        npt.assert_array_equal(out.shifts[-1], jnp.zeros((1, 3), dtype=int))
+
+    def test_patch_call_multiplies_avg_edges_by_rh_size(self):
+        stored = self._make_edges()
+        nl = FixedEdgesNeighborList[Literal[2]](
+            indices=stored.indices, avg_edges=FixedCapacity(2)
+        )
+        lh = _make_simple_lh(4)
+        rh = _make_simple_lh(2)
+        remap = Index(lh.keys, jnp.array([0, 3]))
+        out = nl(lh, rh, _make_simple_systems(), rh_index_remap=remap)
+        npt.assert_array_equal(
+            out.indices.indices,
+            jnp.array([[0, 1], [2, 3], [4, 4], [4, 4]]),
+        )
+
+    def test_patch_call_requires_remap(self):
+        stored = self._make_edges()
+        nl = FixedEdgesNeighborList[Literal[2]](indices=stored.indices)
+        with pytest.raises(AssertionError, match="requires rh_index_remap"):
+            nl(_make_simple_lh(4), _make_simple_lh(1), _make_simple_systems())
+
+    def test_patch_call_capacity_assertion(self):
+        stored = self._make_edges()
+        nl = FixedEdgesNeighborList[Literal[2]](
+            indices=stored.indices, avg_edges=FixedCapacity(1)
+        )
+        lh = _make_simple_lh(4)
+        rh = _make_simple_lh(1)
+        remap = Index(lh.keys, jnp.array([2]))
+        result = as_result_function(nl)(
+            lh=lh, rh=rh, systems=_make_simple_systems(), rh_index_remap=remap
+        )
+        with pytest.raises(CapacityError):
+            result.raise_assertion()
+
+    def test_patch_call_supports_higher_degree_fixed_edges(self):
+        idx = jnp.array([[0, 1, 2], [1, 2, 3], [2, 3, 4], [0, 4, 3]])
+        shifts = jnp.zeros((4, 2, 3), dtype=int)
+        edges = Edges(Index(tuple(ParticleId(i) for i in range(5)), idx), shifts)
+        nl = FixedEdgesNeighborList[Literal[3]](
+            indices=edges.indices, avg_edges=FixedCapacity(3)
+        )
+        lh = _make_simple_lh(5)
+        rh = _make_simple_lh(1)
+        remap = Index(lh.keys, jnp.array([0]))
+        out = nl(lh, rh, _make_simple_systems(), rh_index_remap=remap)
+        npt.assert_array_equal(
+            out.indices.indices,
+            jnp.array([[0, 1, 2], [0, 4, 3], [5, 5, 5]]),
+        )
+        npt.assert_array_equal(out.shifts[-1], jnp.zeros((2, 3), dtype=int))


### PR DESCRIPTION
Two new neighbor list implementations are added that cover non-cutoff cases under the existing `NeighborList[D]` protocol:

**`EmptyNeighborList`** emits a zero-row `Edges[D]` for any edge arity, replacing the inline empty-edges construction previously embedded in `PointCloudConstructor`. The `degree` field controls the shape of the emitted indices and shifts arrays.

**`FixedEdgesNeighborList`** stores a fixed edge topology and computes periodic image shifts from current particle positions at call time. Full calls (no `rh`) return all stored rows. Patch-shaped calls require `rh_index_remap` and return only the rows whose particle indices are touched by the remapped ids, using `EdgeInRhMask` to filter and `ReduceCompactor` (with remapping and mirroring disabled) to compact results to a bounded buffer.

To support the fixed-topology path, `ReduceCompactor` gains two static boolean fields — `remap_rh` and `mirror_on_remap` — that gate the pair-specific rh→lh column remap and edge mirroring. When both are disabled the compactor operates directly on the stored multi-column index array, preserving arbitrary edge degree. A new `EdgeInRhMask` is added to `masks.py` that keeps rows containing any index present in `ctx.rh_index_remap`, passing all rows through when no remap is active.

The `Pipeline` keep-mask initialization is corrected to use `len(batch.edges)` instead of `batch.lh_idx.size`, making it compatible with the fixed-topology selector which does not populate `lh_idx` separately.  
  
Part of #124.