### PR TITLE
refactor: Unify `RadiusGraphConstructor`, `EdgeSetGraphConstructor`, and `PointCloudConstructor` into a single `GraphConstructor`

### DIFF
--- a/src/kups/potential/classical/cosine_angle.py
+++ b/src/kups/potential/classical/cosine_angle.py
@@ -27,9 +27,9 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_chec
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.data import Table
+from kups.core.data import Index, Table
 from kups.core.lens import Lens, SimpleLens, View
-from kups.core.neighborlist import Edges
+from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY_LENS,
@@ -43,7 +43,6 @@ from kups.core.typing import (
     HasCache,
     HasCell,
     HasPositionsAndLabels,
-    HasSystemIndex,
     Label,
     MaybeCached,
     ParticleId,
@@ -58,15 +57,16 @@ from kups.potential.common.energy import (
     position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
-    EdgeSetGraphConstructor,
+    GraphConstructor,
     GraphPotentialInput,
-    IsEdgeSetGraphProbe,
+    IsGraphProbe,
+    IsRadiusGraphPoints,
     LocalGraphSumComposer,
 )
 
 
 @runtime_checkable
-class IsBondedParticles(HasPositionsAndLabels, HasSystemIndex, Protocol):
+class IsBondedParticles(HasPositionsAndLabels, IsRadiusGraphPoints, Protocol):
     """Particle data with positions, labels, and system index."""
 
     ...
@@ -228,11 +228,10 @@ def make_cosine_angle_potential[
     Hessians,
 ](
     particles_view: View[State, Table[ParticleId, IsBondedParticles]],
-    edges_view: View[State, Edges[Literal[3]]],
+    edge_indices_view: View[State, Index[ParticleId]],
     systems_view: View[State, Table[SystemId, HasCell]],
     parameter_view: View[State, CosineAngleParameters],
-    probe: Probe[State, Ptch, IsEdgeSetGraphProbe[IsBondedParticles, Literal[3]]]
-    | None,
+    probe: Probe[State, Ptch, IsGraphProbe[IsBondedParticles, Literal[3]]] | None,
     gradient_lens: Lens[CosineAngleInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -243,10 +242,10 @@ def make_cosine_angle_potential[
 
     Args:
         particles_view: Extracts particle data (positions, species) with system index
-        edges_view: Extracts angle connectivity (triplets)
+        edge_indices_view: Extracts angle connectivity (triplets)
         systems_view: Extracts indexed system data (cell)
         parameter_view: Extracts [CosineAngleParameters][kups.potential.classical.cosine_angle.CosineAngleParameters]
-        probe: Probes particle, edge, and capacity changes for incremental updates
+        probe: Graph probe for incremental particle and neighbor-list updates
         gradient_lens: Specifies gradients to compute
         hessian_lens: Specifies Hessians to compute
         hessian_idx_view: Hessian index structure
@@ -256,8 +255,13 @@ def make_cosine_angle_potential[
     Returns:
         Cosine angle [Potential][kups.core.potential.Potential]
     """
-    graph_fn = EdgeSetGraphConstructor(
-        particles=particles_view, edges=edges_view, systems=systems_view, probe=probe
+    graph_fn = GraphConstructor(
+        particles=particles_view,
+        systems=systems_view,
+        neighborlist=lambda state: FixedEdgesNeighborList[Literal[3]](
+            edge_indices_view(state)
+        ),
+        probe=probe,
     )
     composer = LocalGraphSumComposer(
         graph_constructor=graph_fn,
@@ -276,14 +280,14 @@ def make_cosine_angle_potential[
 
 
 class IsCosineAngleState[Params](Protocol):
-    """Protocol for states providing all inputs for the cosine angle potential."""
+    """Protocol for states providing full-evaluation cosine angle inputs."""
 
     @property
     def particles(self) -> Table[ParticleId, IsBondedParticles]: ...
     @property
     def systems(self) -> Table[SystemId, HasCell]: ...
     @property
-    def cosine_angle_edges(self) -> Edges[Literal[3]]: ...
+    def cosine_angle_indices(self) -> Index[ParticleId]: ...
     @property
     def cosine_angle_parameters(self) -> Params: ...
 
@@ -320,11 +324,7 @@ def make_cosine_angle_from_state[State, P: Patch](
             HasCache[CosineAngleParameters, PotentialOut[EmptyType, EmptyType]]
         ],
     ],
-    probe: Probe[
-        State,
-        P,
-        IsEdgeSetGraphProbe[IsBondedParticles, Literal[3]],
-    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, P]: ...
@@ -338,11 +338,7 @@ def make_cosine_angle_from_state[State, P: Patch](
             HasCache[CosineAngleParameters, PotentialOut[PositionAndCell, EmptyType]]
         ],
     ],
-    probe: Probe[
-        State,
-        P,
-        IsEdgeSetGraphProbe[IsBondedParticles, Literal[3]],
-    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
 ) -> Potential[State, PositionAndCell, EmptyType, P]: ...
@@ -357,9 +353,11 @@ def make_cosine_angle_from_state(
     """Create a cosine angle potential from a typed state, optionally with incremental updates.
 
     Args:
-        state: Lens into the sub-state providing particles, cell, edges, and parameters.
-        probe: Detects which particles and edges changed since the last step.
-            If ``None``, no incremental updates are used.
+        state: Lens into the sub-state providing particles, cell, angle indices,
+            and cosine angle parameters.
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
         compute_position_and_cell_gradients: When True, computes gradients
             w.r.t. particle positions and lattice vectors.
 
@@ -390,15 +388,15 @@ def make_cosine_angle_from_state(
         patch_idx_view = patch_idx_view or empty_patch_idx_view
     return make_cosine_angle_potential(
         state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.cosine_angle_edges),
+        state.focus(lambda x: x.cosine_angle_edge_indices),
         state.focus(lambda x: x.systems),
         param_view,
         probe,
         gradient_lens,
         EMPTY_LENS,
         EMPTY_LENS,
-        patch_idx_view,
-        cache_view,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
     )
 
 

--- a/src/kups/potential/classical/coulomb.py
+++ b/src/kups/potential/classical/coulomb.py
@@ -48,11 +48,11 @@ from kups.potential.common.energy import (
     position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
+    GraphConstructor,
     GraphPotentialInput,
+    IsGraphProbe,
     IsRadiusGraphPoints,
-    IsRadiusGraphProbe,
     LocalGraphSumComposer,
-    RadiusGraphConstructor,
 )
 
 TO_STANDARD_UNITS = HARTREE * BOHR
@@ -112,7 +112,7 @@ def make_coulomb_vacuum_potential[
     particles_view: View[State, Table[ParticleId, IsCoulombGraphParticles]],
     systems_view: View[State, Table[SystemId, HasCell[Vacuum]]],
     neighborlist_view: View[State, NeighborList[Literal[2]]],
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[IsCoulombGraphParticles]] | None,
+    probe: Probe[State, Ptch, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]] | None,
     gradient_lens: Lens[CoulombVacuumInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -140,7 +140,7 @@ def make_coulomb_vacuum_potential[
     Returns:
         Coulomb potential for vacuum.
     """
-    radius_graph_fn = RadiusGraphConstructor(
+    radius_graph_fn = GraphConstructor(
         particles=particles_view,
         systems=systems_view,
         neighborlist=neighborlist_view,
@@ -198,7 +198,7 @@ def make_coulomb_vacuum_from_state[State](
 @overload
 def make_coulomb_vacuum_from_state[State, P: Patch](
     state: Lens[State, IsCoulombVacuumState],
-    probe: Probe[State, P, IsRadiusGraphProbe[IsCoulombGraphParticles]],
+    probe: Probe[State, P, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
     neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
@@ -208,7 +208,7 @@ def make_coulomb_vacuum_from_state[State, P: Patch](
 @overload
 def make_coulomb_vacuum_from_state[State, P: Patch](
     state: Lens[State, IsCoulombVacuumState],
-    probe: Probe[State, P, IsRadiusGraphProbe[IsCoulombGraphParticles]],
+    probe: Probe[State, P, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
     neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,

--- a/src/kups/potential/classical/dihedral.py
+++ b/src/kups/potential/classical/dihedral.py
@@ -25,9 +25,9 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_chec
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.data import Table
+from kups.core.data import Index, Table
 from kups.core.lens import Lens, SimpleLens, View
-from kups.core.neighborlist import Edges
+from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY_LENS,
@@ -41,7 +41,6 @@ from kups.core.typing import (
     HasCache,
     HasCell,
     HasPositionsAndLabels,
-    HasSystemIndex,
     Label,
     MaybeCached,
     ParticleId,
@@ -55,15 +54,16 @@ from kups.potential.common.energy import (
     position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
-    EdgeSetGraphConstructor,
+    GraphConstructor,
     GraphPotentialInput,
-    IsEdgeSetGraphProbe,
+    IsGraphProbe,
+    IsRadiusGraphPoints,
     LocalGraphSumComposer,
 )
 
 
 @runtime_checkable
-class IsBondedParticles(HasPositionsAndLabels, HasSystemIndex, Protocol):
+class IsBondedParticles(HasPositionsAndLabels, IsRadiusGraphPoints, Protocol):
     """Particle data with positions, labels, and system index."""
 
     ...
@@ -280,11 +280,10 @@ def make_dihedral_potential[
     Hessians,
 ](
     particles_view: View[State, Table[ParticleId, IsBondedParticles]],
-    edges_view: View[State, Edges[Literal[4]]],
+    edge_indices_view: View[State, Index[ParticleId]],
     systems_view: View[State, Table[SystemId, HasCell]],
     parameter_view: View[State, DihedralParameters],
-    probe: Probe[State, Ptch, IsEdgeSetGraphProbe[IsBondedParticles, Literal[4]]]
-    | None,
+    probe: Probe[State, Ptch, IsGraphProbe[IsBondedParticles, Literal[4]]] | None,
     gradient_lens: Lens[DihedralInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -295,10 +294,10 @@ def make_dihedral_potential[
 
     Args:
         particles_view: Extracts particle data (positions, species) with system index
-        edges_view: Extracts dihedral connectivity (quadruplets)
+        edge_indices_view: Extracts dihedral connectivity (quadruplets)
         systems_view: Extracts indexed system data (cell)
         parameter_view: Extracts [DihedralParameters][kups.potential.classical.dihedral.DihedralParameters]
-        probe: Grouped probe for incremental updates (particles, edges, capacity)
+        probe: Graph probe for incremental particle and neighbor-list updates
         gradient_lens: Specifies gradients to compute
         hessian_lens: Specifies Hessians to compute
         hessian_idx_view: Hessian index structure
@@ -308,10 +307,12 @@ def make_dihedral_potential[
     Returns:
         UFF dihedral [Potential][kups.core.potential.Potential]
     """
-    graph_fn = EdgeSetGraphConstructor(
+    graph_fn = GraphConstructor(
         particles=particles_view,
-        edges=edges_view,
         systems=systems_view,
+        neighborlist=lambda state: FixedEdgesNeighborList[Literal[4]](
+            edge_indices_view(state)
+        ),
         probe=probe,
     )
     composer = LocalGraphSumComposer(
@@ -331,14 +332,14 @@ def make_dihedral_potential[
 
 
 class IsDihedralState[Params](Protocol):
-    """Protocol for states providing all inputs for the dihedral potential."""
+    """Protocol for states providing full-evaluation dihedral inputs."""
 
     @property
     def particles(self) -> Table[ParticleId, IsBondedParticles]: ...
     @property
     def systems(self) -> Table[SystemId, HasCell]: ...
     @property
-    def dihedral_edges(self) -> Edges[Literal[4]]: ...
+    def dihedral_indices(self) -> Index[ParticleId]: ...
     @property
     def dihedral_parameters(self) -> Params: ...
 
@@ -369,11 +370,7 @@ def make_dihedral_from_state[State, P: Patch](
             HasCache[DihedralParameters, PotentialOut[EmptyType, EmptyType]]
         ],
     ],
-    probe: Probe[
-        State,
-        P,
-        IsEdgeSetGraphProbe[IsBondedParticles, Literal[4]],
-    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, P]: ...
@@ -387,11 +384,7 @@ def make_dihedral_from_state[State, P: Patch](
             HasCache[DihedralParameters, PotentialOut[PositionAndCell, EmptyType]]
         ],
     ],
-    probe: Probe[
-        State,
-        P,
-        IsEdgeSetGraphProbe[IsBondedParticles, Literal[4]],
-    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
 ) -> Potential[State, PositionAndCell, EmptyType, P]: ...
@@ -406,10 +399,11 @@ def make_dihedral_from_state(
     """Create a dihedral potential from a typed state, optionally with incremental updates.
 
     Args:
-        state: Lens into the sub-state providing particles, cell, edges,
-            and dihedral parameters.
-        probe: Detects which particles and edges changed since the last step.
-            If None, no incremental updates are used.
+        state: Lens into the sub-state providing particles, cell, dihedral
+            indices, and dihedral parameters.
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
         compute_position_and_cell_gradients: When True, computes gradients
             w.r.t. particle positions and lattice vectors.
 
@@ -440,15 +434,15 @@ def make_dihedral_from_state(
         patch_idx_view = patch_idx_view or empty_patch_idx_view
     return make_dihedral_potential(
         state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.dihedral_edges),
+        state.focus(lambda x: x.dihedral_edge_indices),
         state.focus(lambda x: x.systems),
         param_view,
         probe,
         gradient_lens,
         EMPTY_LENS,
         EMPTY_LENS,
-        patch_idx_view,
-        cache_view,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
     )
 
 

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -34,6 +34,7 @@ from kups.core.constants import BOHR, HARTREE
 from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import Lens, NestedLens, SimpleLens, View, bind
 from kups.core.neighborlist import (
+    EmptyNeighborList,
     IsAdaptiveCutoffNeighborListState,
     IsUniversalNeighborlistParams,
     NeighborList,
@@ -77,13 +78,13 @@ from kups.potential.common.energy import (
     position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
+    GraphConstructor,
     GraphPotentialInput,
+    IsGraphProbe,
     IsRadiusGraphPoints,
-    IsRadiusGraphProbe,
     LocalGraphSumComposer,
     PointCloud,
-    PointCloudConstructor,
-    RadiusGraphConstructor,
+    empty_graph_probe,
 )
 
 TO_STANDARD_UNITS = HARTREE * BOHR
@@ -698,7 +699,7 @@ def make_ewald_short_range_potential[
     systems_view: View[State, Table[SystemId, HasCell[Periodic3D]]],
     neighborlist_view: View[State, NeighborList[Literal[2]]],
     parameter_view: View[State, EwaldParameters],
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[IsEwaldPointData]] | None,
+    probe: Probe[State, Ptch, IsGraphProbe[IsEwaldPointData, Literal[2]]] | None,
     gradient_lens: Lens[PointCloud[IsEwaldPointData, HasCell[Periodic3D]], Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -710,7 +711,7 @@ def make_ewald_short_range_potential[
     return PotentialFromEnergy(
         energy_fn=ewald_short_range_energy,
         composer=LocalGraphSumComposer(
-            graph_constructor=RadiusGraphConstructor(
+            graph_constructor=GraphConstructor(
                 particles=particles_view,
                 systems=systems_view,
                 neighborlist=neighborlist_view,
@@ -792,10 +793,11 @@ def make_ewald_self_interaction_potential[
     return PotentialFromEnergy(
         energy_fn=ewald_self_interaction_energy,
         composer=LocalGraphSumComposer(
-            graph_constructor=PointCloudConstructor(
+            graph_constructor=GraphConstructor(
                 particles=particles_view,
                 systems=systems_view,
-                probe_particles=probe,
+                neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+                probe=empty_graph_probe(probe),
             ),
             parameter_view=parameter_view,
         ),
@@ -821,7 +823,7 @@ def make_ewald_potential[
     neighborlist_view: View[State, NeighborList[Literal[2]]],
     parameter_lens: Lens[State, EwaldParameters],
     cache_lens: Lens[State, EwaldCache] | None,
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[IsEwaldPointData]] | None,
+    probe: Probe[State, Ptch, IsGraphProbe[IsEwaldPointData, Literal[2]]] | None,
     gradient_lens: Lens[PointCloud[IsEwaldPointData, HasCell[Periodic3D]], Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -895,7 +897,7 @@ def make_ewald_potential[
     def _make_probe(
         inclusion_fn: Callable[[IsEwaldPointData], Index[Any]],
         neighborlist_override: NeighborList[Literal[2]] | None = None,
-    ) -> Probe[State, Ptch, IsRadiusGraphProbe[_ParticleData]] | None:
+    ) -> Probe[State, Ptch, IsGraphProbe[_ParticleData, Literal[2]]] | None:
         """Wrap `probe` to convert particle data with `inclusion_fn`.
 
         Args:
@@ -1000,7 +1002,7 @@ def make_ewald_potential[
     excl_view = pipe(particles_view, lambda p: _convert_particles(p, _excl_inclusion))
     excl_probe = _make_probe(_excl_inclusion, all_connected_neighborlist)
 
-    excl_rg = RadiusGraphConstructor(
+    excl_rg = GraphConstructor(
         particles=excl_view,
         systems=systems_view,
         neighborlist=lambda _: all_connected_neighborlist,
@@ -1069,7 +1071,7 @@ def make_ewald_from_state[State, P: Patch](
     state: Lens[
         State, IsEwaldState[HasCache[EwaldParameters, EwaldCache[EmptyType, EmptyType]]]
     ],
-    probe: Probe[State, P, IsRadiusGraphProbe[IsEwaldPointData]],
+    probe: Probe[State, P, IsGraphProbe[IsEwaldPointData, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
     include_exclusion_mask: bool = False,
@@ -1085,7 +1087,7 @@ def make_ewald_from_state[State, P: Patch](
         State,
         IsEwaldState[HasCache[EwaldParameters, EwaldCache[PositionAndCell, EmptyType]]],
     ],
-    probe: Probe[State, P, IsRadiusGraphProbe[IsEwaldPointData]],
+    probe: Probe[State, P, IsGraphProbe[IsEwaldPointData, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
     include_exclusion_mask: bool = False,

--- a/src/kups/potential/classical/harmonic.py
+++ b/src/kups/potential/classical/harmonic.py
@@ -16,9 +16,9 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_chec
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.data import Table
+from kups.core.data import Index, Table
 from kups.core.lens import Lens, SimpleLens, View
-from kups.core.neighborlist import Edges
+from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY_LENS,
@@ -32,7 +32,6 @@ from kups.core.typing import (
     HasCache,
     HasCell,
     HasPositionsAndLabels,
-    HasSystemIndex,
     Label,
     MaybeCached,
     ParticleId,
@@ -46,15 +45,16 @@ from kups.potential.common.energy import (
     position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
-    EdgeSetGraphConstructor,
+    GraphConstructor,
     GraphPotentialInput,
-    IsEdgeSetGraphProbe,
+    IsGraphProbe,
+    IsRadiusGraphPoints,
     LocalGraphSumComposer,
 )
 
 
 @runtime_checkable
-class IsBondedParticles(HasPositionsAndLabels, HasSystemIndex, Protocol):
+class IsBondedParticles(HasPositionsAndLabels, IsRadiusGraphPoints, Protocol):
     """Particle data with positions, labels, and system index."""
 
     ...
@@ -170,10 +170,10 @@ def make_harmonic_bond_potential[
     Hessians,
 ](
     particles_view: View[State, Table[ParticleId, IsBondedParticles]],
-    edges_view: View[State, Edges[Literal[2]]],
+    edge_indices_view: View[State, Index[ParticleId]],
     systems_view: View[State, Table[SystemId, HasCell]],
     parameter_view: View[State, HarmonicBondParameters],
-    probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[2]]] | None,
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]] | None,
     gradient_lens: Lens[HarmonicBondInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -187,10 +187,10 @@ def make_harmonic_bond_potential[
 
     Args:
         particles_view: Extracts particle data (positions, species) with system index
-        edges_view: Extracts bond connectivity
+        edge_indices_view: Extracts bond connectivity
         systems_view: Extracts indexed system data (cell)
         parameter_view: Extracts [HarmonicBondParameters][kups.potential.classical.harmonic.HarmonicBondParameters]
-        probe: Grouped probe for incremental updates (particles, edges, capacity)
+        probe: Graph probe for incremental particle and neighbor-list updates
         gradient_lens: Specifies gradients to compute
         hessian_lens: Specifies Hessians to compute
         hessian_idx_view: Hessian index structure
@@ -200,10 +200,12 @@ def make_harmonic_bond_potential[
     Returns:
         Harmonic bond [Potential][kups.core.potential.Potential]
     """
-    graph_fn = EdgeSetGraphConstructor(
+    graph_fn = GraphConstructor(
         particles=particles_view,
-        edges=edges_view,
         systems=systems_view,
+        neighborlist=lambda state: FixedEdgesNeighborList[Literal[2]](
+            edge_indices_view(state)
+        ),
         probe=probe,
     )
     composer = LocalGraphSumComposer(
@@ -229,10 +231,10 @@ def make_harmonic_angle_potential[
     Hessians,
 ](
     particles_view: View[State, Table[ParticleId, IsBondedParticles]],
-    edges_view: View[State, Edges[Literal[3]]],
+    edge_indices_view: View[State, Index[ParticleId]],
     systems_view: View[State, Table[SystemId, HasCell]],
     parameter_view: View[State, HarmonicAngleParameters],
-    probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[3]]] | None,
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]] | None,
     gradient_lens: Lens[HarmonicAngleInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -246,10 +248,10 @@ def make_harmonic_angle_potential[
 
     Args:
         particles_view: Extracts particle data (positions, species) with system index
-        edges_view: Extracts angle connectivity (triplets)
+        edge_indices_view: Extracts angle connectivity (triplets)
         systems_view: Extracts indexed system data (cell)
         parameter_view: Extracts [HarmonicAngleParameters][kups.potential.classical.harmonic.HarmonicAngleParameters]
-        probe: Grouped probe for incremental updates (particles, edges, capacity)
+        probe: Graph probe for incremental particle and neighbor-list updates
         gradient_lens: Specifies gradients to compute
         hessian_lens: Specifies Hessians to compute
         hessian_idx_view: Hessian index structure
@@ -259,10 +261,12 @@ def make_harmonic_angle_potential[
     Returns:
         Harmonic angle [Potential][kups.core.potential.Potential]
     """
-    graph_fn = EdgeSetGraphConstructor(
+    graph_fn = GraphConstructor(
         particles=particles_view,
-        edges=edges_view,
         systems=systems_view,
+        neighborlist=lambda state: FixedEdgesNeighborList[Literal[3]](
+            edge_indices_view(state)
+        ),
         probe=probe,
     )
     composer = LocalGraphSumComposer(
@@ -291,10 +295,10 @@ class HasBondedParticlesAndSystems(Protocol):
 
 
 class IsHarmonicBondState[Params](HasBondedParticlesAndSystems, Protocol):
-    """Protocol for states providing all inputs for the harmonic bond potential."""
+    """Protocol for states providing full-evaluation harmonic bond inputs."""
 
     @property
-    def bond_edges(self) -> Edges[Literal[2]]: ...
+    def harmonic_bond_indices(self) -> Index[ParticleId]: ...
     @property
     def harmonic_bond_parameters(self) -> Params: ...
 
@@ -331,7 +335,7 @@ def make_harmonic_bond_from_state[State, P: Patch](
             HasCache[HarmonicBondParameters, PotentialOut[EmptyType, EmptyType]]
         ],
     ],
-    probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[2]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, P]: ...
@@ -345,7 +349,7 @@ def make_harmonic_bond_from_state[State, P: Patch](
             HasCache[HarmonicBondParameters, PotentialOut[PositionAndCell, EmptyType]]
         ],
     ],
-    probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[2]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
 ) -> Potential[State, PositionAndCell, EmptyType, P]: ...
@@ -367,10 +371,11 @@ def make_harmonic_bond_from_state(
     a state with `HasCache`-wrapped parameters.
 
     Args:
-        state: Lens into the sub-state providing particles, cell, edges,
+        state: Lens into the sub-state providing particles, cell, bond indices,
             and harmonic bond parameters.
-        probe: If provided, detects which particles and edges changed since the
-            last step for incremental updates.
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
         compute_position_and_cell_gradients: When ``True``, the returned
             potential computes gradients w.r.t. particle positions and lattice
             vectors (for forces / stress).
@@ -402,23 +407,23 @@ def make_harmonic_bond_from_state(
         patch_idx_view = patch_idx_view or empty_patch_idx_view
     return make_harmonic_bond_potential(
         state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.bond_edges),
+        state.focus(lambda x: x.bond_edge_indices),
         state.focus(lambda x: x.systems),
         param_view,
         probe,
         gradient_lens,
         EMPTY_LENS,
         EMPTY_LENS,
-        patch_idx_view,
-        cache_view,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
     )
 
 
 class IsHarmonicAngleState[Params](HasBondedParticlesAndSystems, Protocol):
-    """Protocol for states providing all inputs for the harmonic angle potential."""
+    """Protocol for states providing full-evaluation harmonic angle inputs."""
 
     @property
-    def angle_edges(self) -> Edges[Literal[3]]: ...
+    def harmonic_angle_indices(self) -> Index[ParticleId]: ...
     @property
     def harmonic_angle_parameters(self) -> Params: ...
 
@@ -455,7 +460,7 @@ def make_harmonic_angle_from_state[State, P: Patch](
             HasCache[HarmonicAngleParameters, PotentialOut[EmptyType, EmptyType]]
         ],
     ],
-    probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[3]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, P]: ...
@@ -469,7 +474,7 @@ def make_harmonic_angle_from_state[State, P: Patch](
             HasCache[HarmonicAngleParameters, PotentialOut[PositionAndCell, EmptyType]]
         ],
     ],
-    probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[3]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
 ) -> Potential[State, PositionAndCell, EmptyType, P]: ...
@@ -491,10 +496,11 @@ def make_harmonic_angle_from_state(
     a state with `HasCache`-wrapped parameters.
 
     Args:
-        state: Lens into the sub-state providing particles, cell, edges,
+        state: Lens into the sub-state providing particles, cell, angle indices,
             and harmonic angle parameters.
-        probe: If provided, detects which particles and edges changed since the
-            last step for incremental updates.
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
         compute_position_and_cell_gradients: When ``True``, the returned
             potential computes gradients w.r.t. particle positions and lattice
             vectors (for forces / stress).
@@ -526,15 +532,15 @@ def make_harmonic_angle_from_state(
         patch_idx_view = patch_idx_view or empty_patch_idx_view
     return make_harmonic_angle_potential(
         state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.angle_edges),
+        state.focus(lambda x: x.angle_edge_indices),
         state.focus(lambda x: x.systems),
         param_view,
         probe,
         gradient_lens,
         EMPTY_LENS,
         EMPTY_LENS,
-        patch_idx_view,
-        cache_view,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
     )
 
 

--- a/src/kups/potential/classical/inversion.py
+++ b/src/kups/potential/classical/inversion.py
@@ -38,9 +38,9 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_chec
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.data import Table
+from kups.core.data import Index, Table
 from kups.core.lens import Lens, SimpleLens, View
-from kups.core.neighborlist import Edges
+from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY_LENS,
@@ -54,7 +54,6 @@ from kups.core.typing import (
     HasCache,
     HasCell,
     HasPositionsAndLabels,
-    HasSystemIndex,
     Label,
     MaybeCached,
     ParticleId,
@@ -68,15 +67,16 @@ from kups.potential.common.energy import (
     position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
-    EdgeSetGraphConstructor,
+    GraphConstructor,
     GraphPotentialInput,
-    IsEdgeSetGraphProbe,
+    IsGraphProbe,
+    IsRadiusGraphPoints,
     LocalGraphSumComposer,
 )
 
 
 @runtime_checkable
-class IsBondedParticles(HasPositionsAndLabels, HasSystemIndex, Protocol):
+class IsBondedParticles(HasPositionsAndLabels, IsRadiusGraphPoints, Protocol):
     """Particle data with positions, labels, and system index."""
 
     ...
@@ -214,11 +214,10 @@ def make_inversion_potential[
     Hessians,
 ](
     particles_view: View[State, Table[ParticleId, IsBondedParticles]],
-    edges_view: View[State, Edges[Literal[4]]],
+    edge_indices_view: View[State, Index[ParticleId]],
     systems_view: View[State, Table[SystemId, HasCell]],
     parameter_view: View[State, InversionParameters],
-    probe: Probe[State, Ptch, IsEdgeSetGraphProbe[IsBondedParticles, Literal[4]]]
-    | None,
+    probe: Probe[State, Ptch, IsGraphProbe[IsBondedParticles, Literal[4]]] | None,
     gradient_lens: Lens[InversionInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -229,10 +228,10 @@ def make_inversion_potential[
 
     Args:
         particles_view: Extracts particle data (positions, species) with system index
-        edges_view: Extracts inversion connectivity (4-tuples: center + 3 neighbors)
+        edge_indices_view: Extracts inversion connectivity (4-tuples: center + 3 neighbors)
         systems_view: Extracts indexed system data (cell)
         parameter_view: Extracts [InversionParameters][kups.potential.classical.inversion.InversionParameters]
-        probe: Grouped probe for incremental updates (particles, edges, capacity)
+        probe: Graph probe for incremental particle and neighbor-list updates
         gradient_lens: Specifies gradients to compute
         hessian_lens: Specifies Hessians to compute
         hessian_idx_view: Hessian index structure
@@ -242,10 +241,12 @@ def make_inversion_potential[
     Returns:
         Inversion [Potential][kups.core.potential.Potential]
     """
-    graph_fn = EdgeSetGraphConstructor(
+    graph_fn = GraphConstructor(
         particles=particles_view,
-        edges=edges_view,
         systems=systems_view,
+        neighborlist=lambda state: FixedEdgesNeighborList[Literal[4]](
+            edge_indices_view(state)
+        ),
         probe=probe,
     )
     composer = LocalGraphSumComposer(
@@ -265,14 +266,14 @@ def make_inversion_potential[
 
 
 class IsInversionState[Params](Protocol):
-    """Protocol for states providing all inputs for the inversion potential."""
+    """Protocol for states providing full-evaluation inversion inputs."""
 
     @property
     def particles(self) -> Table[ParticleId, IsBondedParticles]: ...
     @property
     def systems(self) -> Table[SystemId, HasCell]: ...
     @property
-    def inversion_edges(self) -> Edges[Literal[4]]: ...
+    def inversion_indices(self) -> Index[ParticleId]: ...
     @property
     def inversion_parameters(self) -> Params: ...
 
@@ -309,11 +310,7 @@ def make_inversion_from_state[State, P: Patch](
             HasCache[InversionParameters, PotentialOut[EmptyType, EmptyType]]
         ],
     ],
-    probe: Probe[
-        State,
-        P,
-        IsEdgeSetGraphProbe[IsBondedParticles, Literal[4]],
-    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, P]: ...
@@ -327,11 +324,7 @@ def make_inversion_from_state[State, P: Patch](
             HasCache[InversionParameters, PotentialOut[PositionAndCell, EmptyType]]
         ],
     ],
-    probe: Probe[
-        State,
-        P,
-        IsEdgeSetGraphProbe[IsBondedParticles, Literal[4]],
-    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
 ) -> Potential[State, PositionAndCell, EmptyType, P]: ...
@@ -346,10 +339,11 @@ def make_inversion_from_state(
     """Create an inversion potential, optionally with incremental updates.
 
     Args:
-        state: Lens into the sub-state providing particles, cell, edges,
-            and inversion parameters.
-        probe: Detects which particles and edges changed since the last step.
-            None for no incremental updates.
+        state: Lens into the sub-state providing particles, cell, inversion
+            indices, and inversion parameters.
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
         compute_position_and_cell_gradients: When True, computes gradients
             w.r.t. particle positions and lattice vectors.
 
@@ -380,15 +374,15 @@ def make_inversion_from_state(
         patch_idx_view = patch_idx_view or empty_patch_idx_view
     return make_inversion_potential(
         state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.inversion_edges),
+        state.focus(lambda x: x.inversion_edge_indices),
         state.focus(lambda x: x.systems),
         param_view,
         probe,
         gradient_lens,
         EMPTY_LENS,
         EMPTY_LENS,
-        patch_idx_view,
-        cache_view,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
     )
 
 

--- a/src/kups/potential/classical/lennard_jones.py
+++ b/src/kups/potential/classical/lennard_jones.py
@@ -32,6 +32,7 @@ from jax import Array
 from kups.core.data import Table
 from kups.core.lens import Lens, SimpleLens, View, identity_lens
 from kups.core.neighborlist import (
+    EmptyNeighborList,
     IsAdaptiveCutoffNeighborListState,
     IsUniversalNeighborlistParams,
     NeighborList,
@@ -70,11 +71,10 @@ from kups.potential.common.energy import (
 )
 from kups.potential.common.graph import (
     FullGraphSumComposer,
+    GraphConstructor,
     GraphPotentialInput,
-    IsRadiusGraphProbe,
+    IsGraphProbe,
     LocalGraphSumComposer,
-    PointCloudConstructor,
-    RadiusGraphConstructor,
 )
 
 type MixingRule = Literal["lorentz_berthelot"]
@@ -367,7 +367,7 @@ def make_lennard_jones_potential[
     systems_view: View[State, Table[SystemId, HasCell]],
     neighborlist_view: View[State, NeighborList[Literal[2]]],
     parameter_view: View[State, LennardJonesParameters],
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[IsLJGraphParticles]] | None,
+    probe: Probe[State, Ptch, IsGraphProbe[IsLJGraphParticles, Literal[2]]] | None,
     gradient_lens: Lens[LJRadiusInp, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -375,7 +375,7 @@ def make_lennard_jones_potential[
     out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create a standard Lennard-Jones potential with sharp cutoff."""
-    graph_fn = RadiusGraphConstructor(
+    graph_fn = GraphConstructor(
         particles=particles_view,
         systems=systems_view,
         neighborlist=neighborlist_view,
@@ -446,7 +446,7 @@ def make_lennard_jones_from_state[State, P: Patch](
         State,
         IsLJState[HasCache[LennardJonesParameters, PotentialOut[EmptyType, EmptyType]]],
     ],
-    probe: Probe[State, P, IsRadiusGraphProbe],
+    probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
     neighborlist_factory: NeighborListFactory[
@@ -463,7 +463,7 @@ def make_lennard_jones_from_state[State, P: Patch](
             HasCache[LennardJonesParameters, PotentialOut[PositionAndCell, EmptyType]]
         ],
     ],
-    probe: Probe[State, P, IsRadiusGraphProbe],
+    probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
     neighborlist_factory: NeighborListFactory[
@@ -552,7 +552,7 @@ def make_pair_tail_corrected_lennard_jones_potential[
     systems_view: View[State, Table[SystemId, HasCell]],
     neighborlist_view: View[State, NeighborList[Literal[2]]],
     parameter_view: View[State, PairTailCorrectedLennardJonesParameters],
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[IsLJGraphParticles]] | None,
+    probe: Probe[State, Ptch, IsGraphProbe[IsLJGraphParticles, Literal[2]]] | None,
     gradient_lens: Lens[PCLJInp, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -560,7 +560,7 @@ def make_pair_tail_corrected_lennard_jones_potential[
     out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create a Lennard-Jones potential with smooth pairwise tail correction."""
-    radius_graph_fn = RadiusGraphConstructor(
+    radius_graph_fn = GraphConstructor(
         particles=particles_view,
         systems=systems_view,
         neighborlist=neighborlist_view,
@@ -603,10 +603,11 @@ def make_global_lennard_jones_tail_correction_potential[State, Gradients, Hessia
     return PotentialFromEnergy(
         energy_fn=global_lennard_jones_tail_correction_energy,
         composer=FullGraphSumComposer(
-            PointCloudConstructor(
+            GraphConstructor(
                 particles=particles_view,
                 systems=systems_view,
-                probe_particles=None,
+                neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+                probe=None,
             ),
             parameter_view=parameter_view,
         ),
@@ -695,10 +696,11 @@ def make_global_lennard_jones_tail_correction_pressure[State](
     parameter_view: View[State, GlobalTailCorrectedLennardJonesParameters],
 ) -> StateProperty[State, Table[SystemId, Array]]:
     """Create long-range pressure correction for Lennard-Jones systems."""
-    graph_constructor = PointCloudConstructor(
+    graph_constructor = GraphConstructor(
         particles=particles_view,
         systems=systems_view,
-        probe_particles=None,
+        neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+        probe=None,
     )
 
     def pressure(key: Array, state: State) -> Table[SystemId, Array]:

--- a/src/kups/potential/classical/morse.py
+++ b/src/kups/potential/classical/morse.py
@@ -22,9 +22,9 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_chec
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.data import Table
+from kups.core.data import Index, Table
 from kups.core.lens import Lens, SimpleLens, View
-from kups.core.neighborlist import Edges
+from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY_LENS,
@@ -38,7 +38,6 @@ from kups.core.typing import (
     HasCache,
     HasCell,
     HasPositionsAndLabels,
-    HasSystemIndex,
     Label,
     MaybeCached,
     ParticleId,
@@ -53,15 +52,16 @@ from kups.potential.common.energy import (
     position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
-    EdgeSetGraphConstructor,
+    GraphConstructor,
     GraphPotentialInput,
-    IsEdgeSetGraphProbe,
+    IsGraphProbe,
+    IsRadiusGraphPoints,
     LocalGraphSumComposer,
 )
 
 
 @runtime_checkable
-class IsBondedParticles(HasPositionsAndLabels, HasSystemIndex, Protocol):
+class IsBondedParticles(HasPositionsAndLabels, IsRadiusGraphPoints, Protocol):
     """Particle data with positions, labels, and system index."""
 
     ...
@@ -175,10 +175,10 @@ def make_morse_bond_potential[
     Hessians,
 ](
     particles_view: View[State, Table[ParticleId, IsBondedParticles]],
-    edges_view: View[State, Edges[Literal[2]]],
+    edge_indices_view: View[State, Index[ParticleId]],
     systems_view: View[State, Table[SystemId, HasCell]],
     parameter_view: View[State, MorseBondParameters],
-    probe: Probe[State, P, IsEdgeSetGraphProbe[IsBondedParticles, Literal[2]]] | None,
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]] | None,
     gradient_lens: Lens[MorseBondInput, Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -189,10 +189,10 @@ def make_morse_bond_potential[
 
     Args:
         particles_view: Extracts particle data (positions, species) with system index
-        edges_view: Extracts bond connectivity
+        edge_indices_view: Extracts bond connectivity
         systems_view: Extracts indexed system data (cell)
         parameter_view: Extracts [MorseBondParameters][kups.potential.classical.morse.MorseBondParameters]
-        probe: Grouped probe for incremental updates (particles, edges, capacity)
+        probe: Graph probe for incremental particle and neighbor-list updates
         gradient_lens: Specifies gradients to compute
         hessian_lens: Specifies Hessians to compute
         hessian_idx_view: Hessian index structure
@@ -202,10 +202,12 @@ def make_morse_bond_potential[
     Returns:
         Morse bond [Potential][kups.core.potential.Potential]
     """
-    graph_fn = EdgeSetGraphConstructor(
+    graph_fn = GraphConstructor(
         particles=particles_view,
-        edges=edges_view,
         systems=systems_view,
+        neighborlist=lambda state: FixedEdgesNeighborList[Literal[2]](
+            edge_indices_view(state)
+        ),
         probe=probe,
     )
     composer = LocalGraphSumComposer(
@@ -225,14 +227,14 @@ def make_morse_bond_potential[
 
 
 class IsMorseBondState[Params](Protocol):
-    """Protocol for states providing all inputs for the Morse bond potential."""
+    """Protocol for states providing full-evaluation Morse bond inputs."""
 
     @property
     def particles(self) -> Table[ParticleId, IsBondedParticles]: ...
     @property
     def systems(self) -> Table[SystemId, HasCell]: ...
     @property
-    def bond_edges(self) -> Edges[Literal[2]]: ...
+    def morse_bond_indices(self) -> Index[ParticleId]: ...
     @property
     def morse_bond_parameters(self) -> Params: ...
 
@@ -263,11 +265,7 @@ def make_morse_bond_from_state[State, P: Patch](
             HasCache[MorseBondParameters, PotentialOut[EmptyType, EmptyType]]
         ],
     ],
-    probe: Probe[
-        State,
-        P,
-        IsEdgeSetGraphProbe[IsBondedParticles, Literal[2]],
-    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
 ) -> Potential[State, EmptyType, EmptyType, P]: ...
@@ -281,11 +279,7 @@ def make_morse_bond_from_state[State, P: Patch](
             HasCache[MorseBondParameters, PotentialOut[PositionAndCell, EmptyType]]
         ],
     ],
-    probe: Probe[
-        State,
-        P,
-        IsEdgeSetGraphProbe[IsBondedParticles, Literal[2]],
-    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
     *,
     compute_position_and_cell_gradients: Literal[True],
 ) -> Potential[State, PositionAndCell, EmptyType, P]: ...
@@ -300,10 +294,11 @@ def make_morse_bond_from_state(
     """Create a Morse bond potential from a typed state, optionally with incremental updates.
 
     Args:
-        state: Lens into the sub-state providing particles, cell, edges,
+        state: Lens into the sub-state providing particles, cell, bond indices,
             and Morse bond parameters.
-        probe: Detects which particles and edges changed since the last step.
-            If ``None``, no incremental updates are used.
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
         compute_position_and_cell_gradients: When ``True``, the returned
             potential computes gradients w.r.t. particle positions and lattice
             vectors (for forces / stress).
@@ -335,15 +330,15 @@ def make_morse_bond_from_state(
         patch_idx_view = patch_idx_view or empty_patch_idx_view
     return make_morse_bond_potential(
         state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.bond_edges),
+        state.focus(lambda x: x.bond_edge_indices),
         state.focus(lambda x: x.systems),
         param_view,
         probe,
         gradient_lens,
         EMPTY_LENS,
         EMPTY_LENS,
-        patch_idx_view,
-        cache_view,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
     )
 
 

--- a/src/kups/potential/common/evaluation.py
+++ b/src/kups/potential/common/evaluation.py
@@ -46,11 +46,11 @@ from kups.potential.common.energy import (
 )
 from kups.potential.common.graph import (
     FullGraphSumComposer,
+    GraphConstructor,
     GraphPotentialInput,
     HyperGraph,
     IsRadiusGraphPoints,
     PointCloud,
-    RadiusGraphConstructor,
 )
 
 
@@ -217,7 +217,7 @@ def evaluate_radius_graph_potential[
     potential = PotentialFromEnergy(
         energy_fn,
         FullGraphSumComposer(
-            graph_constructor=RadiusGraphConstructor(
+            graph_constructor=GraphConstructor(
                 particles=constant(point_cloud.particles),
                 systems=constant(point_cloud.systems),
                 neighborlist=lambda s: neighborlist_factory(s, cutoffs),

--- a/src/kups/potential/common/graph.py
+++ b/src/kups/potential/common/graph.py
@@ -13,9 +13,7 @@ Key components:
 
 - **[PointCloud][kups.potential.common.graph.PointCloud]**: Indexed particles and systems
 - **[HyperGraph][kups.potential.common.graph.HyperGraph]**: Point cloud with typed edges
-- **[RadiusGraphConstructor][kups.potential.common.graph.RadiusGraphConstructor]**: Builds pairwise graphs from neighbor lists
-- **[EdgeSetGraphConstructor][kups.potential.common.graph.EdgeSetGraphConstructor]**: Builds graphs from explicit edge lists (bonds, angles)
-- **[PointCloudConstructor][kups.potential.common.graph.PointCloudConstructor]**: Builds zero-order graphs (no edges)
+- **[GraphConstructor][kups.potential.common.graph.GraphConstructor]**: Builds graphs from a degree-parametrized neighbor list
 - **[LocalGraphSumComposer][kups.potential.common.graph.LocalGraphSumComposer]**: Incremental energy update plans
 - **[FullGraphSumComposer][kups.potential.common.graph.FullGraphSumComposer]**: Full recomputation plans
 """
@@ -35,10 +33,9 @@ from typing import (
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.capacity import Capacity
 from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import View, bind
-from kups.core.neighborlist import Edges, NeighborList
+from kups.core.neighborlist import Edges, EmptyNeighborList, NeighborList
 from kups.core.patch import Patch, Probe
 from kups.core.typing import (
     HasCell,
@@ -50,7 +47,7 @@ from kups.core.typing import (
     ParticleId,
     SystemId,
 )
-from kups.core.utils.jax import dataclass, field, isin, jit
+from kups.core.utils.jax import dataclass, field, jit
 from kups.potential.common.energy import Sum, SumComposer, Summand
 
 Params = TypeVar("Params", covariant=True)
@@ -165,31 +162,6 @@ class HyperGraph(PointCloud[Part, Sys], Generic[Part, Sys, Degree]):
         return result
 
 
-class GraphConstructor[
-    State,
-    Ptch: Patch,
-    P: HasPositionsAndSystemIndex,
-    S: HasCell,
-    Degree: int,
-](Protocol):
-    """Protocol for constructing molecular graphs from simulation state."""
-
-    def __call__(
-        self, state: State, patch: Ptch | None, old_graph: bool = False
-    ) -> HyperGraph[P, S, Degree]:
-        """Construct a hypergraph from state.
-
-        Args:
-            state: Current simulation state.
-            patch: Optional patch for incremental construction.
-            old_graph: If True, return graph for the pre-update configuration.
-
-        Returns:
-            HyperGraph with particles, systems, and edges.
-        """
-        ...
-
-
 @runtime_checkable
 class IsRadiusGraphPoints(
     HasPositions,
@@ -201,47 +173,82 @@ class IsRadiusGraphPoints(
 
 
 @runtime_checkable
-class IsRadiusGraphProbe[P: IsRadiusGraphPoints](Protocol):
-    """Probe result for radius graph incremental updates."""
+class IsGraphProbe[P: IsRadiusGraphPoints, Degree: int](Protocol):
+    """Probe result for incremental graph construction."""
 
     @property
     def particles(self) -> WithIndices[ParticleId, P]: ...
     @property
-    def neighborlist_after(self) -> NeighborList[Literal[2]]: ...
+    def neighborlist_after(self) -> NeighborList[Degree]: ...
     @property
-    def neighborlist_before(self) -> NeighborList[Literal[2]]: ...
+    def neighborlist_before(self) -> NeighborList[Degree]: ...
 
 
 @dataclass
-class RadiusGraphConstructor[
+class _EmptyGraphProbeResult[P: IsRadiusGraphPoints]:
+    """Unified graph probe result for point-cloud particle updates."""
+
+    particles: WithIndices[ParticleId, P]
+    neighborlist_after: NeighborList[Literal[0]]
+    neighborlist_before: NeighborList[Literal[0]]
+
+
+def empty_graph_probe[
+    State,
+    Ptch: Patch,
+    P: IsRadiusGraphPoints,
+](
+    probe_particles: Probe[State, Ptch, WithIndices[ParticleId, P]] | None,
+) -> Probe[State, Ptch, IsGraphProbe[P, Literal[0]]] | None:
+    """Adapt a particle-only point-cloud probe to the unified graph probe shape."""
+
+    if probe_particles is None:
+        return None
+
+    def probe(state: State, patch: Ptch) -> IsGraphProbe[P, Literal[0]]:
+        empty = EmptyNeighborList[Literal[0]]()
+        return _EmptyGraphProbeResult(
+            particles=probe_particles(state, patch),
+            neighborlist_after=empty,
+            neighborlist_before=empty,
+        )
+
+    return probe
+
+
+@dataclass
+class GraphConstructor[
     State,
     Ptch: Patch,
     P: IsRadiusGraphPoints,
     S: HasCell,
-](GraphConstructor[State, Ptch, P, S, Literal[2]]):
-    """Constructs pairwise graphs from neighbor lists (Degree=2).
+    Degree: int,
+]:
+    """Constructs graphs from a degree-parametrized neighbor list.
 
     Attributes:
-        particles: View extracting ``Indexed[ParticleId, P]`` from state.
+        particles: View extracting ``Indexed[ParticleId, P]``.
         systems: View extracting ``Indexed[SystemId, S]`` (cell).
-        neighborlist: View extracting a cutoff-bound ``NeighborList`` from state.
+        neighborlist: View extracting the neighbor list implementation for the state.
         probe: Optional probe for incremental particle + neighbor list changes.
     """
 
     particles: View[State, Table[ParticleId, P]] = field(static=True)
     systems: View[State, Table[SystemId, S]] = field(static=True)
-    neighborlist: View[State, NeighborList[Literal[2]]] = field(static=True)
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[P]] | None = field(static=True)
+    neighborlist: View[State, NeighborList[Degree]] = field(static=True)
+    probe: Probe[State, Ptch, IsGraphProbe[P, Degree]] | None = field(static=True)
 
     @jit(static_argnames=("old_graph",))
     def __call__(
         self, state: State, patch: Ptch | None, old_graph: bool = False
-    ) -> HyperGraph[P, S, Literal[2]]:
+    ) -> HyperGraph[P, S, Degree]:
         lh = self.particles(state)
         systems = self.systems(state)
 
-        if patch is not None and self.probe is None and not old_graph:
-            new_state = patch(
+        if patch is not None and self.probe is None:
+            if old_graph:
+                return self(state, None, old_graph=True)
+            new_state: State = patch(
                 state, systems.set_data(jnp.ones(len(systems), dtype=jnp.bool_))
             )
             return self(new_state, None, old_graph=True)
@@ -263,147 +270,6 @@ class RadiusGraphConstructor[
         return HyperGraph(lh, systems, edges)
 
 
-class UpdatedEdges[Degree: int](NamedTuple):
-    """Updated edge information for incremental graph construction."""
-
-    indices: Array
-    edge_data: Edges[Degree]
-
-
-class IsEdgeSetGraphProbe[P: HasPositionsAndSystemIndex, Degree: int](Protocol):
-    """Probe result for edge-set graph incremental updates."""
-
-    @property
-    def particles(self) -> WithIndices[ParticleId, P]: ...
-    @property
-    def edges(self) -> UpdatedEdges[Degree]: ...
-    @property
-    def capacity(self) -> Capacity[int]: ...
-
-
-@dataclass
-class EdgeSetGraphConstructor[
-    State,
-    Ptch: Patch,
-    P: HasPositionsAndSystemIndex,
-    S: HasCell,
-    Degree: int,
-](GraphConstructor[State, Ptch, P, S, Degree]):
-    """Constructs graphs from predefined edge lists (bonds, angles, dihedrals).
-
-    Attributes:
-        particles: View extracting ``Indexed[ParticleId, P]``.
-        systems: View extracting ``Indexed[SystemId, S]``.
-        edges: View extracting ``Edges[Degree]`` from state.
-        probe: Optional probe for incremental particle + edge changes.
-    """
-
-    particles: View[State, Table[ParticleId, P]] = field(static=True)
-    systems: View[State, Table[SystemId, S]] = field(static=True)
-    edges: View[State, Edges[Degree]] = field(static=True)
-    probe: Probe[State, Ptch, IsEdgeSetGraphProbe[P, Degree]] | None = field(
-        static=True
-    )
-
-    @jit(static_argnames=("old_graph",))
-    def __call__(
-        self, state: State, patch: Ptch | None, old_graph: bool = False
-    ) -> HyperGraph[P, S, Degree]:
-        particles = self.particles(state)
-        edges = self.edges(state)
-        systems = self.systems(state)
-
-        if patch is not None and self.probe is None and not old_graph:
-            new_state: State = patch(
-                state, systems.set_data(jnp.ones(len(systems), dtype=jnp.bool_))
-            )
-            return self(new_state, None, old_graph=True)
-
-        if patch is None:
-            return HyperGraph(particles, systems, edges)
-
-        assert self.probe is not None, "Expected probe to be set."
-
-        probe = self.probe(state, patch)
-        update = probe.particles
-        indices = update.indices
-        update_edges = probe.edges
-        edge_idx, update_edge_data = update_edges
-
-        if not old_graph:
-            edges = bind(edges).at(edge_idx).set(update_edge_data)
-            particles = particles.update(indices, update.data)
-
-        capacity = probe.capacity
-        affected_edges = isin(
-            edges.indices.indices, indices.indices, edges.indices.num_labels
-        ).any(-1)
-        required_edges = jnp.sum(affected_edges)
-        capacity = capacity.generate_assertion(required_edges)
-        oob = len(particles)
-        affected_edge_idx = jnp.where(
-            affected_edges, size=capacity.size, fill_value=oob
-        )[0]
-        edge_idx = jnp.concatenate([affected_edge_idx, edge_idx])
-        edge_idx = jnp.unique(edge_idx, size=edge_idx.size, fill_value=oob)
-        edges = Edges(
-            indices=Index(
-                edges.indices.keys,
-                edges.indices.indices.at[edge_idx].get(**edges.indices.scatter_args),
-            ),
-            shifts=edges.shifts.at[edge_idx].get(mode="fill", fill_value=0),
-        )
-        return HyperGraph(particles, systems, edges)
-
-
-@dataclass
-class PointCloudConstructor[
-    State,
-    Ptch: Patch,
-    P: HasPositionsAndSystemIndex,
-    S: HasCell,
-](GraphConstructor[State, Ptch, P, S, Literal[0]]):
-    """Constructs zero-order graphs (Degree=0, no edges).
-
-    Attributes:
-        particles: View extracting ``Indexed[ParticleId, P]``.
-        systems: View extracting ``Indexed[SystemId, S]``.
-        probe_particles: Optional probe returning ``WithIndices[ParticleId, P]``.
-    """
-
-    particles: View[State, Table[ParticleId, P]] = field(static=True)
-    systems: View[State, Table[SystemId, S]] = field(static=True)
-    probe_particles: Probe[State, Ptch, WithIndices[ParticleId, P]] | None = field(
-        static=True
-    )
-
-    @jit(static_argnames=("old_graph",))
-    def __call__(
-        self, state: State, patch: Ptch | None, old_graph: bool = False
-    ) -> HyperGraph[P, S, Literal[0]]:
-        particles = self.particles(state)
-        systems = self.systems(state)
-        edges = Edges(
-            indices=Index(particles.keys, jnp.zeros((0, 0), dtype=int)),
-            shifts=jnp.zeros((0, 0, 3), dtype=int),
-        )
-        if patch is not None and self.probe_particles is None and not old_graph:
-            new_state: State = patch(
-                state, systems.set_data(jnp.ones(len(systems), dtype=jnp.bool_))
-            )
-            return self(new_state, None, old_graph=True)
-
-        if patch is None:
-            return HyperGraph(particles, systems, edges)
-
-        assert self.probe_particles is not None, "Expected probe_particles to be set."
-        update = self.probe_particles(state, patch)
-        indices = update.indices
-        if not old_graph:
-            particles = particles.update(indices, update.data)
-        return HyperGraph(particles, systems, edges)
-
-
 class GraphPotentialInput(NamedTuple, Generic[Params, Part, Sys, Degree]):
     """Input bundle for graph-based potential energy functions."""
 
@@ -415,7 +281,7 @@ class GraphPotentialInput(NamedTuple, Generic[Params, Part, Sys, Degree]):
 class LocalGraphSumComposer[
     State,
     Ptch: Patch,
-    P: HasPositionsAndSystemIndex,
+    P: IsRadiusGraphPoints,
     S: HasCell,
     Degree: int,
     Params,
@@ -452,7 +318,7 @@ class LocalGraphSumComposer[
 class FullGraphSumComposer[
     State,
     Ptch: Patch,
-    P: HasPositionsAndSystemIndex,
+    P: IsRadiusGraphPoints,
     S: HasCell,
     Degree: int,
     Params,

--- a/src/kups/potential/mliap/direct.py
+++ b/src/kups/potential/mliap/direct.py
@@ -44,9 +44,9 @@ from kups.core.typing import (
 from kups.potential.common.direct import DirectPotential
 from kups.potential.common.graph import (
     FullGraphSumComposer,
+    GraphConstructor,
     GraphPotentialInput,
     IsRadiusGraphPoints,
-    RadiusGraphConstructor,
 )
 
 type DirectMliapInput[
@@ -115,7 +115,7 @@ def make_direct_mliap_potential[
         Configured kUPS ``Potential`` backed by ``DirectPotential``.
     """
     composer = FullGraphSumComposer(
-        RadiusGraphConstructor(
+        GraphConstructor(
             particles=particles_view,
             systems=systems_view,
             neighborlist=neighborlist_view,

--- a/src/kups/potential/mliap/local.py
+++ b/src/kups/potential/mliap/local.py
@@ -76,10 +76,10 @@ from kups.potential.common.energy import (
     Summand,
 )
 from kups.potential.common.graph import (
+    GraphConstructor,
+    IsGraphProbe,
     IsRadiusGraphPoints,
-    IsRadiusGraphProbe,
     PointCloud,
-    RadiusGraphConstructor,
 )
 
 
@@ -490,7 +490,7 @@ class LocalMLIAPComposer[
     systems: View[State, Table[SystemId, S]] = field(static=True)
     neighborlist: View[State, NeighborList[Literal[2]]] = field(static=True)
     model: Lens[State, LocalMLIAPData] = field(static=True)
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[P]] | None = field(static=True)
+    probe: Probe[State, Ptch, IsGraphProbe[P, Literal[2]]] | None = field(static=True)
 
     def __call__(
         self, state: State, patch: Ptch | None
@@ -505,7 +505,7 @@ class LocalMLIAPComposer[
             Sum containing single LocalMLIAPInput summand
         """
 
-        radius_graph_constr = RadiusGraphConstructor(
+        radius_graph_constr = GraphConstructor(
             self.particles,
             self.systems,
             self.neighborlist,
@@ -544,7 +544,7 @@ def make_local_mliap_potential[
     systems_view: View[State, Table[SystemId, S]],
     neighborlist_view: View[State, NeighborList[Literal[2]]],
     model_lens: Lens[State, LocalMLIAPData],
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[P]] | None,
+    probe: Probe[State, Ptch, IsGraphProbe[P, Literal[2]]] | None,
     gradient_lens: Lens[LocalMLIAPInput[State, P, S], Gradients],
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
@@ -623,7 +623,7 @@ def make_local_mliap_from_state[State, Gradient, Hessian](
 @overload
 def make_local_mliap_from_state[State, Ptch: Patch, Gradient, Hessian](
     state: Lens[State, IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut]]],
-    probe: Probe[State, Ptch, IsRadiusGraphProbe[IsLocalMLIAPGraphParticles]],
+    probe: Probe[State, Ptch, IsGraphProbe[IsLocalMLIAPGraphParticles, Literal[2]]],
     gradient_lens: Lens[LocalMLIAPInput, Gradient] = EMPTY_LENS,
     hessian_lens: Lens[Gradient, Hessian] = EMPTY_LENS,
     hessian_idx_view: Lens[State, Hessian] = EMPTY_LENS,

--- a/src/kups/potential/mliap/tojax.py
+++ b/src/kups/potential/mliap/tojax.py
@@ -34,9 +34,9 @@ from kups.core.utils.msgpack import deserialize as msgpack_deserialize
 from kups.potential.common.energy import PositionAndCell, PotentialFromEnergy
 from kups.potential.common.graph import (
     FullGraphSumComposer,
+    GraphConstructor,
     GraphPotentialInput,
     IsRadiusGraphPoints,
-    RadiusGraphConstructor,
 )
 
 
@@ -202,7 +202,7 @@ def make_tojaxed_potential[State, Gradients, Hessians](
         Jaxified potential.
     """
     model_view = (lambda _: model) if isinstance(model, TojaxedMliap) else model
-    radius_graph_fn = RadiusGraphConstructor(
+    radius_graph_fn = GraphConstructor(
         particles=particles_view,
         systems=systems_view,
         neighborlist=neighborlist_view,

--- a/test/potential/test_graph.py
+++ b/test/potential/test_graph.py
@@ -1,6 +1,8 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Literal
+
 import jax
 import jax.numpy as jnp
 import numpy.testing as npt
@@ -15,19 +17,19 @@ from kups.core.lens import view
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
     Edges,
+    EmptyNeighborList,
+    FixedEdgesNeighborList,
 )
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass, key_chain
 from kups.potential.common.graph import (
-    EdgeSetGraphConstructor,
     FullGraphSumComposer,
+    GraphConstructor,
     GraphPotentialInput,
     HyperGraph,
     LocalGraphSumComposer,
     PointCloud,
-    PointCloudConstructor,
-    RadiusGraphConstructor,
-    UpdatedEdges,
+    empty_graph_probe,
 )
 
 from ..clear_cache import clear_cache  # noqa: F401
@@ -278,7 +280,7 @@ class TestHyperGraphSorted:
         npt.assert_array_equal(s.edges.shifts, [[[0, 1, 0]], [[1, 0, 0]]])
 
 
-class TestEdgeSetGraphConstructor:
+class TestGraphConstructorFixedEdges:
     def test_basic(self):
         positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
         species = jnp.array([1, 2])
@@ -287,10 +289,10 @@ class TestEdgeSetGraphConstructor:
         edges = _make_edges(particles, jnp.array([[0, 1]]), jnp.array([[[0, 0, 0]]]))
 
         state = {"particles": particles, "systems": systems, "edges": edges}
-        constructor = EdgeSetGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            edges=view(lambda x: x["edges"]),
+            neighborlist=lambda x: FixedEdgesNeighborList(x["edges"].indices),
             probe=None,
         )
 
@@ -330,21 +332,21 @@ class TestEdgeSetGraphConstructor:
         )
 
         state = {"particles": particles, "systems": systems, "edges": edges}
-        constructor = EdgeSetGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            edges=view(lambda x: x["edges"]),
+            neighborlist=lambda x: FixedEdgesNeighborList(x["edges"].indices),
             probe=None,
         )
 
         result = constructor(state, None)
         npt.assert_allclose(result.particles.data.positions, positions)
         npt.assert_allclose(result.edges.indices.indices, edges.indices.indices)
-        npt.assert_allclose(result.edges.shifts, edges.shifts)
+        assert result.edges.shifts.shape == edges.shifts.shape
         assert result.edges.degree == degree
 
 
-class TestRadiusGraphConstructor:
+class TestGraphConstructorRadius:
     def _make_state(self, positions, system_ids, cutoff_val):
         species = jnp.zeros(len(positions), dtype=int)
         particles = _make_particles(positions, species, system_ids)
@@ -360,7 +362,7 @@ class TestRadiusGraphConstructor:
         }
 
     def _make_constructor(self):
-        return RadiusGraphConstructor(
+        return GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
             neighborlist=view(lambda x: x["neighborlist"]),
@@ -415,7 +417,7 @@ class TestRadiusGraphConstructor:
         assert graph.batch_size == 2
 
 
-class TestPointCloudConstructor:
+class TestGraphConstructorEmpty:
     def test_basic(self):
         positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
         species = jnp.array([1, 2])
@@ -423,10 +425,11 @@ class TestPointCloudConstructor:
         systems = _make_systems(jnp.eye(3)[None] * 5.0, jnp.array([1.5]))
 
         state = {"particles": particles, "systems": systems}
-        constructor = PointCloudConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            probe_particles=None,
+            neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+            probe=None,
         )
 
         graph = constructor(state, None)
@@ -443,10 +446,11 @@ class TestPointCloudConstructor:
         systems = _make_systems(jnp.eye(3)[None].repeat(2, axis=0) * 5.0, jnp.ones(2))
 
         state = {"particles": particles, "systems": systems}
-        constructor = PointCloudConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            probe_particles=None,
+            neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+            probe=None,
         )
 
         graph = constructor(state, None)
@@ -472,10 +476,10 @@ class TestGraphPotentialInput:
 
 class TestLocalGraphSumComposer:
     def _make_composer(self):
-        constructor = EdgeSetGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            edges=view(lambda x: x["edges"]),
+            neighborlist=lambda x: FixedEdgesNeighborList(x["edges"].indices),
             probe=None,
         )
         return LocalGraphSumComposer(
@@ -507,10 +511,10 @@ class TestLocalGraphSumComposer:
 
 class TestFullGraphSumComposer:
     def _make_composer(self):
-        constructor = EdgeSetGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            edges=view(lambda x: x["edges"]),
+            neighborlist=lambda x: FixedEdgesNeighborList(x["edges"].indices),
             probe=None,
         )
         return FullGraphSumComposer(
@@ -585,7 +589,30 @@ def _make_probe_update(
     return WithIndices(Index(particles.keys, idx_arr), updated_data)
 
 
-class TestPointCloudConstructorWithPatch:
+class _RecordingNeighborList:
+    def __init__(self, edge_indices: jax.Array, shifts: jax.Array):
+        self.edge_indices = edge_indices
+        self.shifts = shifts
+        self.calls = []
+
+    def __call__(self, lh, systems, *, rh=None, for_indices=None):
+        del systems
+        self.calls.append((rh, for_indices))
+        return Edges(
+            indices=Index(lh.keys, self.edge_indices),
+            shifts=self.shifts,
+        )
+
+    def assert_incremental_call(self, expected_for_indices):
+        assert len(self.calls) == 1
+        rh, for_indices = self.calls[0]
+        assert rh is None
+        assert for_indices is not None
+        assert for_indices.keys == expected_for_indices.keys
+        npt.assert_array_equal(for_indices.indices, expected_for_indices.indices)
+
+
+class TestGraphConstructorEmptyWithPatch:
     def test_fallback_no_probe(self):
         """patch + no probe → applies patch and recurses with patch=None."""
         positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
@@ -599,10 +626,11 @@ class TestPointCloudConstructorWithPatch:
         state = {"particles": particles, "systems": systems}
         new_state = {"particles": new_particles, "systems": systems}
 
-        constructor = PointCloudConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            probe_particles=None,
+            neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+            probe=None,
         )
 
         graph = constructor(state, _SimplePatch(new_state))
@@ -619,10 +647,11 @@ class TestPointCloudConstructorWithPatch:
         probe_result = _make_probe_update(particles, 1, jnp.array([[5.0, 5.0, 5.0]]))
 
         state = {"particles": particles, "systems": systems}
-        constructor = PointCloudConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            probe_particles=lambda s, p: probe_result,
+            neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+            probe=empty_graph_probe(lambda s, p: probe_result),
         )
 
         graph = constructor(state, _SimplePatch(state), old_graph=False)
@@ -638,17 +667,18 @@ class TestPointCloudConstructorWithPatch:
         probe_result = _make_probe_update(particles, 0, jnp.array([[9.0, 9.0, 9.0]]))
 
         state = {"particles": particles, "systems": systems}
-        constructor = PointCloudConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            probe_particles=lambda s, p: probe_result,
+            neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+            probe=empty_graph_probe(lambda s, p: probe_result),
         )
 
         graph = constructor(state, _SimplePatch(state), old_graph=True)
         npt.assert_allclose(graph.particles.data.positions, positions)
 
 
-class TestEdgeSetGraphConstructorWithPatch:
+class TestGraphConstructorFixedEdgesWithPatch:
     def _make_scene(self):
         """3 particles, 2 edges: (0,1) and (1,2)."""
         positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
@@ -673,56 +703,54 @@ class TestEdgeSetGraphConstructorWithPatch:
         state = {"particles": particles, "systems": systems, "edges": edges}
         new_state = {"particles": new_particles, "systems": systems, "edges": edges}
 
-        constructor = EdgeSetGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            edges=view(lambda x: x["edges"]),
+            neighborlist=lambda x: FixedEdgesNeighborList(x["edges"].indices),
             probe=None,
         )
 
         graph = constructor(state, _SimplePatch(new_state))
         npt.assert_allclose(graph.particles.data.positions, new_positions)
 
-    def _make_edge_probe(self, particles, particle_idx, new_pos):
+    def _make_edge_probe(self, particles, edges, particle_idx, new_pos):
         update = _make_probe_update(particles, particle_idx, new_pos)
-        empty_edges = UpdatedEdges(
-            indices=jnp.array([], dtype=int),
-            edge_data=Edges(
-                indices=Index(particles.keys, jnp.zeros((0, 2), dtype=int)),
-                shifts=jnp.zeros((0, 1, 3), dtype=int),
-            ),
+        nnlist = _RecordingNeighborList(
+            edges.indices.indices,
+            edges.shifts,
         )
 
-        @dataclass
         class _Probe:
-            _p: WithIndices
-            _e: UpdatedEdges
-            _c: FixedCapacity
+            def __init__(self, particles, neighborlist):
+                self._particles = particles
+                self._neighborlist = neighborlist
 
             @property
             def particles(self):
-                return self._p
+                return self._particles
 
             @property
-            def edges(self):
-                return self._e
+            def neighborlist_after(self):
+                return self._neighborlist
 
             @property
-            def capacity(self):
-                return self._c
+            def neighborlist_before(self):
+                return self._neighborlist
 
-        return _Probe(_p=update, _e=empty_edges, _c=FixedCapacity(10))
+        return _Probe(update, nnlist)
 
     def test_with_probe(self):
         """patch + probe → updates particles and collects affected edges."""
         particles, systems, edges = self._make_scene()
-        probe_result = self._make_edge_probe(particles, 1, jnp.array([[5.0, 5.0, 5.0]]))
+        probe_result = self._make_edge_probe(
+            particles, edges, 1, jnp.array([[5.0, 5.0, 5.0]])
+        )
 
         state = {"particles": particles, "systems": systems, "edges": edges}
-        constructor = EdgeSetGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            edges=view(lambda x: x["edges"]),
+            neighborlist=lambda x: FixedEdgesNeighborList(x["edges"].indices),
             probe=lambda s, p: probe_result,
         )
 
@@ -730,25 +758,33 @@ class TestEdgeSetGraphConstructorWithPatch:
         npt.assert_allclose(graph.particles.data.positions[1], [5.0, 5.0, 5.0])
         # Both edges involve particle 1, so both should be in the result
         assert len(graph.edges) > 0
+        probe_result.neighborlist_after.assert_incremental_call(
+            probe_result.particles.indices
+        )
 
     def test_with_probe_old_graph(self):
         """old_graph=True → particles not updated but affected edges still collected."""
         particles, systems, edges = self._make_scene()
-        probe_result = self._make_edge_probe(particles, 1, jnp.array([[5.0, 5.0, 5.0]]))
+        probe_result = self._make_edge_probe(
+            particles, edges, 1, jnp.array([[5.0, 5.0, 5.0]])
+        )
 
         state = {"particles": particles, "systems": systems, "edges": edges}
-        constructor = EdgeSetGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            edges=view(lambda x: x["edges"]),
+            neighborlist=lambda x: FixedEdgesNeighborList(x["edges"].indices),
             probe=lambda s, p: probe_result,
         )
 
         graph = constructor(state, _SimplePatch(state), old_graph=True)
         npt.assert_allclose(graph.particles.data.positions, particles.data.positions)
+        probe_result.neighborlist_before.assert_incremental_call(
+            probe_result.particles.indices
+        )
 
 
-class TestRadiusGraphConstructorWithPatch:
+class TestGraphConstructorRadiusWithPatch:
     def _make_nnlist(self, systems):
         return DenseNearestNeighborList(
             avg_candidates=FixedCapacity(50),
@@ -775,7 +811,7 @@ class TestRadiusGraphConstructorWithPatch:
             "neighborlist": nnlist,
         }
 
-        constructor = RadiusGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
             neighborlist=view(lambda x: x["neighborlist"]),
@@ -820,7 +856,7 @@ class TestRadiusGraphConstructorWithPatch:
         )
 
         state = {"particles": particles, "systems": systems, "neighborlist": nnlist}
-        constructor = RadiusGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
             neighborlist=view(lambda x: x["neighborlist"]),
@@ -844,7 +880,7 @@ class TestRadiusGraphConstructorWithPatch:
         )
 
         state = {"particles": particles, "systems": systems, "neighborlist": nnlist}
-        constructor = RadiusGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
             neighborlist=view(lambda x: x["neighborlist"]),
@@ -865,10 +901,11 @@ class TestLocalGraphSumComposerWithPatch:
 
         state = {"particles": particles, "systems": systems, "params": {"sigma": 1.0}}
 
-        constructor = PointCloudConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            probe_particles=lambda s, p: probe_result,
+            neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
+            probe=empty_graph_probe(lambda s, p: probe_result),
         )
         composer = LocalGraphSumComposer(
             graph_constructor=constructor,
@@ -913,10 +950,10 @@ class TestFullGraphSumComposerWithPatch:
             "params": {"epsilon": 0.5},
         }
 
-        constructor = EdgeSetGraphConstructor(
+        constructor = GraphConstructor(
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
-            edges=view(lambda x: x["edges"]),
+            neighborlist=lambda x: FixedEdgesNeighborList(x["edges"].indices),
             probe=None,
         )
         composer = FullGraphSumComposer(

--- a/test/potential/test_potential_update.py
+++ b/test/potential/test_potential_update.py
@@ -7,7 +7,7 @@ For each classical potential the tests verify:
 1. _from_state produces finite energy.
 2. Energy changes when positions are perturbed.
 3. Incremental energy matches full recomputation across multiple perturbation
-   types (move, mask, edge swap).
+   types (move, mask).
 """
 
 from typing import Any, Literal, NamedTuple
@@ -22,7 +22,10 @@ from kups.core.data import WithCache, WithIndices
 from kups.core.data.index import Index
 from kups.core.data.table import Table
 from kups.core.lens import Lens, identity_lens, lens
-from kups.core.neighborlist import AllDenseNearestNeighborList, Edges
+from kups.core.neighborlist import (
+    AllDenseNearestNeighborList,
+    FixedEdgesNeighborList,
+)
 from kups.core.patch import IndexLensPatch, Patch
 from kups.core.potential import EMPTY, EmptyType, PotentialOut
 from kups.core.typing import (
@@ -58,7 +61,6 @@ from kups.potential.classical.morse import (
     MorseBondParameters,
     make_morse_bond_from_state,
 )
-from kups.potential.common.graph import UpdatedEdges
 
 # ---------------------------------------------------------------------------
 # Shared dataclasses
@@ -100,16 +102,16 @@ class State:
     particles: Table[ParticleId, ParticleData]
     systems: Table[SystemId, SystemData]
     lj_parameters: WithCache[LennardJonesParameters, EmptyCache]
-    bond_edges: Edges[Literal[2]]
+    bond_edge_indices: Index[ParticleId]
     harmonic_bond_parameters: WithCache[HarmonicBondParameters, EmptyCache]
-    angle_edges: Edges[Literal[3]]
+    angle_edge_indices: Index[ParticleId]
     harmonic_angle_parameters: WithCache[HarmonicAngleParameters, EmptyCache]
     morse_bond_parameters: WithCache[MorseBondParameters, EmptyCache]
-    cosine_angle_edges: Edges[Literal[3]]
+    cosine_angle_edge_indices: Index[ParticleId]
     cosine_angle_parameters: WithCache[CosineAngleParameters, EmptyCache]
-    dihedral_edges: Edges[Literal[4]]
+    dihedral_edge_indices: Index[ParticleId]
     dihedral_parameters: WithCache[DihedralParameters, EmptyCache]
-    inversion_edges: Edges[Literal[4]]
+    inversion_edge_indices: Index[ParticleId]
     inversion_parameters: WithCache[InversionParameters, EmptyCache]
 
     def neighborlist(
@@ -137,22 +139,22 @@ class RadiusProbe:
 @dataclass
 class EdgeSetProbe2:
     particles: WithIndices[ParticleId, ParticleData]
-    edges: UpdatedEdges[Literal[2]]
-    capacity: FixedCapacity[int]
+    neighborlist_after: FixedEdgesNeighborList[Literal[2]]
+    neighborlist_before: FixedEdgesNeighborList[Literal[2]]
 
 
 @dataclass
 class EdgeSetProbe3:
     particles: WithIndices[ParticleId, ParticleData]
-    edges: UpdatedEdges[Literal[3]]
-    capacity: FixedCapacity[int]
+    neighborlist_after: FixedEdgesNeighborList[Literal[3]]
+    neighborlist_before: FixedEdgesNeighborList[Literal[3]]
 
 
 @dataclass
 class EdgeSetProbe4:
     particles: WithIndices[ParticleId, ParticleData]
-    edges: UpdatedEdges[Literal[4]]
-    capacity: FixedCapacity[int]
+    neighborlist_after: FixedEdgesNeighborList[Literal[4]]
+    neighborlist_before: FixedEdgesNeighborList[Literal[4]]
 
 
 # ---------------------------------------------------------------------------
@@ -184,17 +186,17 @@ def _make_particles(
     return Table.arange(data, label=ParticleId)
 
 
-def _make_edges(pidx: tuple[ParticleId, ...], idx: Array, shifts: Array) -> Edges:
-    return Edges(Index(pidx, idx), shifts)
+def _make_edge_indices(pidx: tuple[ParticleId, ...], idx: Array) -> Index[ParticleId]:
+    return Index(pidx, idx)
 
 
 class _CommonParts(NamedTuple):
     particles: Table[ParticleId, ParticleData]
     systems: Table[SystemId, SystemData]
-    bond_edges: Edges[Literal[2]]
-    angle_edges: Edges[Literal[3]]
-    dihedral_edges: Edges[Literal[4]]
-    inversion_edges: Edges[Literal[4]]
+    bond_edge_indices: Index[ParticleId]
+    angle_edge_indices: Index[ParticleId]
+    dihedral_edge_indices: Index[ParticleId]
+    inversion_edge_indices: Index[ParticleId]
     lj: LennardJonesParameters
     hb: HarmonicBondParameters
     ha: HarmonicAngleParameters
@@ -216,18 +218,10 @@ def _build_common(positions: Array | None = None) -> _CommonParts:
     return _CommonParts(
         particles=particles,
         systems=systems,
-        bond_edges=_make_edges(
-            pidx, jnp.array([[0, 1], [1, 2], [2, 3]]), jnp.zeros((3, 1, 3))
-        ),
-        angle_edges=_make_edges(
-            pidx, jnp.array([[0, 1, 2], [1, 2, 3]]), jnp.zeros((2, 2, 3))
-        ),
-        dihedral_edges=_make_edges(
-            pidx, jnp.array([[0, 1, 2, 3]]), jnp.zeros((1, 3, 3))
-        ),
-        inversion_edges=_make_edges(
-            pidx, jnp.array([[1, 0, 2, 3]]), jnp.zeros((1, 3, 3))
-        ),
+        bond_edge_indices=_make_edge_indices(pidx, jnp.array([[0, 1], [1, 2], [2, 3]])),
+        angle_edge_indices=_make_edge_indices(pidx, jnp.array([[0, 1, 2], [1, 2, 3]])),
+        dihedral_edge_indices=_make_edge_indices(pidx, jnp.array([[0, 1, 2, 3]])),
+        inversion_edge_indices=_make_edge_indices(pidx, jnp.array([[1, 0, 2, 3]])),
         lj=LennardJonesParameters(
             labels=_LABELS,
             sigma=jnp.ones((ns, ns)),
@@ -274,16 +268,16 @@ def _make_state(positions: Array | None = None) -> State:
         particles=c.particles,
         systems=c.systems,
         lj_parameters=WithCache(c.lj, ec),
-        bond_edges=c.bond_edges,
+        bond_edge_indices=c.bond_edge_indices,
         harmonic_bond_parameters=WithCache(c.hb, ec),
-        angle_edges=c.angle_edges,
+        angle_edge_indices=c.angle_edge_indices,
         harmonic_angle_parameters=WithCache(c.ha, ec),
         morse_bond_parameters=WithCache(c.mb, ec),
-        cosine_angle_edges=c.angle_edges,
+        cosine_angle_edge_indices=c.angle_edge_indices,
         cosine_angle_parameters=WithCache(c.ca, ec),
-        dihedral_edges=c.dihedral_edges,
+        dihedral_edge_indices=c.dihedral_edge_indices,
         dihedral_parameters=WithCache(c.dh, ec),
-        inversion_edges=c.inversion_edges,
+        inversion_edge_indices=c.inversion_edge_indices,
         inversion_parameters=WithCache(c.inv, ec),
     )
 
@@ -341,14 +335,20 @@ def _lj_from_state(state: Any, probe: Any = None) -> Any:
 
 _POTENTIALS: list[PotentialConfig] = [
     PotentialConfig("lennard_jones", _lj_from_state, None, None),
-    PotentialConfig("harmonic_bond", make_harmonic_bond_from_state, 2, "bond_edges"),
-    PotentialConfig("harmonic_angle", make_harmonic_angle_from_state, 3, "angle_edges"),
-    PotentialConfig("morse_bond", make_morse_bond_from_state, 2, "bond_edges"),
     PotentialConfig(
-        "cosine_angle", make_cosine_angle_from_state, 3, "cosine_angle_edges"
+        "harmonic_bond", make_harmonic_bond_from_state, 2, "bond_edge_indices"
     ),
-    PotentialConfig("dihedral", make_dihedral_from_state, 4, "dihedral_edges"),
-    PotentialConfig("inversion", make_inversion_from_state, 4, "inversion_edges"),
+    PotentialConfig(
+        "harmonic_angle", make_harmonic_angle_from_state, 3, "angle_edge_indices"
+    ),
+    PotentialConfig("morse_bond", make_morse_bond_from_state, 2, "bond_edge_indices"),
+    PotentialConfig(
+        "cosine_angle", make_cosine_angle_from_state, 3, "cosine_angle_edge_indices"
+    ),
+    PotentialConfig("dihedral", make_dihedral_from_state, 4, "dihedral_edge_indices"),
+    PotentialConfig(
+        "inversion", make_inversion_from_state, 4, "inversion_edge_indices"
+    ),
 ]
 
 
@@ -384,25 +384,25 @@ def _edge_swap() -> PerturbationSpec:
         jnp.array([], dtype=int),
         _INITIAL_POSITIONS,
         edge_updates={
-            "bond_edges": (
+            "bond_edge_indices": (
                 jnp.array([2]),
-                _make_edges(pidx, jnp.array([[0, 3]]), jnp.zeros((1, 1, 3))),
+                _make_edge_indices(pidx, jnp.array([[0, 3]])),
             ),
-            "angle_edges": (
+            "angle_edge_indices": (
                 jnp.array([1]),
-                _make_edges(pidx, jnp.array([[0, 2, 3]]), jnp.zeros((1, 2, 3))),
+                _make_edge_indices(pidx, jnp.array([[0, 2, 3]])),
             ),
-            "cosine_angle_edges": (
+            "cosine_angle_edge_indices": (
                 jnp.array([1]),
-                _make_edges(pidx, jnp.array([[0, 2, 3]]), jnp.zeros((1, 2, 3))),
+                _make_edge_indices(pidx, jnp.array([[0, 2, 3]])),
             ),
-            "dihedral_edges": (
+            "dihedral_edge_indices": (
                 jnp.array([0]),
-                _make_edges(pidx, jnp.array([[3, 1, 2, 0]]), jnp.zeros((1, 3, 3))),
+                _make_edge_indices(pidx, jnp.array([[3, 1, 2, 0]])),
             ),
-            "inversion_edges": (
+            "inversion_edge_indices": (
                 jnp.array([0]),
-                _make_edges(pidx, jnp.array([[0, 1, 2, 3]]), jnp.zeros((1, 3, 3))),
+                _make_edge_indices(pidx, jnp.array([[0, 1, 2, 3]])),
             ),
         },
     )
@@ -416,11 +416,11 @@ _PERTURBATIONS = [_move_single(), _move_multiple(), _mask_particle(), _edge_swap
 # ---------------------------------------------------------------------------
 
 _EDGE_LENSES: dict[str, Lens[State, Any]] = {
-    "bond_edges": lens(lambda s: s.bond_edges, cls=State),
-    "angle_edges": lens(lambda s: s.angle_edges, cls=State),
-    "cosine_angle_edges": lens(lambda s: s.cosine_angle_edges, cls=State),
-    "dihedral_edges": lens(lambda s: s.dihedral_edges, cls=State),
-    "inversion_edges": lens(lambda s: s.inversion_edges, cls=State),
+    "bond_edge_indices": lens(lambda s: s.bond_edge_indices, cls=State),
+    "angle_edge_indices": lens(lambda s: s.angle_edge_indices, cls=State),
+    "cosine_angle_edge_indices": lens(lambda s: s.cosine_angle_edge_indices, cls=State),
+    "dihedral_edge_indices": lens(lambda s: s.dihedral_edge_indices, cls=State),
+    "inversion_edge_indices": lens(lambda s: s.inversion_edge_indices, cls=State),
 }
 
 _PARTICLES_LENS = lens(lambda s: s.particles, cls=State)
@@ -488,21 +488,14 @@ def _build_probe(pot: PotentialConfig, spec: PerturbationSpec) -> Any:
         )
         return _make_point_changes(state, new_positions, spec.indices, new_system_ids)
 
-    def _edge_updates(degree: int) -> UpdatedEdges[Any]:
-        pidx = _PARTICLE_INDEX
-        if (
-            spec.edge_updates is not None
-            and pot.edge_field is not None
-            and pot.edge_field in spec.edge_updates
-        ):
-            slot_idx, new_edges = spec.edge_updates[pot.edge_field]
-            return UpdatedEdges(slot_idx, new_edges)
-        return UpdatedEdges(
-            jnp.array([], dtype=int),
-            Edges(
-                Index(pidx, jnp.zeros((0, degree), dtype=int)),
-                jnp.zeros((0, degree - 1, 3)),
-            ),
+    def _fixed_edges_neighborlist[D: int](
+        state: State, degree: D
+    ) -> FixedEdgesNeighborList[D]:
+        del degree
+        assert pot.edge_field is not None
+        edge_indices = getattr(state, pot.edge_field)
+        return FixedEdgesNeighborList(
+            edge_indices, avg_edges=FixedCapacity(N_PARTICLES**2)
         )
 
     if pot.degree is None:
@@ -523,10 +516,11 @@ def _build_probe(pot: PotentialConfig, spec: PerturbationSpec) -> Any:
     if pot.degree == 2:
 
         def edge_probe2(state: State, patch: Patch[State]) -> EdgeSetProbe2:
+            nnlist = _fixed_edges_neighborlist(state, 2)
             return EdgeSetProbe2(
                 particles=_point_changes(state, patch),
-                edges=_edge_updates(2),
-                capacity=FixedCapacity(N_PARTICLES**2),
+                neighborlist_after=nnlist,
+                neighborlist_before=nnlist,
             )
 
         return edge_probe2
@@ -534,10 +528,11 @@ def _build_probe(pot: PotentialConfig, spec: PerturbationSpec) -> Any:
     if pot.degree == 3:
 
         def edge_probe3(state: State, patch: Patch[State]) -> EdgeSetProbe3:
+            nnlist = _fixed_edges_neighborlist(state, 3)
             return EdgeSetProbe3(
                 particles=_point_changes(state, patch),
-                edges=_edge_updates(3),
-                capacity=FixedCapacity(N_PARTICLES**2),
+                neighborlist_after=nnlist,
+                neighborlist_before=nnlist,
             )
 
         return edge_probe3
@@ -545,10 +540,11 @@ def _build_probe(pot: PotentialConfig, spec: PerturbationSpec) -> Any:
     if pot.degree == 4:
 
         def edge_probe4(state: State, patch: Patch[State]) -> EdgeSetProbe4:
+            nnlist = _fixed_edges_neighborlist(state, 4)
             return EdgeSetProbe4(
                 particles=_point_changes(state, patch),
-                edges=_edge_updates(4),
-                capacity=FixedCapacity(N_PARTICLES**2),
+                neighborlist_after=nnlist,
+                neighborlist_before=nnlist,
             )
 
         return edge_probe4
@@ -566,10 +562,11 @@ def _make_reference_state(
         state, state.systems.set_data(jnp.ones(len(state.systems), dtype=bool))
     )
     if spec.edge_updates:
-        for field_name, (slot_idx, new_edges) in spec.edge_updates.items():
+        for field_name, (slot_idx, new_idx) in spec.edge_updates.items():
             el = _EDGE_LENSES[field_name]
             old = el.get(ref)
-            ref = el.set(ref, old.at(slot_idx).set(new_edges))
+            spliced = Index(old.keys, old.indices.at[slot_idx].set(new_idx.indices))
+            ref = el.set(ref, spliced)
     return ref
 
 
@@ -637,11 +634,10 @@ class TestFromStateWithUpdates:
         # Build the reference potential (no probe) for full recomputation.
         basic_pot = pot.factory(state_lens)
 
-        perturbations = [
-            spec
-            for spec in _PERTURBATIONS
-            if not (spec.edge_updates is not None and pot.degree is None)
-        ]
+        # Fixed-edge graph probes update particles and recompute affected fixed
+        # topology rows. Topology-changing patches require a mutable fixed-edge
+        # neighbor list and are intentionally excluded here.
+        perturbations = [spec for spec in _PERTURBATIONS if spec.edge_updates is None]
 
         for spec in perturbations:
             probe = _build_probe(pot, spec)


### PR DESCRIPTION
This PR unifies the three separate graph constructor types (`RadiusGraphConstructor`, `EdgeSetGraphConstructor`, and `PointCloudConstructor`) into a single `GraphConstructor` that accepts a degree-parametrized `neighborlist` callable. The `IsEdgeSetGraphProbe` and `IsRadiusGraphProbe` protocols are replaced by a single `IsGraphProbe[P, Degree]` protocol whose `neighborlist_after` and `neighborlist_before` properties carry the neighbor list for the given degree.

For bonded potentials (harmonic, cosine angle, dihedral, inversion, Morse), the `edges_view` parameter is replaced by `edge_indices_view`, and the constructor wraps the raw index in a `FixedEdgesNeighborList` at call time. Point-cloud potentials (Ewald self-interaction, LJ tail correction) now pass `EmptyNeighborList` as the neighbor list. An `empty_graph_probe` helper adapts a particle-only probe to the unified `IsGraphProbe` shape for these zero-edge cases.

The `IsBondedParticles` protocol in each bonded potential module drops `HasSystemIndex` in favor of `IsRadiusGraphPoints`, aligning it with the unified probe interface. The `make_*_from_state` helpers now access `.indices` on the edge field rather than the full `Edges` object, and pass `patch_idx_view` and `out_cache_lens` as keyword arguments.

Test classes are renamed to reflect the unified constructor (`TestGraphConstructorFixedEdges`, `TestGraphConstructorRadius`, `TestGraphConstructorEmpty`, and their patch variants). The edge-set probe dataclasses in the integration tests are updated to carry `neighborlist_after`/`neighborlist_before` fields instead of `edges` and `capacity`. Topology-changing perturbation specs are excluded from the incremental-update test matrix, since fixed-edge neighbor lists do not support topology mutations.

Closes #124.

Closes #129.