### PR TITLE
feat: Add `logm` (matrix logarithm) via eigendecomposition

### DIFF
--- a/src/kups/core/utils/math.py
+++ b/src/kups/core/utils/math.py
@@ -274,6 +274,41 @@ def solve_affine_ode(A: Array, b: Array, x0: Array, dt: Array | float) -> Array:
     return jnp.einsum("...ij,...j->...i", E[..., :n, :n], x0) + E[..., :n, n]
 
 
+@jit(static_argnames=("hermitian",))
+def logm(A: Array, *, hermitian: bool = False) -> Array:
+    r"""Compute the principal matrix logarithm via eigendecomposition.
+
+    Inverse of `jax.scipy.linalg.expm`: returns `L` with `expm(L) == A` for
+    diagonalizable `A`. Diagonalizing $A = V\,\mathrm{diag}(\lambda)\,V^{-1}$
+    gives $\log A = V\,\mathrm{diag}(\log\lambda)\,V^{-1}$.
+
+    Args:
+        A: Array of shape `(..., n, n)`. Must be diagonalizable; the result is
+            inaccurate for defective matrices (e.g. non-trivial Jordan blocks).
+        hermitian: If True, treat `A` as Hermitian/symmetric and use `eigh`.
+            This gives a real result for positive-definite `A` and is
+            differentiable. If False (default), `eig` handles general matrices
+            but the result is complex and is not differentiable with respect to
+            `A`, since JAX does not implement derivatives of non-symmetric
+            eigenvectors.
+
+    Returns:
+        Array of shape `(..., n, n)` holding the principal logarithm. Real when
+        `hermitian` and `A` is positive-definite, complex otherwise.
+
+    Example:
+        ```python
+        A = jax.scipy.linalg.expm(B)
+        B_recovered = logm(A)  # ≈ B
+        ```
+    """
+    if hermitian:
+        w, V = jnp.linalg.eigh(A)
+        return (V * jnp.log(w)[..., None, :]) @ jnp.conjugate(jnp.swapaxes(V, -1, -2))
+    w, V = jnp.linalg.eig(A)
+    return (V * jnp.log(w)[..., None, :]) @ jnp.linalg.inv(V)
+
+
 def next_higher_power(value: Array, base: Array | float = 2.0) -> Array:
     """Compute the next higher power of a given base for each element.
 

--- a/test/core/test_math.py
+++ b/test/core/test_math.py
@@ -11,6 +11,7 @@ from kups.core.utils.math import (
     cubic_roots,
     det_and_inverse_3x3,
     log_factorial_ratio,
+    logm,
     next_higher_power,
     triangular_3x3_det_and_inverse,
     triangular_3x3_matmul,
@@ -266,6 +267,33 @@ class TestTriangular3x3Matmul:
         x = jax.random.normal(jax.random.PRNGKey(1), (3,))
         with pytest.raises(ValueError, match="is not a valid MatmulSide"):
             triangular_3x3_matmul(jnp.tril(A), x, lower=True, side="invalid")
+
+
+class TestLogm:
+    def test_logm(self):
+        """Merged: general round-trip, hermitian real output, batching."""
+        # general (eig path): logm(expm(B)) == B
+        B = 0.3 * jax.random.normal(jax.random.PRNGKey(0), (5, 5))
+        npt.assert_allclose(logm(jax.scipy.linalg.expm(B)).real, B, atol=1e-10)
+
+        # hermitian (SPD): real output and expm round-trip
+        M = jax.random.normal(jax.random.PRNGKey(1), (5, 5))
+        spd = M @ M.T + 0.5 * jnp.eye(5)
+        L = logm(spd, hermitian=True)
+        assert L.dtype == spd.dtype
+        npt.assert_allclose(jax.scipy.linalg.expm(L), spd, rtol=1e-6, atol=1e-8)
+
+        # batching preserves shape and matches per-matrix results
+        Lb = logm(jnp.stack([spd, 2 * spd]), hermitian=True)
+        assert Lb.shape == (2, 5, 5)
+        npt.assert_allclose(Lb[0], L, rtol=1e-10)
+
+    def test_logm_hermitian_differentiable(self):
+        """d/dA tr(log A) == A^-1 for symmetric positive-definite A."""
+        M = jax.random.normal(jax.random.PRNGKey(2), (4, 4))
+        spd = M @ M.T + 0.5 * jnp.eye(4)
+        grad = jax.grad(lambda A: jnp.trace(logm(A, hermitian=True)))(spd)
+        npt.assert_allclose(grad, jnp.linalg.inv(spd), rtol=1e-6, atol=1e-8)
 
 
 class TestNextHigherPower:


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Added `logm` function to compute the principal matrix logarithm via eigendecomposition, supporting both general matrices (via `eig`) and hermitian/symmetric positive-definite matrices (via `eigh` for differentiability). Includes comprehensive tests for round-trip accuracy, real output for SPD matrices, batching, and gradient correctness.