### PR TITLE
feat: Add per-system Armijo and strong-Wolfe line-search transforms

### DIFF
--- a/src/kups/relaxation/config.py
+++ b/src/kups/relaxation/config.py
@@ -19,6 +19,10 @@ from kups.relaxation.transforms.clip_by_global_norm import ClipByGlobalNorm
 from kups.relaxation.transforms.fire import ScaleByFire
 from kups.relaxation.transforms.fire2 import ScaleByFire2
 from kups.relaxation.transforms.lbfgs import ScaleByAseLbfgs
+from kups.relaxation.transforms.linesearch import (
+    ScaleByBacktrackingLinesearch,
+    ScaleByMoreThuenteLinesearch,
+)
 from kups.relaxation.transforms.max_step_size import MaxStepSize
 
 Transform = str | dict[str, bool | int | float | str | list[Any] | None]
@@ -33,7 +37,16 @@ _CUSTOM_TRANSFORMS: dict[str, Any] = {
     "max_step_size": MaxStepSize,
     "scale_by_ase_lbfgs": ScaleByAseLbfgs,
     "clip_by_global_norm": ClipByGlobalNorm,
+    "scale_by_backtracking_linesearch": ScaleByBacktrackingLinesearch,
+    "scale_by_more_thuente_linesearch": ScaleByMoreThuenteLinesearch,
 }
+
+_UNSUPPORTED_OPTAX = {
+    "lbfgs": "scale_by_ase_lbfgs + scale_by_more_thuente_linesearch",
+    "scale_by_zoom_linesearch": "scale_by_more_thuente_linesearch",
+}
+"""optax value-based ops (their ``update`` needs ``value``/``value_fn``, which the
+per-system propagator does not supply) mapped to the kups transform(s) to use."""
 
 
 def get_transform(
@@ -49,7 +62,9 @@ def get_transform(
         The constructed GradientTransformation.
 
     Raises:
-        ValueError: If the transform name is not found in custom transforms or optax.
+        ValueError: If the transform name is unknown, or resolves to an optax
+            value-based line search whose ``update`` needs ``value``/``value_fn``
+            (which ``RelaxationPropagator`` does not supply per system).
     """
     if isinstance(transform, str):
         name = transform
@@ -60,13 +75,15 @@ def get_transform(
         kwargs = transform
 
     if name in _CUSTOM_TRANSFORMS:
-        constructor = _CUSTOM_TRANSFORMS[name]
-    elif hasattr(optax, name):
-        constructor = getattr(optax, name)
-    else:
+        return _CUSTOM_TRANSFORMS[name](**kwargs)
+    if name in _UNSUPPORTED_OPTAX:
+        raise ValueError(
+            f"Unsupported optax transform '{name}'; use "
+            f"{_UNSUPPORTED_OPTAX[name]} instead."
+        )
+    if not hasattr(optax, name):
         raise ValueError(f"Unknown transformation: {name}")
-
-    return constructor(**kwargs)
+    return getattr(optax, name)(**kwargs)
 
 
 def get_transformations(

--- a/src/kups/relaxation/propagator.py
+++ b/src/kups/relaxation/propagator.py
@@ -24,13 +24,16 @@ from kups.relaxation.optimizer import Optimizer, apply_updates
 
 @dataclass
 class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
-    """Unified propagator for gradient-based optimization using Optax.
+    """Unified propagator for gradient-based optimization.
 
-    Uses a Potential to compute energy and gradients. Supports both standard
-    optimizers (Adam, SGD) and line-search optimizers (L-BFGS, backtracking).
+    Uses a Potential to compute energy and gradients. Supports standard optax
+    optimizers (Adam, SGD) and the per-system line searches in
+    :mod:`kups.relaxation.transforms` (backtracking, More-Thuente).
 
-    For line-search optimizers, the potential is evaluated at trial points during
-    the line search. For standard optimizers, it's evaluated once per step.
+    Each step it passes the optimizer the gradient, the current per-system
+    energies, and a ``value_and_grad_fn`` for evaluating trial points; the line
+    searches use these to evaluate the objective along the search direction,
+    standard transforms ignore them.
 
     After computing energy and gradients, the potential's patch is applied to the
     state. This allows potentials to update internal state (e.g., neighbor lists)
@@ -43,14 +46,15 @@ class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
     Attributes:
         potential: Potential that computes energy and gradients of type PyTree
         property: Lens to get/set the property being optimized
-        opt_state: Lens to get/set the Optax optimizer state
-        optimizer: Optax gradient transformation
+        opt_state: Lens to get/set the optimizer state
+        optimizer: Gradient transformation
 
     Example:
         ```python
         import optax
+        from kups.relaxation.optimizer import chain
         from kups.relaxation.propagator import RelaxationPropagator
-        from kups.core.potential import MappedPotential
+        from kups.relaxation.transforms import ScaleByAseLbfgs, ScaleByMoreThuenteLinesearch
 
         # Standard optimizer (Adam)
         propagator = RelaxationPropagator(
@@ -60,25 +64,16 @@ class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
             optimizer=optax.adam(0.01),
         )
 
-        # Line-search optimizer (L-BFGS)
+        # L-BFGS with a per-system strong-Wolfe line search
         propagator = RelaxationPropagator(
             potential=my_potential,
             property=positions_lens,
             opt_state=lens(lambda s: s.opt_state),
-            optimizer=optax.lbfgs(),
-        )
-
-        # With gradient projection
-        mapped_potential = MappedPotential(
-            full_potential,
-            gradient_map=lambda g: g.positions,
-            hessian_map=lambda h: h,
-        )
-        propagator = RelaxationPropagator(
-            potential=mapped_potential,
-            property=positions_lens,
-            opt_state=lens(lambda s: s.opt_state),
-            optimizer=optax.lbfgs(),
+            optimizer=chain(
+                ScaleByAseLbfgs(memory_size=10),
+                optax.scale(-1.0),
+                ScaleByMoreThuenteLinesearch(),
+            ),
         )
 
         state = propagator(key, state)  # One optimization step
@@ -94,13 +89,11 @@ class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
         del key
         params = self.property.get(state)
 
-        def value_fn(p: PyTree) -> Array:
-            updated_state = self.property.set(state, p)
-            result = self.potential(updated_state)
-            return result.data.total_energies.data.sum()
+        def value_and_grad_fn(p: PyTree) -> tuple[Any, PyTree]:
+            out = self.potential(self.property.set(state, p)).data
+            return out.total_energies, out.gradients
 
         potential_out = self.potential(state)
-        value = potential_out.data.total_energies.data.sum()
         grad = potential_out.data.gradients
         # Apply the patch
         energies = potential_out.data.total_energies
@@ -110,13 +103,16 @@ class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
 
         opt_state_current = self.opt_state.get(state)
 
+        # grad, energies (the current per-system energies) and value_and_grad_fn
+        # are the per-system objective the line-search transforms read; standard
+        # transforms ignore them.
         updates, new_opt_state = self.optimizer.update(
             grad,
             opt_state_current,
             params,
-            value=value,
             grad=grad,
-            value_fn=value_fn,  # necessary for line-search optimizers
+            energies=energies,
+            value_and_grad_fn=value_and_grad_fn,
         )
 
         new_params = apply_updates(params, updates)

--- a/src/kups/relaxation/transforms/__init__.py
+++ b/src/kups/relaxation/transforms/__init__.py
@@ -20,6 +20,11 @@ from kups.relaxation.transforms.lbfgs import (
     ScaleByAseLbfgs,
     ScaleByAseLbfgsState,
 )
+from kups.relaxation.transforms.linesearch import (
+    LineSearchState,
+    ScaleByBacktrackingLinesearch,
+    ScaleByMoreThuenteLinesearch,
+)
 from kups.relaxation.transforms.max_step_size import (
     MaxStepSize,
     MaxStepSizeState,
@@ -28,12 +33,15 @@ from kups.relaxation.transforms.max_step_size import (
 __all__ = [
     "ClipByGlobalNorm",
     "ClipByGlobalNormState",
+    "LineSearchState",
     "MaxStepSize",
     "MaxStepSizeState",
     "ScaleByAseLbfgs",
     "ScaleByAseLbfgsState",
+    "ScaleByBacktrackingLinesearch",
     "ScaleByFire",
     "ScaleByFire2",
     "ScaleByFire2State",
     "ScaleByFireState",
+    "ScaleByMoreThuenteLinesearch",
 ]

--- a/src/kups/relaxation/transforms/linesearch.py
+++ b/src/kups/relaxation/transforms/linesearch.py
@@ -1,0 +1,580 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-system line searches that reproduce ASE's implementations.
+
+Two transforms that rescale an incoming descent direction ``d`` by a
+per-system step length ``t``. Like every other transform in this package,
+the search is taken per system: ``φ(t)``, ``φ'(t)`` and the accept /
+backtrack decision are arrays of shape ``(n_systems,)`` keyed on the
+system ids, so a system that is already satisfied never throttles the step
+of one that is not, and a batched run is bit-identical to running each
+system on its own.
+
+The two searches reproduce ASE's two line searches step-for-step (a single
+system matches ASE to floating-point tolerance):
+
+* :class:`ScaleByBacktrackingLinesearch` is :class:`ase.utils.linesearcharmijo`
+  ``LineSearchArmijo``: quadratic-interpolation backtracking enforcing the
+  Armijo sufficient-decrease condition, with the ``t ← max(t_quad, t/10)``
+  floor.
+* :class:`ScaleByMoreThuenteLinesearch` is :class:`ase.utils.linesearch` ``LineSearch``:
+  the MINPACK More–Thuente search (``dcsrch``/``dcstep``) targeting the strong
+  Wolfe conditions, which ASE's ``LBFGS(use_line_search=True)`` uses and which
+  pairs naturally with :class:`ScaleByAseLbfgs`.
+
+ASE bakes a per-atom ``maxstep`` clamp into the search (via ``determine_step``);
+here that clamp is left to the separate :class:`MaxStepSize` transform, so
+``determine_step`` is the identity and the searches reproduce the pure
+algorithms. ASE also fixes the initial trial step at ``1.0``; ``t_init = 1.0``
+(the default) reproduces ASE exactly.
+
+API convention
+--------------
+Following the optax composability pattern, the ``updates`` passed to
+:meth:`update` is the *descent direction* ``d`` produced by the preceding
+transforms (e.g. ``-H⁻¹∇L`` once the L-BFGS preconditioner is sign-flipped),
+and the raw gradient ``∇L`` arrives as the ``grad`` keyword. The search emits
+``t · d`` per system, so it belongs at the tail of a chain:
+
+.. code-block:: python
+
+    from kups.relaxation.optimizer import chain
+    from kups.relaxation.transforms import ScaleByAseLbfgs, ScaleByMoreThuenteLinesearch
+    import optax
+
+    optimizer = chain(
+        ScaleByAseLbfgs(memory_size=10),   # H⁻¹∇L
+        optax.scale(-1.0),                 # descent direction d = -H⁻¹∇L
+        ScaleByMoreThuenteLinesearch(),           # t · d
+    )
+
+Each step :class:`kups.relaxation.propagator.RelaxationPropagator` supplies
+the current per-system energies (``energies``), the raw gradient (``grad``)
+and a ``value_and_grad_fn`` that returns the per-system energies and gradient
+at a trial point. A system whose direction is not a descent direction
+(``∇L · d ≥ 0``) is left unmoved (``t = 0``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, override
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.data.index import Index, SupportsSorting
+from kups.core.data.table import Table
+from kups.core.typing import PyTree
+from kups.core.utils.jax import dataclass, field, tree_copy
+from kups.relaxation.optimizer import Optimizer
+from kups.relaxation.transforms._segmented_tree import tree_scale_per_row, tree_vdot
+
+type ValueAndGradFn = Callable[[PyTree], tuple[Table[SupportsSorting, Array], PyTree]]
+"""Maps trial params to ``(per-system energies, gradient pytree)``."""
+
+
+@dataclass
+class LineSearchState:
+    """Line-search state.
+
+    Attributes:
+        index_prefix: Tree prefix whose leaves are ``Index`` objects, captured at
+            init and used to take every reduction per system.
+        prev_phi0: Previous step's per-system energies, ``NaN`` until a step
+            records them. :class:`ScaleByBacktrackingLinesearch` uses them for its
+            Nocedal & Wright eq. 3.60 initial-step estimate;
+            :class:`ScaleByMoreThuenteLinesearch` leaves them untouched.
+    """
+
+    index_prefix: PyTree
+    prev_phi0: Array
+
+
+def _init_state(parameters: PyTree, index_prefix: PyTree | None) -> LineSearchState:
+    if index_prefix is None:
+        index_prefix = jax.tree.map(lambda x: Index.new((0,) * len(x)), parameters)
+    leaves = jax.tree.leaves(index_prefix, is_leaf=lambda x: isinstance(x, Index))
+    keys = next(leaf for leaf in leaves if isinstance(leaf, Index)).keys
+    return LineSearchState(
+        index_prefix=tree_copy(index_prefix), prev_phi0=jnp.full(len(keys), jnp.nan)
+    )
+
+
+def _setup(
+    direction: PyTree,
+    state: LineSearchState,
+    params: PyTree | None,
+    kwargs: dict[str, Any],
+) -> tuple[PyTree, tuple[SupportsSorting, ...], ValueAndGradFn, Array, Array]:
+    """Validate inputs and return ``(idx, keys, value_and_grad_fn, φ0, φ'(0))``."""
+    grad = kwargs.get("grad")
+    energies = kwargs.get("energies")
+    value_and_grad_fn = kwargs.get("value_and_grad_fn")
+    if params is None or grad is None or energies is None or value_and_grad_fn is None:
+        raise ValueError(
+            "line search needs params and the `grad`, `energies` and "
+            "`value_and_grad_fn` keywords that RelaxationPropagator supplies."
+        )
+    idx = state.index_prefix
+    leaves = jax.tree.leaves(idx, is_leaf=lambda x: isinstance(x, Index))
+    keys = next(leaf for leaf in leaves if isinstance(leaf, Index)).keys
+    if tuple(energies.keys) != tuple(keys):
+        raise ValueError(
+            f"total_energies keys {energies.keys} do not match index_prefix "
+            f"keys {keys}; init the optimizer with a matching index_prefix."
+        )
+    return (
+        idx,
+        keys,
+        value_and_grad_fn,
+        energies.data,
+        tree_vdot(grad, direction, idx).data,
+    )
+
+
+def _trial(
+    params: PyTree,
+    direction: PyTree,
+    t: Array,
+    keys: tuple[SupportsSorting, ...],
+    idx: PyTree,
+) -> PyTree:
+    """Trial params ``params + t · d``, with ``t`` applied per system."""
+    return jax.tree.map(
+        jnp.add, params, tree_scale_per_row(direction, Table(keys, t), idx)
+    )
+
+
+def _armijo(
+    params: PyTree,
+    direction: PyTree,
+    idx: PyTree,
+    keys: tuple[SupportsSorting, ...],
+    phi0: Array,
+    dphi0: Array,
+    value_and_grad_fn: ValueAndGradFn,
+    func_old: Array,
+    *,
+    c1: float,
+    a_min: float,
+    a_max: float,
+    max_steps: int,
+    t_init: float,
+) -> Array:
+    """Per-system Armijo backtracking — ASE ``LineSearchArmijo`` (no maxstep).
+
+    Each step evaluates ``φ(t)``; while Armijo (``φ(t) ≤ φ(0) + c1·t·φ'(0)``)
+    fails it replaces ``t`` by the minimiser of the quadratic through
+    ``φ(0), φ'(0), φ(t)`` floored at ``t/10`` (ASE: ``t = max(t_quad, t/10)``).
+    The first trial is the Nocedal & Wright eq. 3.60 estimate
+    ``2·(φ(0) − φ_old)/φ'(0)`` when ``φ_old`` (the previous step's energy) is
+    available and lands in ``[a_min, a_max]``, else ``t_init``; either way it is
+    rounded to ``1.0`` when within ``0.5`` (ASE's rule). Non-descent systems
+    (``φ'(0) ≥ 0``) stay at ``t = 0``. ASE raises once ``t < a_min``; per system
+    that path instead freezes the step.
+    """
+    n = phi0.shape[0]
+    dt = phi0.dtype
+    descent = dphi0 < 0.0
+
+    def phi(t: Array) -> Array:
+        energies, _ = value_and_grad_fn(_trial(params, direction, t, keys, idx))
+        return energies.data.astype(dt)
+
+    estimate = 2.0 * (phi0 - func_old.astype(dt)) / dphi0  # NaN on the first step
+    a1_init = jnp.where(
+        (estimate >= a_min) & (estimate <= a_max), estimate, jnp.asarray(t_init, dt)
+    )
+    # Cast back to φ's dtype: φ' may carry higher precision, which must not leak
+    # into the while_loop carry (see _more_thuente for the same guard).
+    a1_init = jnp.where(
+        jnp.abs(a1_init - 1.0) <= 0.5, jnp.asarray(1.0, dt), a1_init
+    ).astype(dt)
+    init = {
+        "i": jnp.asarray(0, jnp.int32),
+        "done": ~descent,
+        "t": jnp.zeros(n, dt),  # accepted step; 0 for non-descent
+        "a": jnp.where(descent, a1_init, jnp.zeros(n, dt)),  # current trial
+    }
+
+    def cond(c: dict[str, Array]) -> Array:
+        return (c["i"] < max_steps) & ~jnp.all(c["done"])
+
+    def body(c: dict[str, Array]) -> dict[str, Array]:
+        a = c["a"]
+        ph = phi(a)
+        suff = ph <= phi0 + c1 * a * dphi0
+        below = a < a_min  # underflowed the step floor
+        accept = (~c["done"]) & (~below) & suff
+        t = jnp.where(accept, a, c["t"])
+        a_quad = -(dphi0 * a) / (2.0 * ((ph - phi0) / a - dphi0))
+        a_next = jnp.maximum(a_quad, a / 10.0)
+        proceed = (~c["done"]) & (~below) & (~suff)
+        return {
+            "i": c["i"] + 1,
+            "done": c["done"] | below | suff,
+            "t": t,
+            "a": jnp.where(proceed, a_next, a).astype(dt),
+        }
+
+    return jax.lax.while_loop(cond, body, init)["t"]
+
+
+def _dcstep(
+    stx: Array,
+    fx: Array,
+    gx: Array,
+    sty: Array,
+    fy: Array,
+    gy: Array,
+    stp: Array,
+    fp: Array,
+    gp: Array,
+    brackt: Array,
+    lo: Array,
+    hi: Array,
+) -> tuple[Array, Array, Array, Array, Array, Array, Array, Array]:
+    """Per-system MINPACK ``dcstep`` (ASE ``LineSearch.update``).
+
+    Computes a safeguarded trial step from the best step so far (``stx``), the
+    other endpoint (``sty``) and the latest trial (``stp``), selecting among four
+    cubic/secant interpolation cases. ``lo``/``hi`` are the current bracket bounds
+    (``stmin``/``stmax``), not the global step limits. Returns the updated
+    ``(stx, sty, stp, gx, fx, gy, fy, brackt)``.
+    """
+    sgnd = gp * jnp.sign(gx)
+
+    def cubic(theta: Array, ga: Array, gb: Array) -> Array:
+        s = jnp.maximum(jnp.maximum(jnp.abs(theta), jnp.abs(ga)), jnp.abs(gb))
+        return s * jnp.sqrt((theta / s) ** 2 - (ga / s) * (gb / s))
+
+    # case 1: higher function value -> minimum bracketed.
+    theta1 = 3.0 * (fx - fp) / (stp - stx) + gx + gp
+    g1 = jnp.where(stp < stx, -cubic(theta1, gx, gp), cubic(theta1, gx, gp))
+    r1 = ((g1 - gx) + theta1) / (((g1 - gx) + g1) + gp)
+    stpc1 = stx + r1 * (stp - stx)
+    stpq1 = stx + ((gx / ((fx - fp) / (stp - stx) + gx)) / 2.0) * (stp - stx)
+    stpf1 = jnp.where(
+        jnp.abs(stpc1 - stx) < jnp.abs(stpq1 - stx),
+        stpc1,
+        stpc1 + (stpq1 - stpc1) / 2.0,
+    )
+
+    # case 2: lower value, opposite-sign derivatives -> minimum bracketed.
+    theta2 = 3.0 * (fx - fp) / (stp - stx) + gx + gp
+    g2 = jnp.where(stp > stx, -cubic(theta2, gx, gp), cubic(theta2, gx, gp))
+    r2 = ((g2 - gp) + theta2) / (((g2 - gp) + g2) + gx)
+    stpc2 = stp + r2 * (stx - stp)
+    stpq2 = stp + (gp / (gp - gx)) * (stx - stp)
+    stpf2 = jnp.where(jnp.abs(stpc2 - stp) > jnp.abs(stpq2 - stp), stpc2, stpq2)
+
+    # case 3: lower value, same-sign derivatives, magnitude decreasing.
+    theta3 = 3.0 * (fx - fp) / (stp - stx) + gx + gp
+    s3 = jnp.maximum(jnp.maximum(jnp.abs(theta3), jnp.abs(gx)), jnp.abs(gp))
+    g3 = s3 * jnp.sqrt(jnp.maximum(0.0, (theta3 / s3) ** 2 - (gx / s3) * (gp / s3)))
+    g3 = jnp.where(stp > stx, -g3, g3)
+    r3 = ((g3 - gp) + theta3) / ((g3 + (gx - gp)) + g3)
+    stpc3 = jnp.where(
+        (r3 < 0.0) & (g3 != 0.0),
+        stp + r3 * (stx - stp),
+        jnp.where(stp > stx, hi, lo),
+    )
+    stpq3 = stp + (gp / (gp - gx)) * (stx - stp)
+    closer = jnp.abs(stpc3 - stp) < jnp.abs(stpq3 - stp)
+    stpf3_br = jnp.where(closer, stpc3, stpq3)
+    stpf3_br = jnp.where(
+        stp > stx,
+        jnp.minimum(stp + 0.66 * (sty - stp), stpf3_br),
+        jnp.maximum(stp + 0.66 * (sty - stp), stpf3_br),
+    )
+    stpf3_nb = jnp.clip(jnp.where(~closer, stpc3, stpq3), lo, hi)
+    stpf3 = jnp.where(brackt, stpf3_br, stpf3_nb)
+
+    # case 4: lower value, same-sign derivatives, magnitude not decreasing.
+    theta4 = 3.0 * (fp - fy) / (sty - stp) + gy + gp
+    g4 = jnp.where(stp > sty, -cubic(theta4, gy, gp), cubic(theta4, gy, gp))
+    r4 = ((g4 - gp) + theta4) / (((g4 - gp) + g4) + gy)
+    stpf4 = jnp.where(brackt, stp + r4 * (sty - stp), jnp.where(stp > stx, hi, lo))
+
+    m1 = fp > fx
+    m2 = (~m1) & (sgnd < 0.0)
+    m3 = (~m1) & (~(sgnd < 0.0)) & (jnp.abs(gp) < jnp.abs(gx))
+    stpf = jnp.where(m1, stpf1, jnp.where(m2, stpf2, jnp.where(m3, stpf3, stpf4)))
+    brackt = brackt | m1 | m2
+
+    # Update the interval bounds (using the pre-update best point stx/fx/gx).
+    nstx = jnp.where(m1, stx, stp)
+    nfx = jnp.where(m1, fx, fp)
+    ngx = jnp.where(m1, gx, gp)
+    nsty = jnp.where(m1, stp, jnp.where(sgnd < 0.0, stx, sty))
+    nfy = jnp.where(m1, fp, jnp.where(sgnd < 0.0, fx, fy))
+    ngy = jnp.where(m1, gp, jnp.where(sgnd < 0.0, gx, gy))
+    return nstx, nsty, stpf, ngx, nfx, ngy, nfy, brackt
+
+
+def _more_thuente(
+    params: PyTree,
+    direction: PyTree,
+    idx: PyTree,
+    keys: tuple[SupportsSorting, ...],
+    phi0: Array,
+    dphi0: Array,
+    value_and_grad_fn: ValueAndGradFn,
+    *,
+    c1: float,
+    c2: float,
+    t_init: float,
+    stpmin: float,
+    stpmax: float,
+    xtol: float,
+    xtrapl: float,
+    xtrapu: float,
+    max_steps: int,
+) -> Array:
+    """Per-system MINPACK More–Thuente search — ASE ``LineSearch`` (no maxstep).
+
+    Drives ``dcsrch``: it brackets a step satisfying the strong Wolfe conditions
+    (``φ(t) ≤ φ0 + c1·t·φ'(0)`` and ``|φ'(t)| ≤ -c2·φ'(0)``) and refines it with
+    :func:`_dcstep`. Every quantity carries a leading ``(n_systems,)`` axis so
+    each system brackets independently. Non-descent systems (``φ'(0) ≥ 0``) stay
+    at ``t = 0``; a system that exhausts ``max_steps`` falls back to its best
+    bracket endpoint.
+    """
+    n = phi0.shape[0]
+    dt = phi0.dtype
+    descent = dphi0 < 0.0
+    # Run in φ's dtype so the while_loop carry stays single-dtype even when
+    # energies and gradient projections differ in precision.
+    ginit, finit, gtest = dphi0.astype(dt), phi0, c1 * dphi0.astype(dt)
+
+    def evald(t: Array) -> tuple[Array, Array]:
+        energies, grad = value_and_grad_fn(_trial(params, direction, t, keys, idx))
+        return energies.data.astype(dt), tree_vdot(grad, direction, idx).data.astype(dt)
+
+    init = {
+        "i": jnp.asarray(0, jnp.int32),
+        "done": ~descent,
+        "t": jnp.zeros(n, dt),  # accepted step (strong-Wolfe point)
+        "pending": jnp.zeros(n, bool),  # flagged to stop after one more evaluation
+        "stp": jnp.where(descent, jnp.asarray(t_init, dt), jnp.zeros(n, dt)),
+        "stx": jnp.zeros(n, dt),
+        "fx": finit,
+        "gx": ginit,
+        "sty": jnp.zeros(n, dt),
+        "fy": finit,
+        "gy": ginit,
+        "stmin": jnp.zeros(n, dt),
+        "stmax": jnp.full(n, t_init + xtrapu * t_init, dt),
+        "brackt": jnp.zeros(n, bool),
+        "width": jnp.full(n, stpmax - stpmin, dt),
+        "width1": jnp.full(n, (stpmax - stpmin) / 0.5, dt),
+    }
+
+    def cond(c: dict[str, Array]) -> Array:
+        return (c["i"] < max_steps) & ~jnp.all(c["done"])
+
+    def body(c: dict[str, Array]) -> dict[str, Array]:
+        stp = c["stp"]
+        f, g = evald(stp)
+        ftest = finit + stp * gtest
+        warn = (
+            (c["brackt"] & ((stp <= c["stmin"]) | (stp >= c["stmax"])))
+            | (c["brackt"] & ((c["stmax"] - c["stmin"]) <= xtol * c["stmax"]))
+            | ((stp == stpmax) & (f <= ftest) & (g <= gtest))
+            | ((stp == stpmin) & ((f > ftest) | (g >= gtest)))
+        )
+        conv = (f <= ftest) & (jnp.abs(g) <= c2 * (-ginit))
+        terminate = warn | conv | c["pending"]
+        t = jnp.where((~c["done"]) & terminate, stp, c["t"])
+
+        ustx, usty, ustp, ugx, ufx, ugy, ufy, ubr = _dcstep(
+            c["stx"],
+            c["fx"],
+            c["gx"],
+            c["sty"],
+            c["fy"],
+            c["gy"],
+            stp,
+            f,
+            g,
+            c["brackt"],
+            c["stmin"],
+            c["stmax"],
+        )
+        do_bisect = ubr & (jnp.abs(usty - ustx) >= 0.66 * c["width1"])
+        ustp = jnp.where(do_bisect, ustx + 0.5 * (usty - ustx), ustp)
+        nwidth1 = jnp.where(ubr, c["width"], c["width1"])
+        nwidth = jnp.where(ubr, jnp.abs(usty - ustx), c["width"])
+        nstmin = jnp.where(ubr, jnp.minimum(ustx, usty), ustp + xtrapl * (ustp - ustx))
+        nstmax = jnp.where(ubr, jnp.maximum(ustx, usty), ustp + xtrapu * (ustp - ustx))
+        ustp = jnp.clip(ustp, stpmin, stpmax)
+        no_upd = (ustx == ustp) & (ustp == stpmax) & (nstmin > stpmax)
+        fallback = (
+            (ubr & (ustp < nstmin))
+            | (ustp >= nstmax)
+            | (ubr & ((nstmax - nstmin) < xtol * nstmax))
+        )
+        ustp = jnp.where(fallback, ustx, ustp)
+
+        proceed = (~c["done"]) & (~terminate)
+
+        def sel(new: Array, old: Array) -> Array:
+            return jnp.where(proceed, new, old)
+
+        return {
+            "i": c["i"] + 1,
+            "done": c["done"] | terminate,
+            "t": t,
+            "pending": proceed & no_upd,
+            "stp": jnp.where(proceed, ustp, stp).astype(dt),
+            "stx": sel(ustx, c["stx"]),
+            "fx": sel(ufx, c["fx"]),
+            "gx": sel(ugx, c["gx"]),
+            "sty": sel(usty, c["sty"]),
+            "fy": sel(ufy, c["fy"]),
+            "gy": sel(ugy, c["gy"]),
+            "stmin": sel(nstmin, c["stmin"]),
+            "stmax": sel(nstmax, c["stmax"]),
+            "brackt": jnp.where(proceed, ubr, c["brackt"]),
+            "width": sel(nwidth, c["width"]),
+            "width1": sel(nwidth1, c["width1"]),
+        }
+
+    fin = jax.lax.while_loop(cond, body, init)
+    return jnp.where(fin["done"] | ~descent, fin["t"], fin["stx"])
+
+
+@dataclass
+class ScaleByBacktrackingLinesearch[Params](Optimizer[Params, LineSearchState]):
+    """Per-system Armijo backtracking line search — ASE ``LineSearchArmijo``.
+
+    Rescales the incoming descent direction by a per-system step ``t``: it shrinks
+    ``t`` by quadratic interpolation (floored at ``t/10``) until the step meets the
+    Armijo sufficient-decrease condition, deciding per system. The first trial uses
+    a Nocedal & Wright eq. 3.60 estimate from the previous step's energy (clamped
+    to ``[a_min, a_max]``, else ``t_init``). See the module docstring for the chain
+    convention.
+
+    Attributes:
+        c1: Armijo sufficient-decrease constant (``0 < c1 < 0.5``).
+        a_min: Smallest allowed step; the search freezes a system that reaches it.
+            Also the lower clamp on the eq. 3.60 initial-step estimate.
+        a_max: Upper clamp on the eq. 3.60 initial-step estimate; above it the
+            first trial falls back to ``t_init``.
+        max_steps: Maximum backtracking iterations.
+        t_init: Initial trial step when no estimate applies, rounded to ``1.0``
+            when within ``0.5``. ``1.0`` suits Newton-scaled directions.
+    """
+
+    c1: float = field(static=True, default=0.1)
+    a_min: float = field(static=True, default=1e-10)
+    a_max: float = field(static=True, default=2.0)
+    max_steps: int = field(static=True, default=50)
+    t_init: float = field(static=True, default=1.0)
+
+    @override
+    def init(
+        self, parameters: Params, index_prefix: PyTree | None = None
+    ) -> LineSearchState:
+        return _init_state(parameters, index_prefix)
+
+    @override
+    def update(
+        self,
+        updates: Params,
+        state: LineSearchState,
+        params: Params | None = None,
+        **kwargs: Any,
+    ) -> tuple[Params, LineSearchState]:
+        idx, keys, value_and_grad_fn, phi0, dphi0 = _setup(
+            updates, state, params, kwargs
+        )
+        t = _armijo(
+            params,
+            updates,
+            idx,
+            keys,
+            phi0,
+            dphi0,
+            value_and_grad_fn,
+            state.prev_phi0,
+            c1=self.c1,
+            a_min=self.a_min,
+            a_max=self.a_max,
+            max_steps=self.max_steps,
+            t_init=self.t_init,
+        )
+        new_state = LineSearchState(index_prefix=state.index_prefix, prev_phi0=phi0)
+        return tree_scale_per_row(updates, Table(keys, t), idx), new_state
+
+
+@dataclass
+class ScaleByMoreThuenteLinesearch[Params](Optimizer[Params, LineSearchState]):
+    """Per-system More–Thuente line search — ASE ``LineSearch``.
+
+    Brackets and refines a step meeting the strong Wolfe conditions via the
+    MINPACK ``dcsrch``/``dcstep`` algorithm, deciding per system. This is the
+    search ASE's ``LBFGS(use_line_search=True)`` uses; it pairs naturally with
+    :class:`ScaleByAseLbfgs`, whose secant updates rely on the curvature
+    condition. See the module docstring for the chain convention.
+
+    Attributes:
+        c1: Armijo sufficient-decrease constant (``0 < c1 < c2 < 1``).
+        c2: Curvature constant (``c1 < c2 < 1``); smaller demands a flatter slope.
+        t_init: Initial trial step.
+        stpmin: Smallest step the search will return.
+        stpmax: Largest step the search will return.
+        xtol: Relative bracket-width tolerance ending the search.
+        xtrapl: Lower extrapolation factor while bracketing.
+        xtrapu: Upper extrapolation factor while bracketing.
+        max_steps: Maximum combined bracketing + zoom iterations.
+    """
+
+    c1: float = field(static=True, default=0.23)
+    c2: float = field(static=True, default=0.46)
+    t_init: float = field(static=True, default=1.0)
+    stpmin: float = field(static=True, default=1e-8)
+    stpmax: float = field(static=True, default=50.0)
+    xtol: float = field(static=True, default=1e-14)
+    xtrapl: float = field(static=True, default=1.1)
+    xtrapu: float = field(static=True, default=4.0)
+    max_steps: int = field(static=True, default=50)
+
+    @override
+    def init(
+        self, parameters: Params, index_prefix: PyTree | None = None
+    ) -> LineSearchState:
+        return _init_state(parameters, index_prefix)
+
+    @override
+    def update(
+        self,
+        updates: Params,
+        state: LineSearchState,
+        params: Params | None = None,
+        **kwargs: Any,
+    ) -> tuple[Params, LineSearchState]:
+        idx, keys, value_and_grad_fn, phi0, dphi0 = _setup(
+            updates, state, params, kwargs
+        )
+        t = _more_thuente(
+            params,
+            updates,
+            idx,
+            keys,
+            phi0,
+            dphi0,
+            value_and_grad_fn,
+            c1=self.c1,
+            c2=self.c2,
+            t_init=self.t_init,
+            stpmin=self.stpmin,
+            stpmax=self.stpmax,
+            xtol=self.xtol,
+            xtrapl=self.xtrapl,
+            xtrapu=self.xtrapu,
+            max_steps=self.max_steps,
+        )
+        return tree_scale_per_row(updates, Table(keys, t), idx), state

--- a/test/relaxation/test_config.py
+++ b/test/relaxation/test_config.py
@@ -17,7 +17,9 @@ from kups.relaxation.transforms import (
     ClipByGlobalNorm,
     MaxStepSize,
     ScaleByAseLbfgs,
+    ScaleByBacktrackingLinesearch,
     ScaleByFire,
+    ScaleByMoreThuenteLinesearch,
 )
 
 
@@ -47,9 +49,32 @@ class TestGetTransform:
         t = get_transform({"transform": "clip_by_global_norm", "max_norm": 1.0})
         assert isinstance(t, ClipByGlobalNorm)
 
+    def test_linesearch_transforms_resolve_to_kups(self):
+        """The kups per-system line searches override optax's global ones."""
+        assert isinstance(
+            get_transform("scale_by_backtracking_linesearch"),
+            ScaleByBacktrackingLinesearch,
+        )
+        assert isinstance(
+            get_transform("scale_by_more_thuente_linesearch"),
+            ScaleByMoreThuenteLinesearch,
+        )
+
     def test_unknown_transform_raises(self):
         with pytest.raises(ValueError, match="Unknown transformation"):
             get_transform("this_does_not_exist")
+
+    def test_optax_value_based_linesearch_rejected(self):
+        """optax line searches needing value/value_fn are rejected with a clear error.
+
+        These reach the optax fallback (not shadowed by the custom registry) and
+        would otherwise crash at runtime inside the per-system propagator, which
+        supplies `energies`/`value_and_grad_fn` rather than optax's `value`/`value_fn`.
+        """
+        with pytest.raises(ValueError, match="Unsupported optax transform"):
+            get_transform("lbfgs")
+        with pytest.raises(ValueError, match="scale_by_more_thuente_linesearch"):
+            get_transform("scale_by_zoom_linesearch")
 
     def test_dict_does_not_mutate_input(self):
         config = {"transform": "sgd", "learning_rate": 0.01}

--- a/test/relaxation/test_propagator.py
+++ b/test/relaxation/test_propagator.py
@@ -3,6 +3,8 @@
 
 """Tests for relaxation propagators."""
 
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import numpy.testing as npt
@@ -14,7 +16,13 @@ from kups.core.patch import ExplicitPatch, IdPatch, WithPatch
 from kups.core.potential import PotentialOut
 from kups.core.typing import SystemId
 from kups.core.utils.jax import dataclass
+from kups.relaxation.optimizer import Optimizer, chain
 from kups.relaxation.propagator import RelaxationPropagator
+from kups.relaxation.transforms import (
+    ScaleByAseLbfgs,
+    ScaleByBacktrackingLinesearch,
+    ScaleByMoreThuenteLinesearch,
+)
 
 
 @dataclass
@@ -104,64 +112,6 @@ class TestRelaxationPropagator:
         expected = initial_pos - 0.1 * initial_pos
         npt.assert_allclose(new_state.positions, expected)
 
-    def test_lbfgs_converges(self):
-        """L-BFGS with linesearch should converge."""
-        optimizer = optax.lbfgs()
-        potential = QuadraticPotential()
-
-        initial_pos = jnp.array([5.0, -3.0])
-        state = PotentialState(
-            positions=initial_pos,
-            opt_state=optimizer.init(initial_pos),
-        )
-
-        propagator = RelaxationPropagator(
-            potential=potential,
-            property=lens(lambda s: s.positions, cls=PotentialState),
-            opt_state=lens(lambda s: s.opt_state),
-            optimizer=optimizer,
-        )
-        propagator = jax.jit(propagator)
-
-        key = jax.random.key(0)
-
-        for _ in range(10):
-            state = propagator(key, state)
-
-        npt.assert_allclose(state.positions, jnp.zeros(2), atol=1e-6)
-
-    def test_backtracking_linesearch(self):
-        """Backtracking line search works."""
-        optimizer = optax.chain(
-            optax.sgd(learning_rate=1.0),
-            optax.scale_by_backtracking_linesearch(
-                max_backtracking_steps=15,
-                store_grad=True,
-            ),
-        )
-        potential = QuadraticPotential()
-
-        initial_pos = jnp.array([3.0, 4.0])
-        state = PotentialState(
-            positions=initial_pos,
-            opt_state=optimizer.init(initial_pos),
-        )
-
-        propagator = RelaxationPropagator(
-            potential=potential,
-            property=lens(lambda s: s.positions, cls=PotentialState),
-            opt_state=lens(lambda s: s.opt_state),
-            optimizer=optimizer,
-        )
-
-        key = jax.random.key(42)
-        propagator = jax.jit(propagator)
-
-        for _ in range(10):
-            state = propagator(key, state)
-
-        npt.assert_allclose(state.positions, jnp.zeros(2), atol=1e-6)
-
     def test_applies_patch_each_step(self):
         """Potential's patch should be applied after each relaxation step."""
         optimizer = optax.sgd(learning_rate=0.1)
@@ -186,3 +136,49 @@ class TestRelaxationPropagator:
         state = propagator(key, state)
 
         assert state.patch_count == 1
+
+    def test_kups_more_thuente_linesearch_converges(self):
+        """The per-system More-Thuente search drives the quadratic to its minimum."""
+        optimizer: Optimizer[Any, Any] = chain(
+            optax.scale(-1.0), ScaleByMoreThuenteLinesearch()
+        )
+        state = PotentialState(
+            positions=jnp.array([5.0, -3.0]),
+            opt_state=optimizer.init(jnp.array([5.0, -3.0])),
+        )
+        propagator = jax.jit(
+            RelaxationPropagator(
+                potential=QuadraticPotential(),
+                property=lens(lambda s: s.positions, cls=PotentialState),
+                opt_state=lens(lambda s: s.opt_state),
+                optimizer=optimizer,
+            )
+        )
+        key = jax.random.key(0)
+        for _ in range(5):
+            state = propagator(key, state)
+        npt.assert_allclose(state.positions, jnp.zeros(2), atol=1e-6)
+
+    def test_kups_lbfgs_with_backtracking_converges(self):
+        """L-BFGS direction + per-system backtracking (the documented chain)."""
+        optimizer: Optimizer[Any, Any] = chain(
+            ScaleByAseLbfgs(memory_size=10, alpha=1.0),
+            optax.scale(-1.0),
+            ScaleByBacktrackingLinesearch(),
+        )
+        state = PotentialState(
+            positions=jnp.array([5.0, -3.0]),
+            opt_state=optimizer.init(jnp.array([5.0, -3.0])),
+        )
+        propagator = jax.jit(
+            RelaxationPropagator(
+                potential=QuadraticPotential(),
+                property=lens(lambda s: s.positions, cls=PotentialState),
+                opt_state=lens(lambda s: s.opt_state),
+                optimizer=optimizer,
+            )
+        )
+        key = jax.random.key(0)
+        for _ in range(8):
+            state = propagator(key, state)
+        npt.assert_allclose(state.positions, jnp.zeros(2), atol=1e-6)

--- a/test/relaxation/transforms/test_linesearch.py
+++ b/test/relaxation/transforms/test_linesearch.py
@@ -1,0 +1,230 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the per-system Armijo / strong-Wolfe line-search transforms."""
+
+from typing import Any, Callable
+
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+import pytest
+from jax import Array
+
+from kups.core.data.index import Index
+from kups.core.data.table import Table
+from kups.core.typing import SystemId
+from kups.relaxation.optimizer import Optimizer
+from kups.relaxation.transforms.linesearch import (
+    LineSearchState,
+    ScaleByBacktrackingLinesearch,
+    ScaleByMoreThuenteLinesearch,
+)
+
+
+def _system_index(system_ids: list[int], num_systems: int) -> Index[SystemId]:
+    keys = tuple(SystemId(i) for i in range(num_systems))
+    return Index(keys, jnp.array(system_ids), _cls=SystemId)
+
+
+def _value_and_grad_fn(
+    hess: Array, idx: Index[SystemId]
+) -> Callable[[Array], tuple[Any, Array]]:
+    """Per-element diagonal quadratic ``E = 0.5 Σ hess·x²``: per-system energy + grad."""
+    return lambda p: (idx.sum_over(0.5 * hess * p**2), hess * p)
+
+
+def _update(
+    opt: Optimizer[Array, LineSearchState],
+    state: LineSearchState,
+    x: Array,
+    direction: Array,
+    vag: Callable[[Array], tuple[Any, Array]],
+) -> tuple[Array, LineSearchState]:
+    energies, grad = vag(x)
+    return opt.update(
+        direction, state, x, grad=grad, energies=energies, value_and_grad_fn=vag
+    )
+
+
+def _run(
+    opt: Optimizer[Array, LineSearchState],
+    x: Array,
+    state: LineSearchState,
+    steps: int,
+    *,
+    hess: Array,
+    idx: Index[SystemId],
+) -> Array:
+    """Steepest-descent + line search on the quadratic; jit-compiled scan."""
+    vag = _value_and_grad_fn(hess, idx)
+
+    @jax.jit
+    def run(x: Array, state: LineSearchState) -> Array:
+        def body(carry: tuple[Array, Any], _: None) -> tuple[tuple[Array, Any], None]:
+            x, state = carry
+            step, state = _update(opt, state, x, -hess * x, vag)
+            return (x + step, state), None
+
+        (x, _), _ = jax.lax.scan(body, (x, state), None, length=steps)
+        return x
+
+    return run(x, state)
+
+
+def _single_step(
+    opt: Optimizer[Array, LineSearchState],
+    x: Array,
+    *,
+    hess: Array,
+    idx: Index[SystemId],
+    direction: Array,
+) -> Array:
+    vag = _value_and_grad_fn(hess, idx)
+    state = opt.init(x, index_prefix=idx)
+    step, _ = jax.jit(lambda x, d, s: _update(opt, s, x, d, vag))(x, direction, state)
+    return step
+
+
+class TestBacktracking:
+    def test_unit_step_satisfies_armijo(self):
+        """Identity Hessian: the full t=1 step lands on the minimum."""
+        opt = ScaleByBacktrackingLinesearch()
+        idx = _system_index([0, 0], 1)
+        hess = jnp.ones(2)
+        x = jnp.array([3.0, 4.0])
+        step = _single_step(opt, x, hess=hess, idx=idx, direction=-hess * x)
+        npt.assert_allclose(step, -x, rtol=1e-6)
+
+    def test_convergence(self):
+        opt = ScaleByBacktrackingLinesearch()
+        idx = _system_index([0, 0, 0], 1)
+        hess = jnp.ones(3)
+        x = jnp.array([5.0, -3.0, 2.0])
+        x = _run(opt, x, opt.init(x, index_prefix=idx), 3, hess=hess, idx=idx)
+        npt.assert_allclose(x, jnp.zeros(3), atol=1e-5)
+
+    def test_non_descent_direction_does_not_move(self):
+        """A non-descent direction (∇L·d ≥ 0) yields a zero step."""
+        opt = ScaleByBacktrackingLinesearch()
+        idx = _system_index([0, 0], 1)
+        hess = jnp.ones(2)
+        x = jnp.array([1.0, 2.0])
+        step = _single_step(opt, x, hess=hess, idx=idx, direction=hess * x)
+        npt.assert_allclose(step, jnp.zeros(2), atol=1e-12)
+
+    def test_interpolation_finds_minimiser(self):
+        """Ill-conditioned quadratic: interpolation lands on the exact line min.
+
+        The minimiser ``t* = 0.01`` is far below ``t_init = 1``; the quadratic
+        interpolant of a quadratic is exact, so the backtracking steps converge
+        onto it (step ``= -x``).
+        """
+        opt = ScaleByBacktrackingLinesearch()
+        idx = _system_index([0], 1)
+        hess = jnp.array([100.0])
+        x = jnp.array([1.0])
+        step = _single_step(opt, x, hess=hess, idx=idx, direction=-hess * x)
+        npt.assert_allclose(step, -x, atol=1e-4)
+
+    def test_mixed_precision_energy_grad(self):
+        """Float32 energies with float64 gradients keep the carry dtype stable.
+
+        The interpolation mixes φ (energies) with φ' (gradient projections); if
+        they differ in precision the while_loop carry must still keep ``t``'s
+        dtype. ``hess=8`` makes ``t=1`` overshoot so the interpolation runs.
+        """
+        opt = ScaleByBacktrackingLinesearch()
+        idx = _system_index([0, 0], 1)
+        hess = jnp.array([1.0, 8.0])
+        x = jnp.array([1.0, 1.0])
+
+        def vag(p: Array) -> tuple[Any, Array]:
+            e = idx.sum_over(0.5 * hess * p**2)
+            return Table(e.keys, e.data.astype(jnp.float32)), hess * p
+
+        step, _ = _update(opt, opt.init(x, index_prefix=idx), x, -hess * x, vag)
+        assert jnp.all(jnp.isfinite(step)) and bool(jnp.any(step != 0.0))
+
+    def test_batched_matches_separate(self):
+        """Headline guarantee: per-system steps decouple across systems."""
+
+        def run_alone(x0: Array, hess: Array) -> Array:
+            opt = ScaleByBacktrackingLinesearch()
+            idx = _system_index([0] * x0.shape[0], 1)
+            return _run(opt, x0, opt.init(x0, index_prefix=idx), 5, hess=hess, idx=idx)
+
+        x_a, hess_a = jnp.array([5.0, -3.0]), jnp.array([1.0, 4.0])
+        x_b, hess_b = jnp.array([0.5, 2.0]), jnp.array([10.0, 0.5])
+        sep = jnp.concatenate([run_alone(x_a, hess_a), run_alone(x_b, hess_b)])
+
+        opt = ScaleByBacktrackingLinesearch()
+        idx = _system_index([0, 0, 1, 1], 2)
+        x0 = jnp.concatenate([x_a, x_b])
+        hess = jnp.concatenate([hess_a, hess_b])
+        x = _run(opt, x0, opt.init(x0, index_prefix=idx), 5, hess=hess, idx=idx)
+        npt.assert_allclose(x, sep, atol=1e-6)
+
+    def test_requires_objective_keywords(self):
+        """Omitting the per-system objective keywords is rejected."""
+        opt = ScaleByBacktrackingLinesearch()
+        x = jnp.array([1.0])
+        state = opt.init(x)
+        with pytest.raises(ValueError, match="value_and_grad_fn"):
+            opt.update(-x, state, x, grad=x)
+
+
+class TestMoreThuente:
+    def test_unit_step_on_quadratic(self):
+        """Identity Hessian: strong Wolfe accepts the exact step t=1."""
+        opt = ScaleByMoreThuenteLinesearch()
+        idx = _system_index([0, 0], 1)
+        hess = jnp.ones(2)
+        x = jnp.array([3.0, 4.0])
+        step = _single_step(opt, x, hess=hess, idx=idx, direction=-hess * x)
+        npt.assert_allclose(step, -x, rtol=1e-6)
+
+    def test_convergence(self):
+        opt = ScaleByMoreThuenteLinesearch()
+        idx = _system_index([0, 0, 0], 1)
+        hess = jnp.ones(3)
+        x = jnp.array([5.0, -3.0, 2.0])
+        x = _run(opt, x, opt.init(x, index_prefix=idx), 3, hess=hess, idx=idx)
+        npt.assert_allclose(x, jnp.zeros(3), atol=1e-5)
+
+    def test_non_descent_direction_does_not_move(self):
+        opt = ScaleByMoreThuenteLinesearch()
+        idx = _system_index([0, 0], 1)
+        hess = jnp.ones(2)
+        x = jnp.array([1.0, 2.0])
+        step = _single_step(opt, x, hess=hess, idx=idx, direction=hess * x)
+        npt.assert_allclose(step, jnp.zeros(2), atol=1e-12)
+
+    def test_curvature_condition_satisfied(self):
+        """The accepted step meets the strong-Wolfe curvature bound per system."""
+        opt = ScaleByMoreThuenteLinesearch(c2=0.9)
+        idx = _system_index([0, 0], 1)
+        hess = jnp.array([1.0, 8.0])  # ill-conditioned: t=1 overshoots
+        x = jnp.array([1.0, 1.0])
+        direction = -hess * x
+        step = _single_step(opt, x, hess=hess, idx=idx, direction=direction)
+        dphi0 = float(jnp.vdot(hess * x, direction))
+        dphi_t = float(jnp.vdot(hess * (x + step), direction))
+        assert abs(dphi_t) <= -0.9 * dphi0 + 1e-6
+
+    def test_batched_matches_separate(self):
+        def run_alone(x0: Array, hess: Array) -> Array:
+            opt = ScaleByMoreThuenteLinesearch()
+            idx = _system_index([0] * x0.shape[0], 1)
+            return _run(opt, x0, opt.init(x0, index_prefix=idx), 5, hess=hess, idx=idx)
+
+        x_a, hess_a = jnp.array([5.0, -3.0]), jnp.array([1.0, 4.0])
+        x_b, hess_b = jnp.array([0.5, 2.0]), jnp.array([10.0, 0.5])
+        sep = jnp.concatenate([run_alone(x_a, hess_a), run_alone(x_b, hess_b)])
+
+        opt = ScaleByMoreThuenteLinesearch()
+        idx = _system_index([0, 0, 1, 1], 2)
+        x0 = jnp.concatenate([x_a, x_b])
+        hess = jnp.concatenate([hess_a, hess_b])
+        x = _run(opt, x0, opt.init(x0, index_prefix=idx), 5, hess=hess, idx=idx)
+        npt.assert_allclose(x, sep, atol=1e-6)

--- a/test/relaxation/transforms/test_linesearch_ase.py
+++ b/test/relaxation/transforms/test_linesearch_ase.py
@@ -1,0 +1,268 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""The per-system line searches reproduce ASE's implementations exactly.
+
+Each system is given one degree of freedom so the per-system search reduces to a
+1-D problem, run through the full transform interface and compared element-by-
+element against ASE's ``LineSearch`` (More-Thuente) and ``LineSearchArmijo``.
+ASE bakes a per-atom ``maxstep`` clamp into the search; we disable it (the clamp
+is left to ``MaxStepSize``) by passing ``maxstep=1e30``, which makes ASE's
+``determine_step`` the identity. Runs in float64 to match ASE's double precision.
+"""
+
+from typing import Any, Callable
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+from ase.utils.linesearch import LineSearch
+from ase.utils.linesearcharmijo import LineSearchArmijo
+from jax import Array
+
+from kups.core.data.index import Index
+from kups.core.typing import SystemId
+from kups.relaxation.optimizer import Optimizer
+from kups.relaxation.transforms.linesearch import (
+    LineSearchState,
+    ScaleByBacktrackingLinesearch,
+    ScaleByMoreThuenteLinesearch,
+)
+
+Scalar = Callable[[float], float]
+
+
+@pytest.fixture(autouse=True)
+def _x64():
+    """Run these comparisons in float64 to match ASE; isolate the cache."""
+    prev = bool(jax.config.read("jax_enable_x64"))
+    jax.clear_caches()
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+        jax.clear_caches()
+
+
+def _ase_more_thuente(phi: Scalar, dphi: Scalar, c1: float, c2: float) -> float:
+    # Embed the scalar problem on the first of three coords (ASE's gradient norm
+    # reshapes to (-1, 3)); maxstep=1e30 makes determine_step the identity, so the
+    # per-atom clamp (left to MaxStepSize) never fires. Portable across ASE versions.
+    ls = LineSearch()
+    pk = np.array([1.0, 0.0, 0.0])
+    alpha, *_ = ls._line_search(
+        lambda x, *a: phi(x[0]),
+        lambda x, *a: np.array([dphi(x[0]), 0.0, 0.0]),
+        np.zeros(3),
+        pk,
+        np.array([dphi(0.0), 0.0, 0.0]),
+        phi(0.0),
+        None,
+        c1=c1,
+        c2=c2,
+        stpmax=50.0,
+        maxstep=1e30,
+    )
+    assert alpha is not None  # ASE returns None only on failure; our cases succeed
+    return float(alpha)
+
+
+def _ase_armijo(
+    phi: Scalar, dphi: Scalar, c1: float, func_old: float | None = None
+) -> float:
+    # dirn reshaped to (-1, 3) by ASE, so embed the scalar on the first coord.
+    ls = LineSearchArmijo(lambda x: phi(x[0]), c1=c1)
+    alpha, *_ = ls.run(
+        np.zeros(3),
+        np.array([1.0, 0.0, 0.0]),
+        a1=None,
+        func_start=phi(0.0),
+        func_old=func_old,
+        func_prime_start=np.array([dphi(0.0), 0.0, 0.0]),
+        maxstep=1e30,
+    )
+    return float(alpha)
+
+
+def _index(n: int) -> Index[SystemId]:
+    keys = tuple(SystemId(i) for i in range(n))
+    return Index(keys, jnp.arange(n), _cls=SystemId)
+
+
+def _step(
+    opt: Optimizer[Array, LineSearchState],
+    x0: Array,
+    direction: Array,
+    vag: Callable[[Array], tuple[Any, Array]],
+    idx: Index[SystemId],
+) -> np.ndarray:
+    state = opt.init(x0, index_prefix=idx)
+
+    @jax.jit
+    def run(x0: Array, direction: Array) -> Array:
+        energies, grad = vag(x0)
+        step, _ = opt.update(
+            direction, state, x0, grad=grad, energies=energies, value_and_grad_fn=vag
+        )
+        return step
+
+    return np.array(run(x0, direction))
+
+
+# Per-system diagonal quadratics with steepest-descent direction. The line
+# minimiser is t* = 1/hess, spanning overshoot (hess > 1), exact (hess = 1) and
+# undershoot/expansion (hess < 1).
+HESS = jnp.array([1.0, 100.0, 0.2, 2.0, 0.5, 0.05], dtype=jnp.float64)
+X0 = jnp.array([1.0, 1.0, -2.0, 3.0, -1.0, 0.7], dtype=jnp.float64)
+
+# Per-system quartics evaluated from x0 = 0 along direction 1, so phi(t) is the
+# quartic itself; a1 < 0 keeps them descent, a4 > 0 keeps them bounded below.
+QUARTIC = jnp.array(
+    [[1.0, -0.5, 0.3, -1.0], [0.5, 0.2, -0.4, -0.8], [2.0, -1.0, 0.5, -0.3]],
+    dtype=jnp.float64,
+)
+
+
+def _quad_setup() -> tuple[Array, Array, Index[SystemId], Callable[[Array], Any]]:
+    idx = _index(len(HESS))
+    direction = -HESS * X0
+
+    def vag(p: Array) -> tuple[Any, Array]:
+        return idx.sum_over(0.5 * HESS * p**2), HESS * p
+
+    return X0, direction, idx, vag
+
+
+def _quad_scalars(i: int) -> tuple[Scalar, Scalar]:
+    h, x, d = float(HESS[i]), float(X0[i]), float(-HESS[i] * X0[i])
+    return (lambda t: 0.5 * h * (x + t * d) ** 2, lambda t: h * (x + t * d) * d)
+
+
+def _quartic_setup() -> tuple[Array, Array, Index[SystemId], Callable[[Array], Any]]:
+    n = QUARTIC.shape[0]
+    idx = _index(n)
+    a4, a3, a2, a1 = (QUARTIC[:, k] for k in range(4))
+
+    def vag(p: Array) -> tuple[Any, Array]:
+        e = a4 * p**4 + a3 * p**3 + a2 * p**2 + a1 * p
+        g = 4 * a4 * p**3 + 3 * a3 * p**2 + 2 * a2 * p + a1
+        return idx.sum_over(e), g
+
+    return jnp.zeros(n, jnp.float64), jnp.ones(n, jnp.float64), idx, vag
+
+
+def _quartic_scalars(i: int) -> tuple[Scalar, Scalar]:
+    c = np.array(QUARTIC[i])
+    return (
+        lambda t: c[0] * t**4 + c[1] * t**3 + c[2] * t**2 + c[3] * t,
+        lambda t: 4 * c[0] * t**3 + 3 * c[1] * t**2 + 2 * c[2] * t + c[3],
+    )
+
+
+def _shifted_quartic_scalars(ci: float, xi: float, di: float) -> tuple[Scalar, Scalar]:
+    """φ(s) = 0.5·ci·(xi + s·di)² + 0.25·(xi + s·di)⁴ and its derivative in s."""
+    return (
+        lambda s: 0.5 * ci * (xi + s * di) ** 2 + 0.25 * (xi + s * di) ** 4,
+        lambda s: (ci * (xi + s * di) + (xi + s * di) ** 3) * di,
+    )
+
+
+class TestMoreThuenteMatchesAse:
+    def test_quadratic(self):
+        x0, direction, idx, vag = _quad_setup()
+        t = _step(ScaleByMoreThuenteLinesearch(), x0, direction, vag, idx) / np.array(
+            direction
+        )
+        ase = [
+            _ase_more_thuente(*_quad_scalars(i), 0.23, 0.46) for i in range(len(HESS))
+        ]
+        npt.assert_allclose(t, ase, rtol=1e-7, atol=1e-9)
+
+    def test_quartic(self):
+        x0, direction, idx, vag = _quartic_setup()
+        t = _step(
+            ScaleByMoreThuenteLinesearch(), x0, direction, vag, idx
+        )  # direction = 1
+        ase = [
+            _ase_more_thuente(*_quartic_scalars(i), 0.23, 0.46)
+            for i in range(QUARTIC.shape[0])
+        ]
+        npt.assert_allclose(t, ase, rtol=1e-7, atol=1e-9)
+
+    def test_custom_c1_c2(self):
+        x0, direction, idx, vag = _quartic_setup()
+        opt = ScaleByMoreThuenteLinesearch(c1=1e-4, c2=0.9)
+        t = _step(opt, x0, direction, vag, idx)
+        ase = [
+            _ase_more_thuente(*_quartic_scalars(i), 1e-4, 0.9)
+            for i in range(QUARTIC.shape[0])
+        ]
+        npt.assert_allclose(t, ase, rtol=1e-7, atol=1e-9)
+
+
+class TestBacktrackingMatchesAse:
+    def test_quadratic(self):
+        x0, direction, idx, vag = _quad_setup()
+        t = _step(ScaleByBacktrackingLinesearch(), x0, direction, vag, idx) / np.array(
+            direction
+        )
+        ase = [_ase_armijo(*_quad_scalars(i), 0.1) for i in range(len(HESS))]
+        npt.assert_allclose(t, ase, rtol=1e-7, atol=1e-9)
+
+    def test_quartic(self):
+        x0, direction, idx, vag = _quartic_setup()
+        t = _step(ScaleByBacktrackingLinesearch(), x0, direction, vag, idx)
+        ase = [_ase_armijo(*_quartic_scalars(i), 0.1) for i in range(QUARTIC.shape[0])]
+        npt.assert_allclose(t, ase, rtol=1e-7, atol=1e-9)
+
+    def test_custom_c1(self):
+        x0, direction, idx, vag = _quartic_setup()
+        t = _step(ScaleByBacktrackingLinesearch(c1=0.4), x0, direction, vag, idx)
+        ase = [_ase_armijo(*_quartic_scalars(i), 0.4) for i in range(QUARTIC.shape[0])]
+        npt.assert_allclose(t, ase, rtol=1e-7, atol=1e-9)
+
+    def test_initial_step_estimate_matches_ase(self):
+        """Step 2 uses the N&W eq. 3.60 estimate from step 1's energy, like ASE.
+
+        One dof per system on convex quartics ``0.5·c·x² + 0.25·x⁴`` (non-quadratic
+        so step 1 does not land on the minimum and step 2 is a genuine search).
+        """
+        c = jnp.array([1.0, 4.0, 0.5], dtype=jnp.float64)
+        x0 = jnp.array([1.5, 1.2, 2.0], dtype=jnp.float64)
+        idx = _index(len(c))
+
+        def vag(p: Array):
+            return idx.sum_over(0.5 * c * p**2 + 0.25 * p**4), c * p + p**3
+
+        opt = ScaleByBacktrackingLinesearch()
+
+        @jax.jit
+        def update(state: LineSearchState, x: Array):
+            e, g = vag(x)
+            step, state = opt.update(
+                -g, state, x, grad=g, energies=e, value_and_grad_fn=vag
+            )
+            return step, state
+
+        state = opt.init(x0, index_prefix=idx)
+        e0, _ = vag(x0)
+        s0, state = update(state, x0)
+        x1 = x0 + s0
+        _, g1 = vag(x1)
+        s1, _ = update(state, x1)
+        t2 = np.array(s1) / np.array(-g1)
+
+        cn, x1n, d1n = np.array(c), np.array(x1), np.array(-g1)
+        e0n = np.array(e0.data)  # func_old for step 2
+        ase = [
+            _ase_armijo(
+                *_shifted_quartic_scalars(float(cn[i]), float(x1n[i]), float(d1n[i])),
+                0.1,
+                func_old=float(e0n[i]),
+            )
+            for i in range(len(c))
+        ]
+        npt.assert_allclose(t2, ase, rtol=1e-7, atol=1e-9)


### PR DESCRIPTION
> 🤖 _Auto-generated by Claude. Review and edit as needed._

Added per-system Armijo and strong-Wolfe line-search transforms (`ScaleByBacktrackingLinesearch` and `ScaleByZoomLinesearch`) that rescale descent directions by per-system step lengths, enabling efficient batched optimization where systems at convergence don't throttle others, and paired naturally with L-BFGS.

Closes #162