### PR TITLE
feat: Add `adaptive_scale` option to `ScaleByAseLbfgs` for per-system γ scaling

### DIFF
--- a/src/kups/relaxation/transforms/lbfgs.py
+++ b/src/kups/relaxation/transforms/lbfgs.py
@@ -72,11 +72,18 @@ class ScaleByAseLbfgs[Params](Optimizer[Params, ScaleByAseLbfgsState]):
 
     Attributes:
         memory_size: Number of past difference pairs to store. ``>= 1``.
-        alpha: Initial inverse Hessian is ``(1/alpha) * I``.
+        alpha: Fixed initial inverse Hessian is ``(1/alpha) * I``. Used as the
+            initial scale and as the fallback when ``adaptive_scale`` cannot use
+            the curvature pair.
+        adaptive_scale: If ``True``, scale the initial inverse Hessian per system
+            by ``γ = (s·y)/(y·y)`` (Nocedal & Wright eq. 7.20) from the freshest
+            difference pair, falling back to ``1/alpha`` on the first step or when
+            the curvature pair is non-positive.
     """
 
     memory_size: int = field(static=True, default=100)
     alpha: float = field(static=True, default=70.0)
+    adaptive_scale: bool = field(static=True, default=False)
 
     def __post_init__(self) -> None:
         if self.memory_size < 1:
@@ -121,17 +128,31 @@ class ScaleByAseLbfgs[Params](Optimizer[Params, ScaleByAseLbfgsState]):
         if params is None:
             raise ValueError("ScaleByASELBFGS.update requires params")
         idx = state.index_prefix
+        keys = state.weights_memory.keys
         memory_idx = state.count % self.memory_size
         prev_memory_idx = (state.count - 1) % self.memory_size
+        inv_alpha = 1.0 / self.alpha
 
         # Compute fresh (s, y) differences and corresponding ρ = 1/(y·s).
         diff_params = jax.tree.map(jnp.subtract, params, state.params)
         diff_updates = jax.tree.map(jnp.subtract, updates, state.updates)
-        vdot_data = tree_vdot(diff_updates, diff_params, idx).data
-        weight = jnp.where(vdot_data == 0.0, 0.0, 1.0 / vdot_data)
+        sy = tree_vdot(diff_updates, diff_params, idx).data  # (s·y) per system
+        weight = jnp.where(sy == 0.0, 0.0, 1.0 / sy)
+
+        is_first = state.count == 0
+
+        # Per-system initial inverse-Hessian scale γ.
+        if self.adaptive_scale:
+            yy = tree_vdot(diff_updates, diff_updates, idx).data  # (y·y) per system
+            valid = jnp.logical_and(jnp.logical_not(is_first), (yy > 0) & (sy > 0))
+            gamma_data = jnp.where(valid, sy / jnp.where(yy > 0, yy, 1.0), inv_alpha)
+        else:
+            gamma_data = jnp.broadcast_to(
+                jnp.asarray(inv_alpha, dtype=sy.dtype), sy.shape
+            )
+        gamma = Table(keys, gamma_data)
 
         # Differences are undefined at the very first iteration; stay zero.
-        is_first = state.count == 0
         diff_params = jax.tree.map(
             lambda x: jnp.where(is_first, jnp.zeros_like(x), x), diff_params
         )
@@ -157,10 +178,10 @@ class ScaleByAseLbfgs[Params](Optimizer[Params, ScaleByAseLbfgsState]):
             diff_params_memory,
             diff_updates_memory,
             weights_data,
-            identity_scale=1.0 / self.alpha,
+            gamma=gamma,
             memory_idx=memory_idx,
             index_prefix=idx,
-            keys=state.weights_memory.keys,
+            keys=keys,
         )
         return precond, ScaleByAseLbfgsState(
             count=state.count + 1,
@@ -178,7 +199,7 @@ def _precondition_by_lbfgs_segmented[P](
     diff_params_memory: PyTree,
     diff_updates_memory: PyTree,
     weights_data: Array,
-    identity_scale: Array | float,
+    gamma: Table[SupportsSorting, Array],
     memory_idx: Array,
     index_prefix: PyTree,
     keys: tuple[SupportsSorting, ...],
@@ -187,10 +208,10 @@ def _precondition_by_lbfgs_segmented[P](
 
     Runs Nocedal's two-loop recursion (Algorithm 7.4) with all inner
     products replaced by their per-system equivalents — ``α_i`` and ``β_i``
-    are arrays of shape ``(n_systems,)``, while the initial inverse-Hessian
-    ``γ I`` is applied uniformly to every leaf. The block-diagonal
-    structure of the resulting approximation across systems is what makes
-    the batched run bit-identical to running each system alone.
+    are arrays of shape ``(n_systems,)``, and the initial inverse-Hessian
+    ``γ_i I`` is applied per system via its own ``gamma`` entry. The
+    block-diagonal structure of the resulting approximation across systems
+    is what makes the batched run bit-identical to running each system alone.
     """
     memory_size = weights_data.shape[1]
     indices = (memory_idx + jnp.arange(memory_size)) % memory_size
@@ -206,7 +227,7 @@ def _precondition_by_lbfgs_segmented[P](
         return new_q, alpha
 
     q, alphas = jax.lax.scan(right_product, updates, indices, reverse=True)
-    q = jax.tree.map(lambda x: identity_scale * x, q)
+    q = tree_scale_per_row(q, gamma, index_prefix)
 
     def left_product(q: P, args: tuple[Array, Array]) -> tuple[P, Array]:
         mem_idx, alpha = args

--- a/test/relaxation/transforms/test_lbfgs.py
+++ b/test/relaxation/transforms/test_lbfgs.py
@@ -30,18 +30,21 @@ def _run_grad(
     x: Array,
     state: ScaleByAseLbfgsState,
     steps: int,
+    *,
+    hess: Array | float = 1.0,
 ) -> tuple[Array, ScaleByAseLbfgsState]:
-    """Run ``steps`` of ``opt`` on a quadratic (gradient ``∇L = x``) via one scan.
+    """Run ``steps`` of ``opt`` on a quadratic (gradient ``∇L = hess * x``).
 
     Folding the loop into a single ``lax.scan`` compiles the step once instead
     of re-tracing every Python iteration; the trajectory is bit-identical.
+    ``hess`` is a per-element diagonal Hessian (default identity).
     """
 
     def body(
         carry: tuple[Any, ScaleByAseLbfgsState], _: None
     ) -> tuple[tuple[Any, ScaleByAseLbfgsState], None]:
         x, state = carry
-        upd, state = opt.update(x, state, x)
+        upd, state = opt.update(hess * x, state, x)
         x = optax.apply_updates(x, jax.tree.map(lambda u: -u, upd))
         return (x, state), None
 
@@ -164,3 +167,81 @@ class TestScaleByASELBFGSPerSystem:
         rho_a = float(state.weights_memory.data[0, 0])
         rho_b = float(state.weights_memory.data[1, 0])
         assert rho_a != rho_b
+
+
+class TestScaleByASELBFGSAdaptiveScale:
+    """``adaptive_scale`` scales the initial inverse Hessian per system."""
+
+    def test_first_step_falls_back_to_inv_alpha(self):
+        """No curvature pair exists yet, so the first step still uses 1/alpha."""
+        alpha = 70.0
+        opt = ScaleByAseLbfgs(memory_size=10, alpha=alpha, adaptive_scale=True)
+        params = jnp.array([1.0, 2.0, 3.0])
+        gradient = jnp.array([7.0, 14.0, 21.0])
+        updates, _ = opt.update(gradient, opt.init(params), params)
+        npt.assert_allclose(updates, gradient / alpha, rtol=1e-5)
+
+    def test_adaptive_gamma_equals_curvature_ratio(self):
+        """Second step scales by γ = (s·y)/(y·y) from the fresh pair.
+
+        Inputs are chosen so the second gradient is orthogonal to both ``s``
+        and ``y``; the two-loop recursion then collapses to
+        ``precond = γ * updates``, exposing γ directly.
+        """
+        opt = ScaleByAseLbfgs(memory_size=5, alpha=70.0, adaptive_scale=True)
+        params0 = jnp.array([0.0, 0.0, 0.0])
+        updates0 = jnp.array([-2.0, 1.0, 0.0])
+        _, state = opt.update(updates0, opt.init(params0), params0)
+        # s = [1,0,0], y = [2,0,0]  →  γ = (s·y)/(y·y) = 2/4 = 0.5.
+        params1 = jnp.array([1.0, 0.0, 0.0])
+        updates1 = jnp.array([0.0, 1.0, 0.0])
+        precond, _ = opt.update(updates1, state, params1)
+        npt.assert_allclose(precond, 0.5 * updates1, rtol=1e-6)
+
+    def test_non_positive_curvature_falls_back_to_inv_alpha(self):
+        """A non-positive (s·y) curvature pair reverts γ to 1/alpha."""
+        alpha = 4.0
+        params0 = jnp.array([0.0, 0.0, 0.0])
+        updates0 = jnp.array([2.0, 1.0, 0.0])
+        params1 = jnp.array([1.0, 0.0, 0.0])
+        updates1 = jnp.array([0.0, 1.0, 0.0])
+        # s = [1,0,0], y = [-2,0,0]  →  s·y = -2 ≤ 0, so γ = 1/alpha.
+
+        def run(adaptive: bool) -> Array:
+            opt = ScaleByAseLbfgs(memory_size=5, alpha=alpha, adaptive_scale=adaptive)
+            _, state = opt.update(updates0, opt.init(params0), params0)
+            precond, _ = opt.update(updates1, state, params1)
+            return precond
+
+        npt.assert_allclose(run(True), updates1 / alpha, rtol=1e-6)
+        npt.assert_allclose(run(True), run(False), rtol=1e-6)
+
+    def test_batched_matches_separate_with_per_system_curvature(self):
+        """Per-system γ keeps batched runs bit-identical to separate ones.
+
+        Each system has a different diagonal Hessian, so their adaptive γ
+        differ; a per-system γ is required for the block-diagonal guarantee.
+        """
+
+        def run_alone(x0: Array, hess: Array) -> Array:
+            opt = ScaleByAseLbfgs(memory_size=5, alpha=10.0, adaptive_scale=True)
+            x, _ = _run_grad(opt, x0, opt.init(x0), 6, hess=hess)
+            return x
+
+        x_a, hess_a = jnp.array([1.0, -2.0]), jnp.array([1.0, 4.0])
+        x_b, hess_b = jnp.array([0.5, 3.0]), jnp.array([10.0, 0.5])
+        sep = jnp.concatenate([run_alone(x_a, hess_a), run_alone(x_b, hess_b)])
+
+        opt = ScaleByAseLbfgs(memory_size=5, alpha=10.0, adaptive_scale=True)
+        x0 = jnp.concatenate([x_a, x_b])
+        hess = jnp.concatenate([hess_a, hess_b])
+        idx = _system_index([0, 0, 1, 1], 2)
+        x, _ = _run_grad(opt, x0, opt.init(x0, index_prefix=idx), 6, hess=hess)
+        npt.assert_allclose(x, sep, atol=1e-6)
+
+    def test_convergence_on_quadratic(self):
+        """Adaptive scaling still drives a quadratic to its minimum."""
+        opt = ScaleByAseLbfgs(memory_size=10, alpha=70.0, adaptive_scale=True)
+        x = jnp.array([5.0, -3.0, 2.0])
+        x, _ = _run_grad(opt, x, opt.init(x), 15)
+        npt.assert_allclose(x, jnp.zeros(3), atol=1e-4)


### PR DESCRIPTION
Add `adaptive_scale` option to `ScaleByAseLbfgs` for per-system initial inverse-Hessian scaling

When `adaptive_scale=True`, the initial inverse-Hessian scale is computed per system as `γ = (s·y)/(y·y)` (Nocedal & Wright eq. 7.20) using the freshest curvature pair, rather than applying the fixed `1/alpha` uniformly. The fallback to `1/alpha` is preserved for the first step and whenever the curvature pair is non-positive.

The `_precondition_by_lbfgs_segmented` function now accepts a `gamma` `Table` instead of a scalar `identity_scale`, and applies `tree_scale_per_row` so each system uses its own `γ_i`. This maintains the block-diagonal guarantee: batched runs remain bit-identical to running each system independently, even when systems have different curvature and therefore different adaptive scales.

New tests cover:

- First-step fallback to `1/alpha` before any curvature pair exists
- Correct `γ` value on the second step when the two-loop recursion collapses to a scalar multiple
- Non-positive curvature fallback matching the fixed-scale result
- Batched-vs-separate equivalence with per-system diagonal Hessians
- Convergence on a quadratic with adaptive scaling enabled

Closes #159