### PR TITLE
feat: Estimate `max_num_adsorbates` from vdW volumes, fix image-candidate replication

### DIFF
--- a/examples/mcmc_rigid.yaml
+++ b/examples/mcmc_rigid.yaml
@@ -24,4 +24,3 @@ run:
   translation_prob: 0
   rotation_prob: 0
   reinsertion_prob: 0
-max_num_adsorbates: 5000

--- a/src/kups/application/mcmc/data.py
+++ b/src/kups/application/mcmc/data.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, NamedTuple, override
+from typing import Any, Callable, NamedTuple, override
 
 import ase
 import ase.data
@@ -22,10 +22,13 @@ from kups.core.cell import AnyPeriodicity, Cell, is_3d_periodic, make_supercell
 from kups.core.constants import BOLTZMANN_CONSTANT, KELVIN, PASCAL
 from kups.core.data import Index, Table
 from kups.core.data.buffered import Buffered
+from kups.core.data.index import SupportsSorting
 from kups.core.lens import bind, lens
 from kups.core.typing import (
     ExclusionId,
     GroupId,
+    HasAtomicNumbers,
+    HasCell,
     InclusionId,
     Label,
     MotifId,
@@ -457,3 +460,55 @@ def mcmc_state_from_config(
         particles, lambda x: (x.data.motif.keys, x.data.group.max_count)
     ).set((motifs.keys, motifs.data.motif.max_count))
     return particles, groups, system, motifs
+
+
+def estimate_max_adsorbates(
+    particles: Table[Any, MCMCParticles],
+    motifs: Table[Any, MotifParticles],
+    systems: Table[SystemId, HasCell[AnyPeriodicity]],
+) -> Table[SystemId, Array]:
+    """Estimate the maximum number of motifs that could fit in each system.
+
+    The free volume per system (cell volume minus the volume occupied by
+    ``particles``) is divided by the smallest motif's occupied volume, giving
+    an upper bound on how many molecules could be inserted.
+
+    Args:
+        particles: Existing particles with atomic numbers and system membership.
+        motifs: Motif templates, with each motif's atoms grouped by its system index.
+        systems: Per-system table providing the simulation cell.
+
+    Returns:
+        Table mapping each ``SystemId`` to the maximum motif count (clamped at zero).
+    """
+    total_volume = systems.map_data(lambda s: s.cell.volume)
+    taken_volume = estimate_occupied_volume(particles, lambda s: s.system)
+    remaining_volume = total_volume - taken_volume
+    min_motif_volume = estimate_occupied_volume(motifs, lambda s: s.motif).data.min()
+    return remaining_volume.map_data(
+        lambda v: jnp.floor(jnp.maximum(v, 0.0) / min_motif_volume).astype(int)
+    )
+
+
+def estimate_occupied_volume[T: HasAtomicNumbers, K: SupportsSorting](
+    particles: Table[Any, T],
+    group_index: Callable[[T], Index[K]],
+) -> Table[K, Array]:
+    """Estimate the volume occupied by particles, grouped by a chosen index.
+
+    Each particle is treated as a sphere of its van der Waals radius
+    (``ase.data.vdw_radii``) and the volumes are summed within each group
+    selected by ``group_index``. Elements without a tabulated vdW radius
+    contribute zero.
+
+    Args:
+        particles: Particle table carrying atomic numbers.
+        group_index: Selects the grouping index from the particle data, e.g.
+            ``lambda p: p.system`` to aggregate per system.
+
+    Returns:
+        Table mapping each group key to its occupied volume (Ang^3).
+    """
+    radii = jnp.asarray(ase.data.vdw_radii)[particles.data.atomic_numbers]
+    volumes = jnp.nan_to_num(4.0 / 3.0 * jnp.pi * radii**3)
+    return group_index(particles.data).sum_over(volumes)

--- a/src/kups/application/simulations/mcmc_rigid.py
+++ b/src/kups/application/simulations/mcmc_rigid.py
@@ -30,6 +30,7 @@ from kups.application.mcmc.data import (
     HostConfig,
     MotifParticles,
     StressResult,
+    estimate_max_adsorbates,
     mcmc_state_from_config,
 )
 from kups.application.mcmc.logging import make_mcmc_logged_data
@@ -141,7 +142,6 @@ class Config(BaseModel):
     run: RunConfig
     lj: LJConfig
     ewald: EwaldConfig
-    max_num_adsorbates: int
     compute_stress: bool = False
 
 
@@ -371,6 +371,7 @@ def init_state(key: Array, config: Config) -> MCMCState:
         f"Initialized state with {len(particles)} particles, "
         f"{len(groups)} molecules, across {len(system)} systems."
     )
+    max_adsorbates = estimate_max_adsorbates(particles, motifs, system)
     n_sys = len(system)
     lj_params = GlobalTailCorrectedLennardJonesParameters.from_dict(
         cutoff=config.lj.cutoff,
@@ -386,10 +387,10 @@ def init_state(key: Array, config: Config) -> MCMCState:
     particles, groups, motifs, system = unify_keys_by_cls(
         (particles, groups, motifs, system)
     )
-    num_buffer_particles = config.max_num_adsorbates * max_motif_size
+    num_buffer_particles = max_adsorbates * max_motif_size
     particles, groups = add_buffers(
-        (particles, num_buffer_particles),
-        (groups, config.max_num_adsorbates),
+        (particles, int(num_buffer_particles.data.sum())),
+        (groups, int(max_adsorbates.data.sum())),
     )
 
     ewald_params = EwaldParameters.make(
@@ -401,7 +402,7 @@ def init_state(key: Array, config: Config) -> MCMCState:
     n_kvecs = ewald_params.reciprocal_lattice_shifts.data.shape[1]
 
     neighborlist_params = UniversalNeighborlistParameters.estimate(
-        particles.data.system.counts + num_buffer_particles / n_sys,
+        particles.data.system.counts + num_buffer_particles,
         system,
         tree_map(jnp.maximum, lj_params.cutoff, ewald_params.cutoff),
     )

--- a/src/kups/core/neighborlist/common.py
+++ b/src/kups/core/neighborlist/common.py
@@ -11,6 +11,9 @@ Contains:
   selector algorithms while raw ``(lhs, rhs)`` index arrays are being built.
   Not the pipeline carrier (see
   [`CandidateBatch`][kups.core.neighborlist.types.CandidateBatch]).
+- ``candidate_image_counts`` — per-axis periodic-image multiplicity a cutoff
+  reaches (the replication factor); used by ``_get_candidate_images`` and by
+  ``parameters.estimate``.
 - ``_generate_image_offsets``, ``_get_candidate_images`` — image-expansion
   primitives.
 - ``replicate_for_images`` — adapts raw ``Candidates`` into a
@@ -157,7 +160,7 @@ def _generate_image_offsets(images: jax.Array, out_size: Capacity[int]) -> jax.A
     return coords - half
 
 
-def _candidate_image_counts(cells: Cell[AnyPeriodicity], cutoffs: Array) -> Array:
+def candidate_image_counts(cells: Cell[AnyPeriodicity], cutoffs: Array) -> Array:
     """Return per-system, per-axis image counts for candidate replication.
 
     Periodic axes covered by the minimum-image convention use one image. Wider
@@ -182,7 +185,7 @@ def _get_candidate_images(
     out_size: Capacity[int],
 ) -> tuple[Array, Array, Array]:
     cells = systems.data.cell
-    images = _candidate_image_counts(cells, cutoffs)
+    images = candidate_image_counts(cells, cutoffs)
     images_per_sys = jnp.prod(images, axis=-1).astype(int)
 
     cand_sys_ids = lh.data.system.indices[candidates.lhs.indices]

--- a/src/kups/core/neighborlist/parameters.py
+++ b/src/kups/core/neighborlist/parameters.py
@@ -17,7 +17,7 @@ import jax.numpy as jnp
 from jax import Array
 
 from kups.core.data import Table
-from kups.core.neighborlist.common import num_cells
+from kups.core.neighborlist.common import candidate_image_counts, num_cells
 from kups.core.neighborlist.types import NeighborListSystems
 from kups.core.typing import SystemId
 from kups.core.utils.jax import dataclass, field, no_jax_tracing
@@ -66,7 +66,9 @@ class UniversalNeighborlistParameters:
     Attributes:
         avg_edges: Average number of edges per particle (for edge capacity).
         avg_candidates: Average number of candidate pairs per particle.
-        avg_image_candidates: Average number of image candidate pairs per particle.
+        avg_image_candidates: Average number of candidate pairs per particle after
+            periodic-image replication (equals ``avg_candidates`` when every cutoff
+            stays within the minimum-image regime).
         cells: Maximum number of spatial hash cells across all systems.
     """
 
@@ -102,21 +104,30 @@ class UniversalNeighborlistParameters:
         Returns:
             A ``UniversalNeighborlistParameters`` instance with estimated values.
         """
+
+        def _next_power(total: float | Array) -> int:
+            return int(next_higher_power(jnp.array(total * multiplier), base=base))
+
         sys = Table.join(systems, particles_per_system, cutoffs)
-        total_candidates = total_edges = max_cells = 0
+        total_candidates = total_image_candidates = total_edges = max_cells = 0
         for _, (s, n_p, c) in sys:
             n_bins = num_cells(s, c).prod()
-            total_candidates += min(n_p / n_bins * (3**3), n_p)
+            candidates = min(n_p / n_bins * (3**3), n_p)
+            # A cutoff reaching past perp/2 replicates each candidate once per
+            # periodic image (product of per-axis image counts). Summing per
+            # system keeps the estimate tight for heterogeneous cutoffs instead
+            # of assuming every system replicates at the maximum rate.
+            images = candidate_image_counts(s.cell, c).prod()
+            total_candidates += candidates
+            total_image_candidates += _next_power(candidates) * images
             total_edges += _estimate_avg_num_edges(
                 n_p, s.cell.volume, c, base, multiplier
             )
             max_cells = max(n_bins, max_cells)
-        total_candidates = next_higher_power(
-            jnp.array(total_candidates * multiplier / sys.size), base=base
-        )
+
         return UniversalNeighborlistParameters(
             avg_edges=int(total_edges // sys.size),
-            avg_candidates=int(total_candidates),
-            avg_image_candidates=int(total_candidates),  # Image candidates ~ candidates
+            avg_candidates=_next_power(total_candidates / sys.size),
+            avg_image_candidates=_next_power(total_image_candidates / sys.size),
             cells=int(max_cells),
         )

--- a/test/application/test_mcmc_data.py
+++ b/test/application/test_mcmc_data.py
@@ -1,11 +1,12 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for mcmc_state_from_ase and _make_molecule."""
+"""Tests for mcmc_state_from_ase, _make_molecule, and estimate_occupied_volume."""
 
 import tempfile
 
 import ase
+import ase.data
 import ase.io
 import jax
 import jax.numpy as jnp
@@ -15,12 +16,24 @@ import numpy.testing as npt
 from kups.application.mcmc.data import (
     AdsorbateConfig,
     HostConfig,
+    MCMCParticles,
+    MCMCSystems,
+    MotifParticles,
     _make_molecule,
+    estimate_max_adsorbates,
+    estimate_occupied_volume,
     mcmc_state_from_config,
 )
 from kups.core.cell import PeriodicCell, TriclinicFrame
 from kups.core.data import Index, Table
-from kups.core.typing import Label, MotifId
+from kups.core.typing import (
+    GroupId,
+    Label,
+    MotifId,
+    MotifParticleId,
+    ParticleId,
+    SystemId,
+)
 
 L = 10.0  # cubic box side (Ang)
 
@@ -270,3 +283,140 @@ class TestSystemFields:
         log_act = self.systems_multi.data.log_activity
         assert log_act.shape == (1, 2)
         assert jnp.all(log_act > self.systems_multi.data.log_fugacity)
+
+
+def _particles(
+    atomic_numbers: list[int],
+    system: list[int],
+    group: list[int] | None = None,
+) -> Table[ParticleId, MCMCParticles]:
+    """Build a minimal particle table from atomic numbers, system, and group ids."""
+    n = len(atomic_numbers)
+    group = group if group is not None else [0] * n
+    return Table.arange(
+        MCMCParticles(
+            positions=jnp.zeros((n, 3)),
+            masses=jnp.ones(n),
+            atomic_numbers=jnp.asarray(atomic_numbers),
+            charges=jnp.zeros(n),
+            labels=Index.new([Label("X")] * n),
+            system=Index.integer(np.asarray(system), label=SystemId),
+            group=Index.integer(np.asarray(group), label=GroupId, max_count=n),
+            motif=Index.zeros(n, label=MotifParticleId),
+        ),
+        label=ParticleId,
+    )
+
+
+def _sphere_volume(z: int) -> float:
+    return float(4.0 / 3.0 * np.pi * ase.data.vdw_radii[z] ** 3)
+
+
+class TestEstimateOccupiedVolume:
+    """Tests for estimate_occupied_volume."""
+
+    def test_per_system_sum(self):
+        # System 0: H + O, system 1: C + H.
+        vol = estimate_occupied_volume(
+            _particles([1, 8, 6, 1], [0, 0, 1, 1]), lambda p: p.system
+        )
+        assert vol.keys == (SystemId(0), SystemId(1))
+        npt.assert_allclose(
+            vol.data,
+            jnp.array(
+                [
+                    _sphere_volume(1) + _sphere_volume(8),
+                    _sphere_volume(6) + _sphere_volume(1),
+                ]
+            ),
+            rtol=1e-5,
+        )
+
+    def test_group_index_selects_aggregation(self):
+        # Same particles, grouped by group index instead of system.
+        particles = _particles([1, 8, 6], [0, 0, 0], group=[0, 1, 1])
+        vol = estimate_occupied_volume(particles, lambda p: p.group)
+        assert vol.keys == (GroupId(0), GroupId(1))
+        npt.assert_allclose(
+            vol.data,
+            jnp.array([_sphere_volume(1), _sphere_volume(8) + _sphere_volume(6)]),
+            rtol=1e-5,
+        )
+
+    def test_undefined_radius_contributes_zero(self):
+        # Sc (Z=21) has no tabulated vdW radius -> treated as zero volume.
+        vol = estimate_occupied_volume(_particles([21, 8], [0, 0]), lambda p: p.system)
+        npt.assert_allclose(vol.data, jnp.array([_sphere_volume(8)]), rtol=1e-5)
+
+    def test_jit(self):
+        particles = _particles([1, 8, 6, 1], [0, 0, 1, 1])
+        fn = lambda p: estimate_occupied_volume(p, lambda x: x.system)  # noqa: E731
+        npt.assert_allclose(jax.jit(fn)(particles).data, fn(particles).data)
+
+
+def _motifs(species: list[list[int]]) -> Table[MotifParticleId, MotifParticles]:
+    """Build motif templates, one motif per inner list of atomic numbers."""
+    atomic_numbers = [z for s in species for z in s]
+    motif_ids = [i for i, s in enumerate(species) for _ in s]
+    n = len(atomic_numbers)
+    return Table.arange(
+        MotifParticles(
+            positions=jnp.zeros((n, 3)),
+            masses=jnp.ones(n),
+            atomic_numbers=jnp.asarray(atomic_numbers),
+            charges=jnp.zeros(n),
+            labels=Index.new([Label("X")] * n),
+            motif=Index.integer(np.asarray(motif_ids), label=MotifId),
+        ),
+        label=MotifParticleId,
+    )
+
+
+def _systems(sides: list[float]) -> Table[SystemId, MCMCSystems]:
+    """Build a per-system table of cubic cells with the given side lengths."""
+    n = len(sides)
+    frames = TriclinicFrame.from_matrix(jnp.stack([jnp.eye(3) * s for s in sides]))
+    return Table.arange(
+        MCMCSystems(
+            cell=PeriodicCell(frames),
+            temperature=jnp.full(n, 300.0),
+            potential_energy=jnp.zeros(n),
+            log_fugacity=jnp.zeros((n, 1)),
+        ),
+        label=SystemId,
+    )
+
+
+class TestEstimateMaxAdsorbates:
+    """Tests for estimate_max_adsorbates."""
+
+    def test_counts_use_smallest_motif(self):
+        # Cubic box (vol L^3) holding two O atoms; motifs are [H] and [C, O].
+        particles = _particles([8, 8], [0, 0])
+        motifs = _motifs([[1], [6, 8]])
+        free = L**3 - 2 * _sphere_volume(8)
+        expected = np.floor(free / _sphere_volume(1))  # smallest motif is the H atom
+        result = estimate_max_adsorbates(particles, motifs, _systems([L]))
+        assert result.keys == (SystemId(0),)
+        npt.assert_array_equal(result.data, jnp.array([expected], dtype=int))
+
+    def test_per_system(self):
+        # System 0 empty (side L); system 1 holds one O atom (side L / 2).
+        particles = _particles([8], [1])
+        result = estimate_max_adsorbates(
+            particles, _motifs([[1], [6, 8]]), _systems([L, L / 2])
+        )
+        expected = jnp.array(
+            [
+                np.floor(L**3 / _sphere_volume(1)),
+                np.floor(((L / 2) ** 3 - _sphere_volume(8)) / _sphere_volume(1)),
+            ],
+            dtype=int,
+        )
+        npt.assert_array_equal(result.data, expected)
+
+    def test_clamped_at_zero(self):
+        # Tiny box fully occupied -> no room for adsorbates.
+        particles = _particles([8, 8, 8], [0, 0, 0])
+        result = estimate_max_adsorbates(particles, _motifs([[6, 8]]), _systems([1.0]))
+        npt.assert_array_equal(result.data, jnp.array([0]))

--- a/test/core/neighborlist/integration/test_against_ase.py
+++ b/test/core/neighborlist/integration/test_against_ase.py
@@ -178,7 +178,7 @@ def _build_bulk_al() -> ase.Atoms:
 # size. Cost is dominated by the periodic-image replication depth,
 # ceil(cutoff / perpendicular_length): each axis emits (2*ceil+1) images, so a
 # 3-shell cutoff replicates a (multi-atom) candidate set ~343x. Because the
-# replication / stencil code (``_candidate_image_counts``,
+# replication / stencil code (``candidate_image_counts``,
 # ``_generate_image_offsets``) is geometry-agnostic, the deepest (3-shell)
 # regime only needs covering once — and the cheapest place is the 1-atom,
 # non-orthogonal ``triclinic`` cell (also the hardest geometry). The multi-atom

--- a/test/core/neighborlist/test_common.py
+++ b/test/core/neighborlist/test_common.py
@@ -13,10 +13,10 @@ from kups.core.cell import PeriodicCell, TriclinicFrame
 from kups.core.data.index import Index
 from kups.core.neighborlist.common import (
     Candidates,
-    _candidate_image_counts,
     _generate_image_offsets,
     _get_candidate_images,
     _minimum_image_shifts,
+    candidate_image_counts,
     candidates_to_batch,
     edge_rhs_table,
     lift_query_candidates,
@@ -78,14 +78,14 @@ class TestCandidateImageCounts:
         # ratio <= 0.5 -> one image per axis.
         cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 10.0))
         systems, _ = make_systems(cell, jnp.array([2.0]))
-        images = _candidate_image_counts(systems.data.cell, jnp.array([2.0]))
+        images = candidate_image_counts(systems.data.cell, jnp.array([2.0]))
         npt.assert_array_equal(np.asarray(images), np.array([[1, 1, 1]]))
 
     def test_wide_cutoff_uses_symmetric_stencil(self):
         # ratio = 0.8 -> 2*ceil(0.8)+1 = 3 images per axis.
         cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 1.0))
         systems, _ = make_systems(cell, jnp.array([0.8]))
-        images = _candidate_image_counts(systems.data.cell, jnp.array([0.8]))
+        images = candidate_image_counts(systems.data.cell, jnp.array([0.8]))
         npt.assert_array_equal(np.asarray(images), np.array([[3, 3, 3]]))
 
     def test_handles_nonfinite_ratios(self):
@@ -93,7 +93,7 @@ class TestCandidateImageCounts:
             perpendicular_lengths = jnp.array([[0.0, 4.0, jnp.nan]])
             periodic = (True, True, True)
 
-        images = _candidate_image_counts(Cells(), jnp.array([6.0]))
+        images = candidate_image_counts(Cells(), jnp.array([6.0]))
         npt.assert_array_equal(np.asarray(images), np.array([[1, 5, 1]]))
 
 

--- a/test/core/neighborlist/test_parameters.py
+++ b/test/core/neighborlist/test_parameters.py
@@ -50,9 +50,40 @@ class TestUniversalNeighborlistParametersEstimate:
         assert params.cells == 125
         # candidates ≈ 100/125*27 ≈ 21.6 -> next power of two = 32.
         assert params.avg_candidates == 32
+        # cutoff 2 << box 10 (ratio 0.2) stays in the minimum-image regime: 1
+        # image per axis, so image candidates match candidates.
         assert params.avg_image_candidates == params.avg_candidates
         # edges ≈ 3.35 -> 4.
         assert params.avg_edges == 4
+
+    def test_wide_cutoff_replicates_image_candidates(self):
+        # cutoff 6 in a 10 Å box: ratio 0.6 -> 2*ceil(0.6)+1 = 3 images/axis,
+        # i.e. 27x candidate replication.
+        ppc, systems, cutoffs = self._single_system(n_particles=200, cutoff=6.0)
+        params = UniversalNeighborlistParameters.estimate(ppc, systems, cutoffs)
+        # 1 bin/axis -> candidates capped at n_particles=200 -> 256.
+        assert params.avg_candidates == 256
+        # the rounded candidate buffer is what gets replicated 27x:
+        # 256 * 27 = 6912 -> next power of two = 8192.
+        assert params.avg_image_candidates == 8192
+
+    def test_heterogeneous_cutoffs_sum_per_system(self):
+        # Image candidates sum each system's own replication factor rather than
+        # assuming every system replicates at the maximum rate.
+        cell = PeriodicCell(
+            TriclinicFrame.from_matrix(jnp.eye(3)[None].repeat(2, axis=0) * 10.0)
+        )
+        # System 0: cutoff 2 (1 image), 1000 particles -> 216 candidates -> 256.
+        # System 1: cutoff 6 (27 images), 10 particles -> 10 candidates -> 16.
+        systems, cutoffs = make_systems(cell, jnp.array([2.0, 6.0]))
+        ppc = Table((SystemId(0), SystemId(1)), jnp.array([1000, 10]))
+        params = UniversalNeighborlistParameters.estimate(ppc, systems, cutoffs)
+        # mean candidates = (216 + 10) / 2 = 113 -> 128.
+        assert params.avg_candidates == 128
+        # each system's rounded candidate buffer replicates by its own image
+        # count: (256*1 + 16*27) / 2 = 344 -> 512, well below the pessimistic
+        # avg_candidates * max_images = 128 * 27 -> 4096.
+        assert params.avg_image_candidates == 512
 
     def test_all_fields_positive_powers_of_two(self):
         ppc, systems, cutoffs = self._single_system(n_particles=512)


### PR DESCRIPTION
This PR removes the manual `max_num_adsorbates` configuration field and replaces it with an automatic estimate computed at initialization time.

Two new functions, `estimate_occupied_volume` and `estimate_max_adsorbates`, calculate how many motifs can fit in each system by treating each atom as a van der Waals sphere, summing occupied volume per system, and dividing the remaining free volume by the smallest motif's volume. Buffer sizes for particles and groups are then derived per-system from these estimates rather than from a single user-supplied integer.

The neighborlist parameter estimation is also improved: `avg_image_candidates` is now computed by multiplying each system's candidate count by its own periodic-image replication factor (the product of per-axis image counts from `candidate_image_counts`), then summing across systems. This avoids the previous pessimistic assumption that every system replicates at the maximum rate, producing tighter buffer allocations for heterogeneous cutoffs. As part of this, `_candidate_image_counts` is renamed to `candidate_image_counts` and made part of the public API so it can be reused in the parameter estimator.

Tests cover `estimate_occupied_volume` (per-system aggregation, alternative grouping indices, undefined vdW radii, and JIT compatibility), `estimate_max_adsorbates` (single and multi-system cases, zero-clamping), and the updated neighborlist parameter estimator (wide-cutoff replication and heterogeneous multi-system cutoffs).