### PR TITLE
refactor: Project cell gradients via vjp of `frame.vectors` instead of `from_matrix`

### DIFF
--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -14,7 +14,6 @@ from kups.core.cell import (
     AnyPeriodicity,
     Cell,
     Periodic3D,
-    TriclinicFrame,
     require_periodic_3d_triclinic,
 )
 from kups.core.constants import BOLTZMANN_CONSTANT
@@ -1085,8 +1084,8 @@ class CellPositionStep[State](Propagator[State]):
         # V_old, V_dot both lower-tri ⇒ V_new lower-tri.
         V_new = V_old + (params.time_step[..., None, None] / 2) * V_dot
         # Reconstruct TriclinicFrame so cached volume refreshes.
-        return self.systems.focus(lambda x: x.data.cell.frame).set(
-            state, TriclinicFrame.from_matrix(V_new)
+        return self.systems.focus(lambda x: x.data.cell.frame).apply(
+            state, lambda frame: frame.from_matrix(V_new)
         )
 
 

--- a/src/kups/potential/mliap/torch/interface.py
+++ b/src/kups/potential/mliap/torch/interface.py
@@ -34,11 +34,12 @@ from __future__ import annotations
 
 from typing import Any, Literal, Protocol, TypedDict, overload
 
+import jax
 import jax.numpy as jnp
 import torch  # pyright: ignore[reportMissingImports]
 from jax import Array
 
-from kups.core.cell import AnyPeriodicity
+from kups.core.cell import AnyPeriodicity, Cell
 from kups.core.data import Table
 from kups.core.lens import Lens, View, bind
 from kups.core.neighborlist import (
@@ -281,6 +282,19 @@ def _prepare_torch_inputs(graph: Any) -> AtomGraphInput:
     )
 
 
+def _project_grad_onto_frame[C: Cell[Any]](cell: C, cell_grad: Array) -> C:
+    """Express a raw ``∂E/∂h`` matrix in ``cell``'s frame parameter space.
+
+    The vjp of the frame's ``vectors`` map pulls the matrix gradient back onto
+    the frame's own degrees of freedom (``tril`` for triclinic, ``lengths`` for
+    orthogonal), preserving the input frame type without recomputing any
+    inverse/volume that an instance constructor would. Returns a copy of
+    ``cell`` carrying the projected gradient as its frame.
+    """
+    (frame_grad,) = jax.vjp(lambda f: f.vectors, cell.frame)[1](cell_grad)
+    return bind(cell, lambda c: c.frame).set(frame_grad)
+
+
 @overload
 def torch_mliap_model_fn[
     P: IsTorchMliapParticles,
@@ -346,12 +360,9 @@ def torch_mliap_model_fn[
 
     if compute_cell_gradients:
         cell_grad = result["cell_gradients"].astype(out_dtype)
-        # Preserve the input cell/frame type: project the raw ∂E/∂h onto
-        # the frame's parameter space via its ``from_matrix`` classmethod,
-        # then swap in the new frame on a copy of the input cell.
-        input_cell = inp.graph.systems.data.cell
-        new_frame = input_cell.frame.from_matrix(cell_grad)
-        new_cell = bind(input_cell, lambda c: c.frame).set(new_frame)
+        # Project the raw ∂E/∂h onto the input frame's parameter space,
+        # preserving its type for downstream stress/relaxation consumers.
+        new_cell = _project_grad_onto_frame(inp.graph.systems.data.cell, cell_grad)
         gradients = PositionAndCell(
             positions=Table(inp.graph.particles.keys, pos_grad),
             cell=Table(inp.graph.systems.keys, new_cell),

--- a/test/potential/test_torch_mace.py
+++ b/test/potential/test_torch_mace.py
@@ -269,6 +269,39 @@ class TestLatticeGradientFromVirial:
         assert torch.allclose(cell_grad, g_h, atol=1e-10)
 
 
+class TestProjectGradOntoFrame:
+    """``∂E/∂h`` matrix → frame-parameter-space projection used for cell gradients."""
+
+    def test_preserves_triclinic_frame_and_projects_lower_triangle(self):
+        from kups.core.cell import PeriodicCell, TriclinicFrame
+        from kups.potential.mliap.torch.interface import _project_grad_onto_frame
+
+        cell = PeriodicCell(
+            TriclinicFrame.from_matrix(
+                jnp.array([[2.0, 0, 0], [0.5, 3.0, 0], [0.1, 0.2, 4.0]])
+            )
+        )
+        cell_grad = jnp.arange(9.0).reshape(3, 3)
+        out = _project_grad_onto_frame(cell, cell_grad)
+
+        # Frame type (not a vjp cotangent tuple) must survive for downstream
+        # ``gradients.cell.data.vectors`` consumers.
+        assert isinstance(out, PeriodicCell)
+        assert isinstance(out.frame, TriclinicFrame)
+        assert jnp.allclose(out.frame.tril, jnp.array([0.0, 3.0, 4.0, 6.0, 7.0, 8.0]))
+
+    def test_preserves_orthogonal_frame_and_projects_diagonal(self):
+        from kups.core.cell import OrthogonalFrame, PeriodicCell
+        from kups.potential.mliap.torch.interface import _project_grad_onto_frame
+
+        cell = PeriodicCell(OrthogonalFrame(jnp.array([2.0, 3.0, 4.0])))
+        cell_grad = jnp.arange(9.0).reshape(3, 3)
+        out = _project_grad_onto_frame(cell, cell_grad)
+
+        assert isinstance(out.frame, OrthogonalFrame)
+        assert jnp.allclose(out.frame.lengths, jnp.array([0.0, 4.0, 8.0]))
+
+
 class TestUniversalInterfaceAPI:
     """Smoke checks for the universal interface surface."""
 


### PR DESCRIPTION
Replace `from_matrix` class method with VJP-based gradient projection for cell frame updates

The `from_matrix` class method was being used in two places to map raw `∂E/∂h` matrices back onto a cell frame's parameter space (e.g., `tril` for triclinic, `lengths` for orthogonal). This approach was incorrect because `from_matrix` recomputes derived quantities like inverse and volume, which is inappropriate when handling gradients — only the relevant degrees of freedom should be populated.

A new helper, `_project_grad_onto_frame`, replaces this pattern in the MLIAP interface. It uses `jax.vjp` on the frame's `vectors` property to correctly pull the raw matrix gradient back onto the frame's own parameter space, preserving the frame type without triggering any unnecessary recomputation.

The same misuse in `CellPositionStep` is also corrected by switching from `.set(TriclinicFrame.from_matrix(...))` to `.apply(lambda x: x.from_matrix(...))`, removing the hard-coded `TriclinicFrame` import and making the call polymorphic over the actual frame type.

Tests are added to verify that both triclinic and orthogonal frames are preserved through the projection and that only the correct components (lower triangle and diagonal, respectively) are populated in the output.



Closes #158