### PR TITLE
feat: Add `LogTriclinicFrame` with closed-form triangular matrix log/exp parameterisation

### DIFF
--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -119,11 +119,17 @@ import jax.numpy as jnp
 import numpy as np
 from jax import Array
 from jax.flatten_util import ravel_pytree
+from jax.scipy.linalg import expm
 
 from kups.core.data import Sliceable
 from kups.core.lens import Lens, bind
 from kups.core.utils.jax import dataclass, field
-from kups.core.utils.math import triangular_3x3_det_and_inverse, triangular_3x3_matmul
+from kups.core.utils.math import (
+    triangular_3x3_det_and_inverse,
+    triangular_3x3_from_tril,
+    triangular_3x3_logm,
+    triangular_3x3_matmul,
+)
 
 _P = TypeVar("_P", bound=tuple[bool, bool, bool], covariant=True)
 
@@ -496,15 +502,7 @@ class TriclinicFrame(LinearFrame, Sliceable):
     @property
     @override
     def vectors(self) -> Array:
-        zero = jnp.zeros_like(self.tril[..., :1])
-        return jnp.stack(
-            [
-                jnp.concatenate([self.tril[..., 0:1], zero, zero], axis=-1),
-                jnp.concatenate([self.tril[..., 1:3], zero], axis=-1),
-                self.tril[..., 3:6],
-            ],
-            axis=-2,
-        )
+        return triangular_3x3_from_tril(self.tril)
 
     @property
     @override
@@ -543,6 +541,66 @@ class TriclinicFrame(LinearFrame, Sliceable):
     @override
     def __mul__(self, other: Array | float | int) -> Self:
         return type(self)(self.tril * jnp.asarray(other)[..., None])
+
+
+@dataclass
+class LogTriclinicFrame(BaseFrame, Sliceable):
+    """Triclinic [Frame][kups.core.cell.Frame] parameterised in the matrix log.
+
+    Stores the 6 lower-triangular elements of a matrix ``A``; the basis vectors
+    are ``expm(A)``. Because ``A`` is lower-triangular, ``expm(A)`` is too (its
+    diagonal is ``exp`` of ``A``'s diagonal), so the lower-triangular convention
+    shared by every other frame is preserved.
+
+    The exponential map is unconstrained: any ``A`` yields a basis with strictly
+    positive volume ``exp(tr A)``, so gradient-based cell relaxation in ``A`` never
+    has to guard against a collapsing or inverting cell. Unlike
+    [TriclinicFrame][kups.core.cell.TriclinicFrame], ``vectors`` is a *nonlinear*
+    function of the parameters, so the parameter/cartesian gradient maps use the
+    general inverse-Jacobian path on [BaseFrame][kups.core.cell.BaseFrame] rather
+    than a constant-Jacobian shortcut.
+
+    Attributes:
+        tril: Lower-triangular elements ``[A00, A10, A11, A20, A21, A22]`` of
+            ``A``, shape ``(..., 6)``.
+    """
+
+    tril: Array
+
+    @classmethod
+    @override
+    def from_matrix(cls, vecs: Array) -> Self:
+        """Construct from a lower-triangular basis matrix ``L`` (positive
+        diagonal), shape ``(..., 3, 3)``, storing ``logm(L)`` so that
+        ``vectors == L``."""
+        return cls(triangular_3x3_logm(jnp.asarray(vecs))[..., *np.tril_indices(3)])
+
+    @property
+    @override
+    def vectors(self) -> Array:
+        return expm(triangular_3x3_from_tril(self.tril))
+
+    @property
+    @override
+    def volume(self) -> Array:
+        # det(expm(A)) = exp(tr A); the diagonal of A is tril[0], tril[2], tril[5].
+        return jnp.exp(self.tril[..., 0] + self.tril[..., 2] + self.tril[..., 5])
+
+    @override
+    def tile(self, multiplicities: tuple[int, int, int]) -> Self:
+        # Per-axis row scaling has no closed form in A (diag(m) does not commute
+        # with A), so scale the basis matrix and re-take the log.
+        m = jnp.asarray(multiplicities)
+        log_matrix = triangular_3x3_logm(self.vectors * m[:, None])
+        return type(self)(log_matrix[..., *np.tril_indices(3)])
+
+    @override
+    def __mul__(self, other: Array | float | int) -> Self:
+        # Uniform scaling commutes: expm(A + log(s) I) = s * expm(A), so add
+        # log(s) to the diagonal elements A00, A11, A22 (tril indices 0, 2, 5).
+        log_scale = jnp.log(jnp.asarray(other))[..., None]
+        diagonal = jnp.array([1.0, 0.0, 1.0, 0.0, 0.0, 1.0])
+        return type(self)(self.tril + log_scale * diagonal)
 
 
 @dataclass

--- a/src/kups/core/utils/math.py
+++ b/src/kups/core/utils/math.py
@@ -167,6 +167,98 @@ def triangular_3x3_det_and_inverse(
     return inner(A)
 
 
+def triangular_3x3_from_tril(tril: Array) -> Array:
+    """Assemble a lower-triangular 3×3 matrix from its 6 elements.
+
+    Args:
+        tril: Array of shape `(..., 6)` holding ``[m00, m10, m11, m20, m21, m22]``.
+
+    Returns:
+        Array of shape `(..., 3, 3)`::
+
+            [[m00,   0,   0],
+             [m10, m11,   0],
+             [m20, m21, m22]]
+    """
+    zero = jnp.zeros_like(tril[..., :1])
+    return jnp.stack(
+        [
+            jnp.concatenate([tril[..., 0:1], zero, zero], axis=-1),
+            jnp.concatenate([tril[..., 1:3], zero], axis=-1),
+            tril[..., 3:6],
+        ],
+        axis=-2,
+    )
+
+
+def _ddlog(x: Array, y: Array) -> Array:
+    """First divided difference of ``log``: ``(log x - log y) / (x - y)``,
+    with the confluent limit ``1/x`` as ``y -> x``. Gradient-safe at ``x == y``."""
+    diff = x - y
+    safe = jnp.where(diff == 0.0, 1.0, diff)
+    return jnp.where(diff == 0.0, 1.0 / x, (jnp.log(x) - jnp.log(y)) / safe)
+
+
+def _ddlog2(x: Array, y: Array, z: Array) -> Array:
+    """Second divided difference of ``log`` (symmetric in its arguments), with
+    confluent limits when the outer pair or all three coincide."""
+    diff = x - z
+    safe = jnp.where(diff == 0.0, 1.0, diff)
+    generic = (_ddlog(x, y) - _ddlog(y, z)) / safe
+    # x == z: by symmetry log[x, y, x] = log[x, x, y] = (1/x - log[x, y]) / (x - y),
+    # whose own y -> x limit is f''(x) / 2 = -1 / (2 x^2).
+    diff_xy = x - y
+    safe_xy = jnp.where(diff_xy == 0.0, 1.0, diff_xy)
+    confluent = jnp.where(
+        diff_xy == 0.0, -0.5 / x**2, (1.0 / x - _ddlog(x, y)) / safe_xy
+    )
+    return jnp.where(diff == 0.0, confluent, generic)
+
+
+def triangular_3x3_logm(A: Array, *, lower: bool = True) -> Array:
+    r"""Principal matrix logarithm of triangular 3×3 matrices with positive diagonal.
+
+    Closed form from the fact that ``L`` and ``B = logm(L)`` commute (``BL = LB``):
+    the diagonal of ``B`` is ``log`` of ``L``'s diagonal, and the off-diagonal
+    couplings are divided differences of ``log`` over the diagonal entries. Using
+    divided differences keeps repeated diagonal entries (e.g. cubic / tetragonal
+    cells) well-conditioned.
+
+    Real and gradient-safe, unlike the eigendecomposition-based
+    [logm][kups.core.utils.math.logm] which is complex and inaccurate for these
+    (defective) matrices. Inverse of ``jax.scipy.linalg.expm`` on triangular
+    matrices.
+
+    Args:
+        A: Array of shape `(..., 3, 3)` containing triangular matrices with
+            strictly positive diagonal.
+        lower: Whether matrices are lower (True) or upper (False) triangular.
+
+    Returns:
+        Array of shape `(..., 3, 3)` containing the triangular logarithms.
+    """
+    M = A if lower else jnp.swapaxes(A, -1, -2)
+    l0, l1, l2 = M[..., 0, 0], M[..., 1, 1], M[..., 2, 2]
+    a, b, c = M[..., 1, 0], M[..., 2, 0], M[..., 2, 1]
+    zero = jnp.zeros_like(l0)
+    out = jnp.stack(
+        [
+            jnp.stack([jnp.log(l0), zero, zero], axis=-1),
+            jnp.stack([a * _ddlog(l0, l1), jnp.log(l1), zero], axis=-1),
+            jnp.stack(
+                [
+                    b * _ddlog(l0, l2) + a * c * _ddlog2(l0, l1, l2),
+                    c * _ddlog(l1, l2),
+                    jnp.log(l2),
+                ],
+                axis=-1,
+            ),
+        ],
+        axis=-2,
+    )
+    return out if lower else jnp.swapaxes(out, -1, -2)
+
+
 class MatmulSide(StrEnum):
     """Enumeration for matrix multiplication side."""
 

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -9,12 +9,15 @@ import jax
 import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
+from jax.scipy.linalg import expm
 
 from kups.core.cell import (
     BaseFrame,
     Cell,
     CoordinateSpace,
     Frame,
+    LinearFrame,
+    LogTriclinicFrame,
     MaterializedFrame,
     OrthogonalFrame,
     PeriodicCell,
@@ -712,6 +715,7 @@ _LINEAR_FRAME_CLASSES = [
 # nonlinear toy frame that exercises the general inverse-Jacobian path.
 _GRAD_FRAME_CLASSES = [
     *_LINEAR_FRAME_CLASSES,
+    pytest.param(LogTriclinicFrame, id="log_triclinic"),
     pytest.param(_ExpFrame, id="exp_nonlinear"),
 ]
 
@@ -795,6 +799,7 @@ _GEOMETRY_FRAMES = [
     ),
     pytest.param(OrthogonalFrame.from_matrix(_M_ORTHO[None]), id="orthogonal"),
     pytest.param(MaterializedFrame.from_matrix(_M_TRICLINIC[None]), id="materialized"),
+    pytest.param(LogTriclinicFrame.from_matrix(_M_TRICLINIC[None]), id="log_triclinic"),
 ]
 _frame_case = pytest.mark.parametrize("frame", _GEOMETRY_FRAMES)
 
@@ -869,3 +874,38 @@ class TestFrameGeometry:
             frame.vectors * multiples[:, None],
             atol=1e-6,
         )
+
+
+class TestLogTriclinicFrame:
+    """Matrix-log parameterisation: ``vectors == expm(A)`` for lower-triangular ``A``."""
+
+    def test_vectors_is_expm_of_lower_triangular(self):
+        a = jnp.array([[0.7, 0.0, 0.0], [0.5, 1.1, 0.0], [0.1, 0.2, 1.4]])
+        tril = jnp.array([0.7, 0.5, 1.1, 0.1, 0.2, 1.4])
+        frame = LogTriclinicFrame(tril)
+        npt.assert_allclose(frame.vectors, expm(a), atol=1e-6)
+        # expm of a lower-triangular matrix stays lower-triangular.
+        npt.assert_allclose(jnp.triu(frame.vectors, 1), 0.0, atol=1e-6)
+
+    def test_volume_is_exp_trace(self):
+        tril = jnp.array([0.7, 0.5, 1.1, 0.1, 0.2, 1.4])
+        frame = LogTriclinicFrame(tril)
+        trace = tril[0] + tril[2] + tril[5]
+        npt.assert_allclose(frame.volume, jnp.exp(trace), atol=1e-6)
+        # The exponential map always yields a positive-volume cell.
+        assert float(frame.volume) > 0.0
+
+    def test_from_matrix_roundtrips_through_expm(self):
+        """``from_matrix`` (triangular logm) then ``vectors`` (expm) recovers the
+        input lattice. Degenerate-diagonal robustness is covered by
+        ``test_math.TestTriangular3x3Logm``."""
+        lattice = expm(jnp.array([[0.7, 0, 0], [0.5, 1.1, 0], [0.3, 0.2, 1.4]]))
+        frame = LogTriclinicFrame.from_matrix(lattice)
+        npt.assert_allclose(frame.vectors, lattice, atol=1e-5)
+
+    def test_uses_general_nonlinear_gradient_path(self):
+        """``vectors`` is nonlinear in the parameters, so the frame is a plain
+        ``BaseFrame`` (general inverse-Jacobian), not a ``LinearFrame``."""
+        frame = LogTriclinicFrame.from_matrix(jnp.eye(3) * 2.0)
+        assert isinstance(frame, BaseFrame)
+        assert not isinstance(frame, LinearFrame)

--- a/test/core/test_math.py
+++ b/test/core/test_math.py
@@ -3,6 +3,7 @@
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import numpy.testing as npt
 import pytest
 
@@ -14,6 +15,8 @@ from kups.core.utils.math import (
     logm,
     next_higher_power,
     triangular_3x3_det_and_inverse,
+    triangular_3x3_from_tril,
+    triangular_3x3_logm,
     triangular_3x3_matmul,
 )
 
@@ -294,6 +297,62 @@ class TestLogm:
         spd = M @ M.T + 0.5 * jnp.eye(4)
         grad = jax.grad(lambda A: jnp.trace(logm(A, hermitian=True)))(spd)
         npt.assert_allclose(grad, jnp.linalg.inv(spd), rtol=1e-6, atol=1e-8)
+
+
+class TestTriangular3x3FromTril:
+    def test_assembles_lower_triangular(self):
+        tril = jnp.arange(12.0).reshape(2, 6)
+        m = triangular_3x3_from_tril(tril)
+        assert m.shape == (2, 3, 3)
+        npt.assert_array_equal(m[0], jnp.array([[0.0, 0, 0], [1, 2, 0], [3, 4, 5]]))
+        # Inverse of the ``np.tril_indices`` extraction used to read the elements.
+        npt.assert_array_equal(m[..., *np.tril_indices(3)], tril)
+
+
+class TestTriangular3x3Logm:
+    @pytest.mark.parametrize(
+        "diagonal",
+        [
+            pytest.param(jnp.array([0.7, 1.1, 1.4]), id="distinct"),
+            pytest.param(jnp.array([0.9, 0.9, 1.4]), id="two-equal"),
+            pytest.param(jnp.array([0.8, 0.8, 0.8]), id="cubic-repeated"),
+        ],
+    )
+    def test_inverse_of_expm(self, diagonal: jax.Array):
+        """``expm(triangular_3x3_logm(L)) == L``, including the defective
+        repeated-diagonal matrices the eig-based ``logm`` cannot handle. The
+        result stays lower-triangular."""
+        b = jnp.array(
+            [[diagonal[0], 0, 0], [0.5, diagonal[1], 0], [0.3, 0.2, diagonal[2]]]
+        )
+        lattice = jax.scipy.linalg.expm(b)
+        recovered = triangular_3x3_logm(lattice)
+        npt.assert_allclose(recovered, b, atol=1e-5)
+        npt.assert_allclose(jax.scipy.linalg.expm(recovered), lattice, atol=1e-5)
+        npt.assert_allclose(jnp.triu(recovered, 1), 0.0, atol=1e-10)
+
+    def test_upper_and_batched(self):
+        b = jnp.array([[0.7, 0, 0], [0.5, 1.1, 0], [0.3, 0.2, 1.4]])
+        lattice = jax.scipy.linalg.expm(b)
+        # Upper-triangular convention is the transpose of the lower one.
+        npt.assert_allclose(
+            triangular_3x3_logm(lattice.T, lower=False),
+            triangular_3x3_logm(lattice).T,
+            atol=1e-6,
+        )
+        batched = triangular_3x3_logm(
+            jnp.stack([lattice, jax.scipy.linalg.expm(2 * b)])
+        )
+        assert batched.shape == (2, 3, 3)
+        npt.assert_allclose(batched[0], b, atol=1e-5)
+
+    def test_gradient_safe_at_repeated_diagonal(self):
+        """No NaN gradients when diagonal entries coincide (cubic cell)."""
+        lattice = jax.scipy.linalg.expm(
+            jnp.array([[0.8, 0, 0], [0.5, 0.8, 0], [0.3, 0.2, 0.8]])
+        )
+        grad = jax.grad(lambda m: jnp.sum(triangular_3x3_logm(m)))(lattice)
+        assert bool(jnp.all(jnp.isfinite(grad)))
 
 
 class TestNextHigherPower:


### PR DESCRIPTION
> 🤖 _Auto-generated by Claude. Review and edit as needed._

Added `LogTriclinicFrame` class that parameterizes triclinic frames via the matrix logarithm, enabling unconstrained gradient-based optimization since any lower-triangular matrix yields a basis with strictly positive volume. Includes closed-form `triangular_3x3_logm` implementation for efficient log/exp operations on 3×3 triangular matrices.



Closes #157