### PR TITLE
refactor: Rename `lh`/`rh`/`for_indices` to `keys`/`queries`/`queried_keys` in neighbor list API

### DIFF
--- a/docs/notebooks/neighborlist.ipynb
+++ b/docs/notebooks/neighborlist.ipynb
@@ -161,11 +161,11 @@
    "source": [
     "## The protocol: NeighborList\n",
     "\n",
-    "Callers never depend on a specific algorithm. They hold something that satisfies [NeighborList][kups.core.neighborlist.NeighborList], a protocol whose `__call__` method takes a left-hand particle table `lh`, a system table, and two optional keyword-only query modes: `rh` for truly bipartite queries and `for_indices` for a subset of particles already stored in `lh`. Cutoff-aware neighbor-list instances own their per-system cutoff table, so a `View[State, NeighborList[Literal[2]]]` returns an object that is already bound to the cutoff for that use case. With neither keyword, the neighbor list finds pairs within `lh`, which is the familiar self-graph used by MD force evaluations.\n",
+    "Callers never depend on a specific algorithm. They hold something that satisfies [NeighborList][kups.core.neighborlist.NeighborList], a protocol whose `__call__` method takes a key particle table `keys`, a system table, and two optional keyword-only query modes: `queries` for truly bipartite queries and `queried_keys` for a subset of particles already stored in `keys`. Cutoff-aware neighbor-list instances own their per-system cutoff table, so a `View[State, NeighborList[Literal[2]]]` returns an object that is already bound to the cutoff for that use case. With neither keyword, the neighbor list finds pairs within `keys`, which is the familiar self-graph used by MD force evaluations.\n",
     "\n",
-    "Most local updates use `for_indices`. A Monte Carlo displacement first stages the proposed particle data into the left-hand table, then asks for edges touching only the moved particle ids. This keeps all returned indices in the same `lh` key space and avoids ambiguity about whether an edge endpoint points into the full state or into a separate query table. The `rh` keyword is reserved for the rare case where the right-hand data is genuinely separate from `lh`, such as a disjoint insertion-candidate table. `rh` and `for_indices` are mutually exclusive.\n",
+    "Most local updates use `queried_keys`. A Monte Carlo displacement first stages the proposed particle data into the key table, then asks for edges touching only the moved particle ids. This keeps all returned indices in the same `keys` key space and avoids ambiguity about whether an edge endpoint points into the full state or into a separate query table. The `queries` keyword is reserved for the rare case where the query data is genuinely separate from `keys`, such as a disjoint insertion-candidate table. `queries` and `queried_keys` are mutually exclusive.\n",
     "\n",
-    "The call below first runs the neighbor list over a five-particle chain, then asks for only the edges incident to particle 1 with `for_indices`. The second call returns the local self-graph subset that touches particle 1, in both directions, and nothing else."
+    "The call below first runs the neighbor list over a five-particle chain, then asks for only the edges incident to particle 1 with `queried_keys`. The second call returns the local self-graph subset that touches particle 1, in both directions, and nothing else."
    ]
   },
   {
@@ -206,10 +206,10 @@
     "\n",
     "# Query only the edges incident to particle 1 within the same table.\n",
     "query_idx = 1\n",
-    "for_indices = Index(particles.keys, jnp.array([query_idx]))\n",
+    "queried_keys = Index(particles.keys, jnp.array([query_idx]))\n",
     "\n",
-    "subset = nl(particles, systems, for_indices=for_indices)\n",
-    "print(\"for_indices={1}:\", sorted(edge_set(subset, len(particles))))"
+    "subset = nl(particles, systems, queried_keys=queried_keys)\n",
+    "print(\"queried_keys={1}:\", sorted(edge_set(subset, len(particles))))"
    ]
   },
   {

--- a/src/kups/core/neighborlist/__init__.py
+++ b/src/kups/core/neighborlist/__init__.py
@@ -9,12 +9,12 @@ accuracy trade-offs.
 
 ## Call Contract
 
-Neighbor lists are called as ``neighborlist(lh, systems, *, rh=None,
-for_indices=None)``. ``lh`` is the self-graph/output table. Use keyword-only
-``rh`` only for true bipartite queries. Use keyword-only ``for_indices`` only
-for self-graph updates; it is mutually exclusive with ``rh`` and names affected
-``lh`` ids after the caller has already written updated particle data into
-``lh``.
+Neighbor lists are called as ``neighborlist(keys, systems, *, queries=None,
+queried_keys=None)``. ``keys`` is the self-graph/output table. Use keyword-only
+``queries`` only for true bipartite queries. Use keyword-only ``queried_keys``
+only for self-graph updates; it is mutually exclusive with ``queries`` and names
+affected ``keys`` ids after the caller has already written updated particle data
+into ``keys``.
 
 ## Core Components
 
@@ -58,7 +58,7 @@ These cover non-cutoff cases under the same `NeighborList[D]` protocol.
 7. **[FixedEdgesNeighborList][kups.core.neighborlist.FixedEdgesNeighborList]**:
    stores fixed edge topology for bonded edge sets supplied by the state and
    computes current periodic shifts during calls. Affected self-graph calls use
-   ``for_indices`` and return only rows touched by those affected ``lh`` ids.
+   ``queried_keys`` and return only rows touched by those affected ``keys`` ids.
 
 ## Pipeline Primitives
 
@@ -108,10 +108,10 @@ from kups.core.neighborlist.fixed import (
 from kups.core.neighborlist.masks import (
     DistanceCutoffMask,
     ExclusionMask,
-    ForIndicesDedupMask,
     InBoundsMask,
     InclusionMatchMask,
-    TouchesForIndicesMask,
+    QueriedKeysDedupMask,
+    TouchesQueriedKeysMask,
 )
 from kups.core.neighborlist.parameters import UniversalNeighborlistParameters
 from kups.core.neighborlist.pipeline import Pipeline
@@ -152,7 +152,7 @@ __all__ = [
     "Edges",
     "EmptyNeighborList",
     "ExclusionMask",
-    "TouchesForIndicesMask",
+    "TouchesQueriedKeysMask",
     "FixedEdgesNeighborList",
     "InBoundsMask",
     "InclusionGroupSelector",
@@ -178,7 +178,7 @@ __all__ = [
     "ReduceCompactor",
     "RefineCutoffNeighborList",
     "RefineMaskNeighborList",
-    "ForIndicesDedupMask",
+    "QueriedKeysDedupMask",
     "UniversalNeighborlistParameters",
     "adaptive_cutoff_neighborlist_from_state",
     "all_connected_neighborlist",

--- a/src/kups/core/neighborlist/all_connected.py
+++ b/src/kups/core/neighborlist/all_connected.py
@@ -11,7 +11,7 @@ real-space exclusion list.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal, overload
 
 import jax.numpy as jnp
 
@@ -20,17 +20,16 @@ from kups.core.data import Index, Table, subselect
 from kups.core.neighborlist.common import (
     Candidates,
     candidates_to_batch,
-    edge_rhs_table,
     lift_query_candidates,
-    query_table,
 )
 from kups.core.neighborlist.compact import ReduceCompactor
 from kups.core.neighborlist.edges import Edges
-from kups.core.neighborlist.masks import ExclusionMask, ForIndicesDedupMask
+from kups.core.neighborlist.masks import ExclusionMask, QueriedKeysDedupMask
 from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.postprocess import MirrorPairEdges
 from kups.core.neighborlist.types import (
     CandidateBatch,
+    NeighborList,
     NeighborListPoints,
     NeighborListSystems,
     PipelineContext,
@@ -51,38 +50,56 @@ class InclusionGroupSelector:
     capacity: Capacity[int]
 
     def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
-        query = query_table(ctx)
-        ngraphs = ctx.lh.data.inclusion.num_labels
+        query = ctx.query_table
+        ngraphs = ctx.keys.data.inclusion.num_labels
         selection_result = subselect(
-            ctx.lh.data.inclusion.indices,
+            ctx.keys.data.inclusion.indices,
             query.data.inclusion.indices,
             output_buffer_size=self.capacity,
             num_segments=ngraphs,
         )
         candidates = Candidates(
-            lhs=Index(ctx.lh.keys, selection_result.scatter_idxs),
-            rhs=Index(query.keys, selection_result.gather_idxs),
+            key_idx=Index(ctx.keys.keys, selection_result.scatter_idxs),
+            query_idx=Index(query.keys, selection_result.gather_idxs),
         )
         candidates = lift_query_candidates(candidates, ctx)
-        rhs = edge_rhs_table(ctx)
+        query_tbl = ctx.edge_query_table
         deltas = (
-            ctx.lh.data.positions[candidates.lhs.indices]
-            - rhs.data.positions[candidates.rhs.indices]
+            ctx.keys.data.positions[candidates.key_idx.indices]
+            - query_tbl.data.positions[candidates.query_idx.indices]
         )
         shifts = jnp.round(deltas).astype(int)
         return candidates_to_batch(
             candidates,
             shifts,
-            jnp.ones((candidates.lhs.size,), dtype=bool),
+            jnp.ones((candidates.key_idx.size,), dtype=bool),
         )
 
 
-def all_connected_neighborlist(
-    lh: Table[ParticleId, NeighborListPoints],
+@overload
+def all_connected_neighborlist[P: NeighborListPoints](
+    keys: Table[ParticleId, P],
     systems: Table[SystemId, NeighborListSystems],
     *,
-    rh: Table[ParticleId, NeighborListPoints] | None = None,
-    for_indices: Index[ParticleId] | None = None,
+    queries: Table[ParticleId, P],
+) -> Edges[Literal[2]]: ...
+
+
+@overload
+def all_connected_neighborlist[P: NeighborListPoints](
+    keys: Table[ParticleId, P],
+    systems: Table[SystemId, NeighborListSystems],
+    *,
+    queried_keys: Index[ParticleId] | None = None,
+) -> Edges[Literal[2]]: ...
+
+
+def all_connected_neighborlist[P: NeighborListPoints](
+    keys: Table[ParticleId, P],
+    systems: Table[SystemId, NeighborListSystems],
+    *,
+    queries: Table[ParticleId, P] | None = None,
+    queried_keys: Index[ParticleId] | None = None,
 ) -> Edges[Literal[2]]:
     """Neighbor list connecting all pairs sharing the same inclusion segment, ignoring distance.
 
@@ -92,19 +109,25 @@ def all_connected_neighborlist(
 
     Requires ``max_count`` to be set on the inclusion ``Index``.
     """
-    max_count = lh.data.inclusion.max_count
+    max_count = keys.data.inclusion.max_count
     assert max_count is not None, "inclusion.max_count must be set"
     query_size = (
-        for_indices.size
-        if for_indices is not None
-        else (rh.size if rh is not None else lh.size)
+        queried_keys.size
+        if queried_keys is not None
+        else (queries.size if queries is not None else keys.size)
     )
-    capacity = FixedCapacity(max_count).multiply(min(lh.size, query_size))
+    capacity = FixedCapacity(max_count).multiply(min(keys.size, query_size))
 
     pipeline = Pipeline[Literal[2]](
         selector=InclusionGroupSelector(capacity=capacity),
-        masks=(ExclusionMask(), ForIndicesDedupMask()),
+        masks=(ExclusionMask(), QueriedKeysDedupMask()),
         compactor=ReduceCompactor(avg_edges=capacity),
         postprocessors=(MirrorPairEdges(),),
     )
-    return pipeline(lh, systems, rh=rh, for_indices=for_indices)
+    if queries is not None:
+        return pipeline(keys, systems, queries=queries)
+    return pipeline(keys, systems, queried_keys=queried_keys)
+
+
+if TYPE_CHECKING:
+    x: NeighborList[Literal[2]] = all_connected_neighborlist

--- a/src/kups/core/neighborlist/all_dense.py
+++ b/src/kups/core/neighborlist/all_dense.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal, Protocol
+from typing import Literal, Protocol, overload
 
 import jax.numpy as jnp
 from jax import Array
@@ -16,9 +16,7 @@ from kups.core.data import Index, Table
 from kups.core.lens import Lens, lens
 from kups.core.neighborlist.common import (
     Candidates,
-    edge_rhs_table,
     lift_query_candidates,
-    query_table,
     replicate_for_images,
 )
 from kups.core.neighborlist.compact import ReduceCompactor
@@ -26,9 +24,9 @@ from kups.core.neighborlist.edges import Edges
 from kups.core.neighborlist.masks import (
     DistanceCutoffMask,
     ExclusionMask,
-    ForIndicesDedupMask,
     InBoundsMask,
     InclusionMatchMask,
+    QueriedKeysDedupMask,
 )
 from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.postprocess import MirrorPairEdges
@@ -53,12 +51,15 @@ class IsAllDenseNeighborListParams(Protocol):
 
 
 def _all_subselect(
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints],
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
 ) -> Candidates:
-    lh_indices, rh_indices = jnp.indices((len(lh), len(rh))).reshape(2, -1)
-    return Candidates(lhs=Index(lh.keys, lh_indices), rhs=Index(rh.keys, rh_indices))
+    key_indices, queried_keys = jnp.indices((len(keys), len(queries))).reshape(2, -1)
+    return Candidates(
+        key_idx=Index(keys.keys, key_indices),
+        query_idx=Index(queries.keys, queried_keys),
+    )
 
 
 @dataclass
@@ -69,13 +70,13 @@ class AllDenseSelector:
     max_image_candidates: Capacity[int]
 
     def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
-        query = query_table(ctx)
-        candidates = _all_subselect(ctx.lh, query, ctx.systems)
+        query = ctx.query_table
+        candidates = _all_subselect(ctx.keys, query, ctx.systems)
         candidates = lift_query_candidates(candidates, ctx)
         return replicate_for_images(
             candidates,
-            ctx.lh,
-            edge_rhs_table(ctx),
+            ctx.keys,
+            ctx.edge_query_table,
             ctx.systems,
             self.cutoffs,
             self.max_image_candidates,
@@ -142,25 +143,41 @@ class AllDenseNearestNeighborList:
     ) -> AllDenseNearestNeighborList:
         return cls.new(state, lens(lambda s: s.neighborlist_params), cutoffs)
 
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, NeighborListPoints],
+    ) -> Edges[Literal[2]]: ...
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[Literal[2]]: ...
     @jit
     def __call__(
         self,
-        lh: Table[ParticleId, NeighborListPoints],
+        keys: Table[ParticleId, NeighborListPoints],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, NeighborListPoints] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, NeighborListPoints] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
-        if lh.data.inclusion.num_labels >= 2:
+        if keys.data.inclusion.num_labels >= 2:
             logging.warning(
                 "AllDenseNearestNeighborList is intended for single-system simulations. "
                 "Performance may be degraded when using multiple systems. "
                 "Consider using DenseNearestNeighborList or CellListNeighborList instead."
             )
         query_size = (
-            for_indices.size
-            if for_indices is not None
-            else (rh.size if rh is not None else lh.size)
+            queried_keys.size
+            if queried_keys is not None
+            else (queries.size if queries is not None else keys.size)
         )
         cutoffs = Table.broadcast_to(self.cutoffs, systems)
         pipeline = Pipeline[Literal[2]](
@@ -171,11 +188,13 @@ class AllDenseNearestNeighborList:
             masks=(
                 InBoundsMask(),
                 InclusionMatchMask(),
-                ForIndicesDedupMask(),
+                QueriedKeysDedupMask(),
                 DistanceCutoffMask(cutoffs=cutoffs),
                 ExclusionMask(),
             ),
             compactor=ReduceCompactor(avg_edges=self.avg_edges.multiply(query_size)),
             postprocessors=(MirrorPairEdges(),),
         )
-        return pipeline(lh, systems, rh=rh, for_indices=for_indices)
+        if queries is not None:
+            return pipeline(keys, systems, queries=queries)
+        return pipeline(keys, systems, queried_keys=queried_keys)

--- a/src/kups/core/neighborlist/cell_list.py
+++ b/src/kups/core/neighborlist/cell_list.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Literal, Protocol
+from typing import Literal, Protocol, overload
 
 import jax
 import jax.numpy as jnp
@@ -17,10 +17,8 @@ from kups.core.data import Index, Table, subselect
 from kups.core.lens import Lens, lens
 from kups.core.neighborlist.common import (
     Candidates,
-    edge_rhs_table,
     lift_query_candidates,
     num_cells,
-    query_table,
     replicate_for_images,
 )
 from kups.core.neighborlist.compact import ReduceCompactor
@@ -28,9 +26,9 @@ from kups.core.neighborlist.edges import Edges
 from kups.core.neighborlist.masks import (
     DistanceCutoffMask,
     ExclusionMask,
-    ForIndicesDedupMask,
     InBoundsMask,
     InclusionMatchMask,
+    QueriedKeysDedupMask,
 )
 from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.postprocess import MirrorPairEdges
@@ -77,16 +75,16 @@ def _cell_stencil(dim: int) -> Array:
 
 
 def _cell_list_subselect(
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints],
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
     cutoffs: Array,
     max_num_cells: Capacity[int],
     max_num_candidates: Capacity[int],
 ) -> Candidates:
     cell = systems.data.cell
-    key_positions, _ = cell.fold(lh.data.positions)
-    query_positions, _ = cell.fold(rh.data.positions)
+    key_positions, _ = cell.fold(keys.data.positions)
+    query_positions, _ = cell.fold(queries.data.positions)
 
     bins = systems.map_data(partial(num_cells, cutoff=cutoffs))
     max_num_cells = max_num_cells.generate_assertion(
@@ -102,26 +100,28 @@ def _cell_list_subselect(
     )
 
     # Raw system IDs for hash offset computation
-    lh_system_ids = lh.data.system.indices
-    rh_system_ids = rh.data.system.indices
+    key_system_ids = keys.data.system.indices
+    query_system_ids = queries.data.system.indices
 
     key_hashes = (
-        _cell_hash(key_positions, bins[lh.data.system])
-        + lh_system_ids * max_num_cells.size
+        _cell_hash(key_positions, bins[keys.data.system])
+        + key_system_ids * max_num_cells.size
     )
 
     # Expand neighborhood around query points: for each query, tile across stencil
     stencil = _cell_stencil(dim)
-    raw_shifted = jax.vmap(lambda s: query_positions + s[None] / bins[rh.data.system])(
-        stencil
-    ).reshape(-1, dim)
-    query_original = Index(rh.keys, jnp.tile(jnp.arange(len(rh)), len(stencil)))
-    query_system = rh.data.system[query_original.indices]
+    raw_shifted = jax.vmap(
+        lambda s: query_positions + s[None] / bins[queries.data.system]
+    )(stencil).reshape(-1, dim)
+    query_original = Index(
+        queries.keys, jnp.tile(jnp.arange(len(queries)), len(stencil))
+    )
+    query_system = queries.data.system[query_original.indices]
 
     shifted, in_cell = cell.fold(raw_shifted)
     hashes = (
         _cell_hash(shifted, bins[query_system])
-        + rh_system_ids[query_original.indices] * max_num_cells.size
+        + query_system_ids[query_original.indices] * max_num_cells.size
     )
     # Stencil offsets that left the box on a non-periodic axis route to
     # cell_oob so they produce no key matches (cross-boundary candidates
@@ -133,10 +133,10 @@ def _cell_list_subselect(
         jnp.stack([query_neighborhood_hashes, query_original.indices], axis=-1),
         axis=0,
         size=len(query_original),
-        fill_value=jnp.array([cell_oob, len(rh)]),
+        fill_value=jnp.array([cell_oob, len(queries)]),
     )
     query_neighborhood_hashes = unique_queries[:, 0]
-    query_original = Index(rh.keys, unique_queries[:, 1])
+    query_original = Index(queries.keys, unique_queries[:, 1])
 
     selection_result = subselect(
         key_hashes,
@@ -145,14 +145,14 @@ def _cell_list_subselect(
         num_segments=cell_oob,
         is_sorted=True,  # unique sorts the neighborhood hashes
     )
-    lhs = Index(lh.keys, selection_result.scatter_idxs)
-    rhs = Index(
+    key_idx = Index(keys.keys, selection_result.scatter_idxs)
+    query_idx = Index(
         query_original.keys,
         query_original.indices.at[selection_result.gather_idxs].get(
             **query_original.scatter_args
         ),
     )
-    return Candidates(lhs=lhs, rhs=rhs)
+    return Candidates(key_idx=key_idx, query_idx=query_idx)
 
 
 @dataclass
@@ -169,9 +169,9 @@ class CellListSelector:
     max_image_candidates: Capacity[int]
 
     def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
-        query = query_table(ctx)
+        query = ctx.query_table
         candidates = _cell_list_subselect(
-            ctx.lh,
+            ctx.keys,
             query,
             ctx.systems,
             cutoffs=self.cutoffs.data,
@@ -181,8 +181,8 @@ class CellListSelector:
         candidates = lift_query_candidates(candidates, ctx)
         return replicate_for_images(
             candidates,
-            ctx.lh,
-            edge_rhs_table(ctx),
+            ctx.keys,
+            ctx.edge_query_table,
             ctx.systems,
             self.cutoffs,
             self.max_image_candidates,
@@ -273,19 +273,35 @@ class CellListNeighborList:
     ) -> CellListNeighborList:
         return cls.new(state, lens(lambda s: s.neighborlist_params), cutoffs)
 
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, NeighborListPoints],
+    ) -> Edges[Literal[2]]: ...
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[Literal[2]]: ...
     @jit
     def __call__(
         self,
-        lh: Table[ParticleId, NeighborListPoints],
+        keys: Table[ParticleId, NeighborListPoints],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, NeighborListPoints] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, NeighborListPoints] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
         query_size = (
-            for_indices.size
-            if for_indices is not None
-            else (rh.size if rh is not None else lh.size)
+            queried_keys.size
+            if queried_keys is not None
+            else (queries.size if queries is not None else keys.size)
         )
         cutoffs = Table.broadcast_to(self.cutoffs, systems)
         pipeline = Pipeline[Literal[2]](
@@ -298,11 +314,13 @@ class CellListNeighborList:
             masks=(
                 InBoundsMask(),
                 InclusionMatchMask(),
-                ForIndicesDedupMask(),
+                QueriedKeysDedupMask(),
                 DistanceCutoffMask(cutoffs=cutoffs),
                 ExclusionMask(),
             ),
             compactor=ReduceCompactor(avg_edges=self.avg_edges.multiply(query_size)),
             postprocessors=(MirrorPairEdges(),),
         )
-        return pipeline(lh, systems, rh=rh, for_indices=for_indices)
+        if queries is not None:
+            return pipeline(keys, systems, queries=queries)
+        return pipeline(keys, systems, queried_keys=queried_keys)

--- a/src/kups/core/neighborlist/changes.py
+++ b/src/kups/core/neighborlist/changes.py
@@ -67,13 +67,15 @@ def neighborlist_changes(
     p_idx = rh.indices.indices_in(lh.keys)
 
     # Build a single self-graph query with both old and proposed particles in
-    # the left-hand table. ``for_indices`` asks the neighbor list to enumerate
+    # the key table. ``queried_keys`` asks the neighbor list to enumerate
     # only edges incident to the old/proposed changed rows.
-    lh_combined = Table.union((lh, rh.data))
-    for_indices = Index(lh_combined.keys, jnp.concatenate([p_idx, jnp.arange(k) + N]))
+    keys_combined = Table.union((lh, rh.data))
+    queried_keys = Index(
+        keys_combined.keys, jnp.concatenate([p_idx, jnp.arange(k) + N])
+    )
 
     # single neighborlist call
-    all_edges = neighborlist(lh_combined, systems, for_indices=for_indices)
+    all_edges = neighborlist(keys_combined, systems, queried_keys=queried_keys)
 
     # split into removed / added
     raw = all_edges.indices.indices  # (n_edges, 2)

--- a/src/kups/core/neighborlist/common.py
+++ b/src/kups/core/neighborlist/common.py
@@ -8,8 +8,8 @@ Contains:
 - ``num_cells`` — per-axis spatial bin counts (used by the cell-list
   selector and by ``parameters.estimate``).
 - ``Candidates`` — private intermediate struct used inside individual
-  selector algorithms while raw ``(lhs, rhs)`` index arrays are being built.
-  Not the pipeline carrier (see
+  selector algorithms while raw ``(key_idx, query_idx)`` index arrays are being
+  built. Not the pipeline carrier (see
   [`CandidateBatch`][kups.core.neighborlist.types.CandidateBatch]).
 - ``candidate_image_counts`` — per-axis periodic-image multiplicity a cutoff
   reaches (the replication factor); used by ``_get_candidate_images`` and by
@@ -69,36 +69,21 @@ class Candidates:
     ``make_batch_with_mic``) before returning.
     """
 
-    lhs: Index[ParticleId]
-    rhs: Index[ParticleId]
-
-
-def edge_rhs_table(ctx: PipelineContext) -> Table[ParticleId, NeighborListPoints]:
-    """Return the table addressed by the second edge column."""
-    return ctx.rh if ctx.rh is not None else ctx.lh
-
-
-def query_table(ctx: PipelineContext) -> Table[ParticleId, NeighborListPoints]:
-    """Return the table used to enumerate rhs/query candidates.
-
-    ``rh`` is reserved for true bipartite calls. ``for_indices`` selects a
-    self-graph update subset from ``lh`` and is lifted back to ``lh`` index
-    space before masks and compaction see the batch.
-    """
-    if ctx.rh is not None:
-        return ctx.rh
-    if ctx.for_indices is None:
-        return ctx.lh
-    return ctx.lh.subset(Index(ctx.lh.keys, ctx.for_indices))
+    key_idx: Index[ParticleId]
+    query_idx: Index[ParticleId]
 
 
 def lift_query_candidates(candidates: Candidates, ctx: PipelineContext) -> Candidates:
-    """Convert query-local self-update candidates to ``ctx.lh`` positions."""
-    if ctx.for_indices is None:
+    """Convert query-local self-update candidates to ``ctx.keys`` positions."""
+    if ctx.queried_keys is None:
         return candidates
-    oob = ctx.lh.size
-    rhs = ctx.for_indices.at[candidates.rhs.indices].get(mode="fill", fill_value=oob)
-    return Candidates(lhs=candidates.lhs, rhs=Index(ctx.lh.keys, rhs))
+    oob = ctx.keys.size
+    query_idx = ctx.queried_keys.at[candidates.query_idx.indices].get(
+        mode="fill", fill_value=oob
+    )
+    return Candidates(
+        key_idx=candidates.key_idx, query_idx=Index(ctx.keys.keys, query_idx)
+    )
 
 
 def _generate_image_offsets(images: jax.Array, out_size: Capacity[int]) -> jax.Array:
@@ -179,7 +164,7 @@ def candidate_image_counts(cells: Cell[AnyPeriodicity], cutoffs: Array) -> Array
 
 def _get_candidate_images(
     candidates: Candidates,
-    lh: Table[ParticleId, NeighborListPoints],
+    keys: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
     cutoffs: Array,
     out_size: Capacity[int],
@@ -188,13 +173,13 @@ def _get_candidate_images(
     images = candidate_image_counts(cells, cutoffs)
     images_per_sys = jnp.prod(images, axis=-1).astype(int)
 
-    cand_sys_ids = lh.data.system.indices[candidates.lhs.indices]
+    cand_sys_ids = keys.data.system.indices[candidates.key_idx.indices]
     cand_per_sys = jnp.bincount(cand_sys_ids, length=systems.size)
     total_cand = jnp.vdot(cand_per_sys, images_per_sys)
     out_size = out_size.generate_assertion(total_cand)
-    num_cands = candidates.lhs.size
+    num_cands = candidates.key_idx.size
     if out_size.size <= num_cands:
-        offset = jnp.zeros((num_cands, 3), dtype=lh.data.positions.dtype)
+        offset = jnp.zeros((num_cands, 3), dtype=keys.data.positions.dtype)
         idx = jnp.arange(num_cands)
         return idx, offset, jnp.zeros((num_cands,), dtype=bool)
 
@@ -212,30 +197,30 @@ def _get_candidate_images(
 
 def _minimum_image_shifts(
     candidates: Candidates,
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints],
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
 ) -> Array:
     """Compute minimum-image fractional shifts for each candidate pair."""
     deltas = (
-        lh.data.positions[candidates.lhs.indices]
-        - rh.data.positions[candidates.rhs.indices]
+        keys.data.positions[candidates.key_idx.indices]
+        - queries.data.positions[candidates.query_idx.indices]
     )
     return systems.data.cell.minimum_image_shifts(deltas)
 
 
 def make_batch_with_mic(
     candidates: Candidates,
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints],
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
 ) -> CandidateBatch[Literal[2]]:
     """Pack raw candidates with minimum-image shifts; ``is_minimum_image=all-True``."""
-    min_shifts = _minimum_image_shifts(candidates, lh, rh, systems)
+    min_shifts = _minimum_image_shifts(candidates, keys, queries, systems)
     return candidates_to_batch(
         candidates,
         min_shifts,
-        jnp.ones((candidates.lhs.size,), dtype=bool),
+        jnp.ones((candidates.key_idx.size,), dtype=bool),
     )
 
 
@@ -245,22 +230,24 @@ def candidates_to_batch(
     is_minimum_image: Array,
 ) -> CandidateBatch[Literal[2]]:
     """Pack ``(candidates, flat shifts, is_min)`` into a ``CandidateBatch[2]``."""
-    indices_2d = jnp.stack([candidates.lhs.indices, candidates.rhs.indices], axis=-1)
+    indices_2d = jnp.stack(
+        [candidates.key_idx.indices, candidates.query_idx.indices], axis=-1
+    )
     edges: Edges[Literal[2]] = Edges(
-        Index(candidates.lhs.keys, indices_2d),
+        Index(candidates.key_idx.keys, indices_2d),
         jnp.expand_dims(shifts, axis=-2),
     )
     return CandidateBatch(
         edges=edges,
         is_minimum_image=is_minimum_image,
-        rhs_keys=candidates.rhs.keys,
+        query_keys=candidates.query_idx.keys,
     )
 
 
 def replicate_for_images(
     candidates: Candidates,
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints],
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
     cutoffs: Table[SystemId, Array],
     max_image_candidates: Capacity[int] | None,
@@ -275,10 +262,10 @@ def replicate_for_images(
 
     Args:
         candidates: Raw candidate pair indices.
-        lh, rh, systems: Pipeline tables (fractional coords).
+        keys, queries, systems: Pipeline tables (fractional coords).
         cutoffs: Per-system cutoff.
         max_image_candidates: Capacity for replicated-candidates buffer.
-            When ``None``, falls back to ``FixedCapacity(candidates.lhs.size)``
+            When ``None``, falls back to ``FixedCapacity(candidates.key_idx.size)``
             with an error message — pass an editable capacity if image
             replication is expected.
 
@@ -288,21 +275,21 @@ def replicate_for_images(
     cutoffs_t = Table.broadcast_to(cutoffs, systems)
     if max_image_candidates is None:
         max_image_candidates = FixedCapacity(
-            candidates.lhs.size,
+            candidates.key_idx.size,
             "Cutoff is larger than half the cell length, "
             "we need to generate additional images. "
             "Please provide a editable max_candidates.",
         )
 
     idx, image_shifts, has_been_replicated = _get_candidate_images(
-        candidates, lh, systems, cutoffs_t.data, max_image_candidates
+        candidates, keys, systems, cutoffs_t.data, max_image_candidates
     )
-    min_shifts = _minimum_image_shifts(candidates, lh, rh, systems)
+    min_shifts = _minimum_image_shifts(candidates, keys, queries, systems)
 
-    if idx.size == candidates.lhs.size:
+    if idx.size == candidates.key_idx.size:
         # No replication needed — MIC shifts cover everything.
         return candidates_to_batch(
-            candidates, min_shifts, jnp.ones((candidates.lhs.size,), dtype=bool)
+            candidates, min_shifts, jnp.ones((candidates.key_idx.size,), dtype=bool)
         )
 
     replicated = bind(candidates).at(idx).get()
@@ -314,22 +301,22 @@ def replicate_for_images(
 
 
 def real_distance_sq(
-    lhs_positions: Array,
-    rhs_positions: Array,
+    key_positions: Array,
+    query_positions: Array,
     frames: MaterializedFrame,
     shifts: Array,
 ) -> Array:
     """Squared real-space distance between already-broadcast candidate pairs.
 
     Args:
-        lhs_positions: Fractional left endpoint positions, shape ``(n, 3)``.
-        rhs_positions: Fractional right endpoint positions, shape ``(n, 3)``.
-        frames: Materialized cell frames broadcast to the candidate lhs system.
+        key_positions: Fractional left endpoint positions, shape ``(n, 3)``.
+        query_positions: Fractional right endpoint positions, shape ``(n, 3)``.
+        frames: Materialized cell frames broadcast to the candidate key system.
         shifts: ``(n, 3)`` fractional shifts.
 
     Returns:
         ``(n,)`` array of squared distances in real coordinates.
     """
-    deltas = lhs_positions - rhs_positions - shifts
+    deltas = key_positions - query_positions - shifts
     real_deltas = frames.to_real(deltas)
     return jnp.einsum("...d,...d->...", real_deltas, real_deltas)

--- a/src/kups/core/neighborlist/compact.py
+++ b/src/kups/core/neighborlist/compact.py
@@ -13,7 +13,7 @@ Compactor variants:
   and zero shifts. Used by ``RefineMaskNeighborList``.
 
 Graph-level output shaping, such as restoring undirected symmetry after
-``for_indices`` deduplication, lives in pipeline postprocessors.
+``queried_keys`` deduplication, lives in pipeline postprocessors.
 """
 
 from __future__ import annotations
@@ -23,7 +23,6 @@ from jax import Array
 
 from kups.core.capacity import Capacity
 from kups.core.data import Index
-from kups.core.neighborlist.common import edge_rhs_table
 from kups.core.neighborlist.edges import Edges
 from kups.core.neighborlist.types import CandidateBatch, Compactor, PipelineContext
 from kups.core.utils.jax import dataclass
@@ -46,7 +45,7 @@ class ReduceCompactor[D: int](Compactor[D]):
         batch: CandidateBatch[D],
         ctx: PipelineContext,
     ) -> Edges[D]:
-        oob = max(ctx.lh.size, edge_rhs_table(ctx).size)
+        oob = max(ctx.keys.size, ctx.edge_query_table.size)
         max_edges = self.avg_edges.generate_assertion(keep.sum())
         sort_idxs = jnp.where(keep, size=max_edges.size, fill_value=keep.size)[0]
         shifts = batch.edges.shifts.at[sort_idxs].get(
@@ -73,8 +72,8 @@ class MaskOnlyCompactor[D: int](Compactor[D]):
         batch: CandidateBatch[D],
         ctx: PipelineContext,
     ) -> Edges[D]:
-        oob = max(ctx.lh.size, edge_rhs_table(ctx).size)
-        indices_in = jnp.stack([batch.lh_idx.indices, batch.rh_idx.indices], axis=-1)
+        oob = max(ctx.keys.size, ctx.edge_query_table.size)
+        indices_in = batch.edges.indices.indices
         indices = where_broadcast_last(keep, indices_in, oob)
         shifts = where_broadcast_last(keep, batch.edges.shifts, 0)
         return Edges(Index(batch.edges.indices.keys, indices), shifts)

--- a/src/kups/core/neighborlist/dense.py
+++ b/src/kups/core/neighborlist/dense.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import Literal, Protocol
+from typing import Literal, Protocol, overload
 
 from jax import Array
 
@@ -14,9 +14,7 @@ from kups.core.data import Index, Table, subselect
 from kups.core.lens import Lens, lens
 from kups.core.neighborlist.common import (
     Candidates,
-    edge_rhs_table,
     lift_query_candidates,
-    query_table,
     replicate_for_images,
 )
 from kups.core.neighborlist.compact import ReduceCompactor
@@ -24,9 +22,9 @@ from kups.core.neighborlist.edges import Edges
 from kups.core.neighborlist.masks import (
     DistanceCutoffMask,
     ExclusionMask,
-    ForIndicesDedupMask,
     InBoundsMask,
     InclusionMatchMask,
+    QueriedKeysDedupMask,
 )
 from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.postprocess import MirrorPairEdges
@@ -53,20 +51,20 @@ class IsDenseNeighborlistParams(Protocol):
 
 
 def _dense_subselect(
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints],
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
     max_num_candidates: Capacity[int],
 ) -> Candidates:
     selection_result = subselect(
-        lh.data.system.indices,
-        rh.data.system.indices,
+        keys.data.system.indices,
+        queries.data.system.indices,
         output_buffer_size=max_num_candidates,
         num_segments=systems.size,
     )
     return Candidates(
-        lhs=Index(lh.keys, selection_result.scatter_idxs),
-        rhs=Index(rh.keys, selection_result.gather_idxs),
+        key_idx=Index(keys.keys, selection_result.scatter_idxs),
+        query_idx=Index(queries.keys, selection_result.gather_idxs),
     )
 
 
@@ -79,15 +77,15 @@ class DenseSelector:
     max_image_candidates: Capacity[int]
 
     def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
-        query = query_table(ctx)
+        query = ctx.query_table
         candidates = _dense_subselect(
-            ctx.lh, query, ctx.systems, max_num_candidates=self.max_candidates
+            ctx.keys, query, ctx.systems, max_num_candidates=self.max_candidates
         )
         candidates = lift_query_candidates(candidates, ctx)
         return replicate_for_images(
             candidates,
-            ctx.lh,
-            edge_rhs_table(ctx),
+            ctx.keys,
+            ctx.edge_query_table,
             ctx.systems,
             self.cutoffs,
             self.max_image_candidates,
@@ -160,18 +158,34 @@ class DenseNearestNeighborList:
     ) -> DenseNearestNeighborList:
         return cls.new(state, lens(lambda s: s.neighborlist_params), cutoffs)
 
+    @overload
     def __call__(
         self,
-        lh: Table[ParticleId, NeighborListPoints],
+        keys: Table[ParticleId, NeighborListPoints],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, NeighborListPoints] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, NeighborListPoints],
+    ) -> Edges[Literal[2]]: ...
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[Literal[2]]: ...
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, NeighborListPoints] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
         query_size = (
-            for_indices.size
-            if for_indices is not None
-            else (rh.size if rh is not None else lh.size)
+            queried_keys.size
+            if queried_keys is not None
+            else (queries.size if queries is not None else keys.size)
         )
         cutoffs = Table.broadcast_to(self.cutoffs, systems)
         pipeline = Pipeline[Literal[2]](
@@ -183,11 +197,13 @@ class DenseNearestNeighborList:
             masks=(
                 InBoundsMask(),
                 InclusionMatchMask(),
-                ForIndicesDedupMask(),
+                QueriedKeysDedupMask(),
                 DistanceCutoffMask(cutoffs=cutoffs),
                 ExclusionMask(),
             ),
             compactor=ReduceCompactor(avg_edges=self.avg_edges.multiply(query_size)),
             postprocessors=(MirrorPairEdges(),),
         )
-        return pipeline(lh, systems, rh=rh, for_indices=for_indices)
+        if queries is not None:
+            return pipeline(keys, systems, queries=queries)
+        return pipeline(keys, systems, queried_keys=queried_keys)

--- a/src/kups/core/neighborlist/fixed.py
+++ b/src/kups/core/neighborlist/fixed.py
@@ -9,11 +9,12 @@ interactions, optionally filtered to a patch-affected subset. They satisfy the
 standard :class:`NeighborList[D]` protocol so a unified graph constructor can
 ask any neighbor list for edges, regardless of how those edges were obtained.
 
-The public call contract treats ``lh`` as the self-graph/output table. ``rh``
-is keyword-only and reserved for true bipartite neighbor-list queries; fixed
-topology is a self-graph implementation and does not use ``rh``. ``for_indices``
-is keyword-only, mutually exclusive with ``rh``, and names affected ``lh`` ids
-after the caller has already written updated particle data into ``lh``.
+The public call contract treats ``keys`` as the self-graph/output table.
+``queries`` is keyword-only and reserved for true bipartite neighbor-list
+queries; fixed topology is a self-graph implementation and does not use
+``queries``. ``queried_keys`` is keyword-only, mutually exclusive with
+``queries``, and names affected ``keys`` ids after the caller has already
+written updated particle data into ``keys``.
 ``FixedEdgesNeighborList`` returns only fixed topology rows touched by those
 ids. Its implementation is a normal selector -> mask -> compactor pipeline over
 the fixed edge rows; shifts are computed from the current particle positions
@@ -22,13 +23,15 @@ during selection.
 
 from __future__ import annotations
 
+from typing import overload
+
 import jax.numpy as jnp
 
 from kups.core.capacity import Capacity, FixedCapacity
 from kups.core.data import Index, Table
 from kups.core.neighborlist.compact import ReduceCompactor
 from kups.core.neighborlist.edges import Edges
-from kups.core.neighborlist.masks import TouchesForIndicesMask
+from kups.core.neighborlist.masks import TouchesQueriedKeysMask
 from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.types import (
     CandidateBatch,
@@ -47,12 +50,12 @@ class _FixedEdgesSelector[D: int]:
     indices: Index[ParticleId]
 
     def __call__(self, ctx: PipelineContext) -> CandidateBatch[D]:
-        indices = self.indices.update_labels(ctx.lh.keys).indices
-        positions = ctx.lh.data.positions.at[indices].get(mode="fill", fill_value=0)
+        indices = self.indices.update_labels(ctx.keys.keys).indices
+        positions = ctx.keys.data.positions.at[indices].get(mode="fill", fill_value=0)
         deltas = positions[:, :1] - positions[:, 1:]
         shifts = ctx.systems.data.cell.minimum_image_shifts(deltas)
         return CandidateBatch(
-            edges=Edges(Index(ctx.lh.keys, indices), shifts),
+            edges=Edges(Index(ctx.keys.keys, indices), shifts),
             is_minimum_image=jnp.ones((len(self.indices),), dtype=bool),
         )
 
@@ -71,22 +74,40 @@ class EmptyNeighborList[D: int]:
 
     degree: int = field(static=True, default=0)
 
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, NeighborListPoints],
+    ) -> Edges[D]: ...
+
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[D]: ...
+
     @jit
     def __call__(
         self,
-        lh: Table[ParticleId, NeighborListPoints],
+        keys: Table[ParticleId, NeighborListPoints],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, NeighborListPoints] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, NeighborListPoints] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[D]:
-        assert rh is None or for_indices is None, (
-            "Neighbor-list calls cannot combine rh with for_indices."
+        assert queries is None or queried_keys is None, (
+            "Neighbor-list calls cannot combine queries with queried_keys."
         )
-        del rh, systems, for_indices
+        del queries, systems, queried_keys
         shift_inner = self.degree - 1 if self.degree > 1 else 0
         return Edges(
-            indices=Index(lh.keys, jnp.zeros((0, self.degree), dtype=int)),
+            indices=Index(keys.keys, jnp.zeros((0, self.degree), dtype=int)),
             shifts=jnp.zeros((0, shift_inner, 3), dtype=int),
         )
 
@@ -97,16 +118,16 @@ class FixedEdgesNeighborList[D: int]:
 
     Full self-graph calls return all fixed topology rows with shifts computed
     from the current particle positions. Affected self-graph calls pass
-    keyword-only ``for_indices`` after updated particle data has been written
-    into ``lh``; the neighbor list returns only fixed rows touched by those
-    affected ``lh`` ids. ``rh`` is reserved for true bipartite neighbor-list
-    implementations and is not a fixed-edge update mechanism.
+    keyword-only ``queried_keys`` after updated particle data has been written
+    into ``keys``; the neighbor list returns only fixed rows touched by those
+    affected ``keys`` ids. ``queries`` is reserved for true bipartite
+    neighbor-list implementations and is not a fixed-edge update mechanism.
 
     Attributes:
         indices: Fixed edge topology. Shifts are intentionally not stored;
             they are computed from the call's current particle positions.
         avg_edges: Update-only average affected-edge capacity per affected
-            ``lh`` id. Full calls ignore this field and use the stored
+            ``keys`` id. Full calls ignore this field and use the stored
             topology length; affected calls default to the full edge-buffer
             size when it is not provided.
     """
@@ -114,31 +135,49 @@ class FixedEdgesNeighborList[D: int]:
     indices: Index[ParticleId]
     avg_edges: Capacity[int] | None = None
 
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, NeighborListPoints],
+    ) -> Edges[D]: ...
+
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[D]: ...
+
     @jit
     def __call__(
         self,
-        lh: Table[ParticleId, NeighborListPoints],
+        keys: Table[ParticleId, NeighborListPoints],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, NeighborListPoints] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, NeighborListPoints] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[D]:
-        assert rh is None or for_indices is None, (
-            "Neighbor-list calls cannot combine rh with for_indices."
+        assert queries is None or queried_keys is None, (
+            "Neighbor-list calls cannot combine queries with queried_keys."
         )
-        assert rh is None, "FixedEdgesNeighborList only supports self-graph calls."
-        if for_indices is None:
+        assert queries is None, "FixedEdgesNeighborList only supports self-graph calls."
+        if queried_keys is None:
             max_edges = FixedCapacity(len(self.indices))
         else:
             max_edges = (
-                self.avg_edges.multiply(for_indices.size)
+                self.avg_edges.multiply(queried_keys.size)
                 if self.avg_edges is not None
                 else FixedCapacity(len(self.indices))
             )
 
         pipeline = Pipeline[D](
             selector=_FixedEdgesSelector(self.indices),
-            masks=(TouchesForIndicesMask(),),
+            masks=(TouchesQueriedKeysMask(),),
             compactor=ReduceCompactor(max_edges),
         )
-        return pipeline(lh, systems, for_indices=for_indices)
+        return pipeline(keys, systems, queried_keys=queried_keys)

--- a/src/kups/core/neighborlist/masks.py
+++ b/src/kups/core/neighborlist/masks.py
@@ -28,50 +28,52 @@ from kups.core.utils.jax import dataclass, isin
 
 @dataclass
 class InBoundsMask:
-    """Drops candidates whose lh/rh indices fall outside the valid inclusion-segment range.
+    """Drops candidates whose key/query indices fall outside the valid inclusion-segment range.
 
     Implements the per-side ``inclusion.indices < num_labels`` check used to
     guard scatter/gather lookups when the candidate buffer is padded.
     """
 
     def __call__[D: int](self, batch: CandidateBatch[D], ctx: PipelineContext) -> Array:
-        ngraphs = ctx.lh.data.inclusion.num_labels
-        lh_inclusions = ctx.lh.map_data(lambda d: d.inclusion.indices < ngraphs)
-        if ctx.rh is None:
-            idx = batch.edges.indices.indices_in(lh_inclusions.keys)
-            edge_in = lh_inclusions.data.at[idx].get(mode="fill", fill_value=False)
+        ngraphs = ctx.keys.data.inclusion.num_labels
+        key_inclusions = ctx.keys.map_data(lambda d: d.inclusion.indices < ngraphs)
+        if ctx.queries is None:
+            idx = batch.edges.indices.indices_in(key_inclusions.keys)
+            edge_in = key_inclusions.data.at[idx].get(mode="fill", fill_value=False)
             return edge_in.all(axis=-1)
 
-        rh_inclusions = ctx.rh.map_data(lambda d: d.inclusion.indices < ngraphs)
-        lh_idx = batch.lh_idx.indices_in(lh_inclusions.keys)
-        rh_idx = batch.rh_idx.indices_in(rh_inclusions.keys)
-        lh_in = lh_inclusions.data.at[lh_idx].get(mode="fill", fill_value=False)
-        rh_in = rh_inclusions.data.at[rh_idx].get(mode="fill", fill_value=False)
-        return lh_in & rh_in
+        query_inclusions = ctx.queries.map_data(lambda d: d.inclusion.indices < ngraphs)
+        key_idx = batch.key_idx.indices_in(key_inclusions.keys)
+        query_idx = batch.query_idx.indices_in(query_inclusions.keys)
+        key_in = key_inclusions.data.at[key_idx].get(mode="fill", fill_value=False)
+        query_in = query_inclusions.data.at[query_idx].get(
+            mode="fill", fill_value=False
+        )
+        return key_in & query_in
 
 
 @dataclass
 class InclusionMatchMask:
-    """Drops candidates whose lh/rh inclusion segments differ."""
+    """Drops candidates whose key/query inclusion segments differ."""
 
     def __call__[D: int](self, batch: CandidateBatch[D], ctx: PipelineContext) -> Array:
-        if ctx.rh is None:
-            edge_incl = ctx.lh[batch.edges.indices].inclusion.indices
+        if ctx.queries is None:
+            edge_incl = ctx.keys[batch.edges.indices].inclusion.indices
             return (edge_incl == edge_incl[:, :1]).all(axis=-1)
 
-        lh_incl, rh_incl = Index.match(
-            ctx.lh[batch.lh_idx].inclusion, ctx.rh[batch.rh_idx].inclusion
+        key_incl, query_incl = Index.match(
+            ctx.keys[batch.key_idx].inclusion, ctx.queries[batch.query_idx].inclusion
         )
-        return lh_incl == rh_incl
+        return key_incl == query_incl
 
 
 @dataclass
-class ForIndicesDedupMask:
+class QueriedKeysDedupMask:
     """Deduplicate self-graph update candidates.
 
-    Pair selectors emit candidates in ``lh`` space. When ``ctx.for_indices``
-    is set, the rhs query side was restricted to those affected ``lh`` rows.
-    We keep edges whose lhs endpoint is unaffected, plus one orientation for
+    Pair selectors emit candidates in ``keys`` space. When ``ctx.queried_keys``
+    is set, the query side was restricted to those affected ``keys`` rows.
+    We keep edges whose key endpoint is unaffected, plus one orientation for
     edges where both endpoints are affected. ``MirrorPairEdges`` restores the
     reverse orientation after compaction.
 
@@ -81,25 +83,27 @@ class ForIndicesDedupMask:
     def __call__(
         self, batch: CandidateBatch[Literal[2]], ctx: PipelineContext
     ) -> Array:
-        if ctx.for_indices is None:
-            return jnp.ones((batch.lh_idx.size,), dtype=bool)
-        return ~isin(batch.lh_idx.indices, ctx.for_indices, ctx.lh.size) | (
-            batch.lh_idx.indices >= batch.rh_idx.indices
+        if ctx.queried_keys is None:
+            return jnp.ones((batch.key_idx.size,), dtype=bool)
+        return ~isin(batch.key_idx.indices, ctx.queried_keys, ctx.keys.size) | (
+            batch.key_idx.indices >= batch.query_idx.indices
         )
 
 
 @dataclass
-class TouchesForIndicesMask[D: int]:
-    """Keep fixed-topology rows touched by ``ctx.for_indices``.
+class TouchesQueriedKeysMask[D: int]:
+    """Keep fixed-topology rows touched by ``ctx.queried_keys``.
 
     When no affected-index subset is active, every row is kept. This lets fixed
     topology use the same pipeline for full and patch-shaped calls.
     """
 
     def __call__(self, batch: CandidateBatch[D], ctx: PipelineContext) -> Array:
-        if ctx.for_indices is None:
+        if ctx.queried_keys is None:
             return jnp.ones((len(batch.edges),), dtype=bool)
-        return isin(batch.edges.indices.indices, ctx.for_indices, ctx.lh.size).any(-1)
+        return isin(batch.edges.indices.indices, ctx.queried_keys, ctx.keys.size).any(
+            -1
+        )
 
 
 @dataclass
@@ -116,17 +120,17 @@ class DistanceCutoffMask:
         frame_table: Table[SystemId, MaterializedFrame] = ctx.systems.map_data(
             lambda s: s.cell.frame.materialize()
         )
-        lh_system = ctx.lh[batch.lh_idx].system
-        frames: MaterializedFrame = frame_table[lh_system]
-        if ctx.rh is None:
-            pair_positions = ctx.lh[batch.edges.indices].positions
-            lhs_positions = pair_positions[:, 0]
-            rhs_positions = pair_positions[:, 1]
+        key_system = ctx.keys[batch.key_idx].system
+        frames: MaterializedFrame = frame_table[key_system]
+        if ctx.queries is None:
+            pair_positions = ctx.keys[batch.edges.indices].positions
+            key_positions = pair_positions[:, 0]
+            query_positions = pair_positions[:, 1]
         else:
-            lhs_positions = ctx.lh[batch.lh_idx].positions
-            rhs_positions = ctx.rh[batch.rh_idx].positions
-        dist_sq = real_distance_sq(lhs_positions, rhs_positions, frames, shifts)
-        return dist_sq < cutoffs[lh_system] ** 2
+            key_positions = ctx.keys[batch.key_idx].positions
+            query_positions = ctx.queries[batch.query_idx].positions
+        dist_sq = real_distance_sq(key_positions, query_positions, frames, shifts)
+        return dist_sq < cutoffs[key_system] ** 2
 
 
 @dataclass
@@ -140,11 +144,11 @@ class ExclusionMask:
     def __call__(
         self, batch: CandidateBatch[Literal[2]], ctx: PipelineContext
     ) -> Array:
-        if ctx.rh is None:
-            edge_excl = ctx.lh[batch.edges.indices].exclusion.indices
+        if ctx.queries is None:
+            edge_excl = ctx.keys[batch.edges.indices].exclusion.indices
             return (edge_excl[:, 0] != edge_excl[:, 1]) | ~batch.is_minimum_image
 
-        lh_excl, rh_excl = Index.match(
-            ctx.lh[batch.lh_idx].exclusion, ctx.rh[batch.rh_idx].exclusion
+        key_excl, query_excl = Index.match(
+            ctx.keys[batch.key_idx].exclusion, ctx.queries[batch.query_idx].exclusion
         )
-        return (lh_excl != rh_excl) | ~batch.is_minimum_image
+        return (key_excl != query_excl) | ~batch.is_minimum_image

--- a/src/kups/core/neighborlist/pipeline.py
+++ b/src/kups/core/neighborlist/pipeline.py
@@ -11,6 +11,8 @@ a ``Pipeline`` internally inside their ``__call__``.
 
 from __future__ import annotations
 
+from typing import overload
+
 import jax.numpy as jnp
 from jax import Array
 
@@ -47,15 +49,31 @@ class Pipeline[D: int]:
     compactor: Compactor[D]
     postprocessors: tuple[Postprocessor[D], ...] = field(default=(), static=True)
 
+    @overload
     def __call__(
         self,
-        lh: Table[ParticleId, NeighborListPoints],
+        keys: Table[ParticleId, NeighborListPoints],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, NeighborListPoints] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, NeighborListPoints],
+    ) -> Edges[D]: ...
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[D]: ...
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, NeighborListPoints] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[D]:
-        ctx = _prepare(lh, rh, systems, for_indices)
+        ctx = _prepare(keys, queries, systems, queried_keys)
         batch = self.selector(ctx)
         keep = jnp.ones((len(batch.edges),), dtype=bool)
         for mask in self.masks:
@@ -67,30 +85,32 @@ class Pipeline[D: int]:
 
 
 def _prepare(
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints] | None,
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints] | None,
     systems: Table[SystemId, NeighborListSystems],
-    for_indices: Index[ParticleId] | None,
+    queried_keys: Index[ParticleId] | None,
 ) -> PipelineContext:
-    """Transform positions to fractional coords and resolve ``for_indices``."""
-    assert rh is None or for_indices is None, (
-        "Neighbor-list calls cannot combine rh with for_indices. "
-        "Use for_indices for self-graph updates, or rh for bipartite queries."
+    """Transform positions to fractional coords and resolve ``queried_keys``."""
+    assert queries is None or queried_keys is None, (
+        "Neighbor-list calls cannot combine queries with queried_keys. "
+        "Use queried_keys for self-graph updates, or queries for bipartite queries."
     )
     frames = systems.map_data(lambda s: s.cell.frame.materialize())
-    lh_frame = frames[lh.data.system]
-    lh = bind(lh, lambda x: x.data.positions).apply(lh_frame.to_fractional)
-    if rh is not None:
-        rh_frame = frames[rh.data.system]
-        rh = bind(rh, lambda x: x.data.positions).apply(rh_frame.to_fractional)
+    keys_frame = frames[keys.data.system]
+    keys = bind(keys, lambda x: x.data.positions).apply(keys_frame.to_fractional)
+    if queries is not None:
+        queries_frame = frames[queries.data.system]
+        queries = bind(queries, lambda x: x.data.positions).apply(
+            queries_frame.to_fractional
+        )
 
-    for_indices_raw: Array | None = (
-        for_indices.indices_in(lh.keys) if for_indices is not None else None
+    queried_keys_raw: Array | None = (
+        queried_keys.indices_in(keys.keys) if queried_keys is not None else None
     )
 
     return PipelineContext(
-        lh=lh,
-        rh=rh,
+        keys=keys,
+        queries=queries,
         systems=systems,
-        for_indices=for_indices_raw,
+        queried_keys=queried_keys_raw,
     )

--- a/src/kups/core/neighborlist/postprocess.py
+++ b/src/kups/core/neighborlist/postprocess.py
@@ -26,24 +26,24 @@ class MirrorPairEdges(Postprocessor[Literal[2]]):
     """Append reversed pair edges for undirected graph outputs.
 
     The default mirrors only self-graph update calls selected by
-    ``ctx.for_indices``. Full self-neighbor calls already emit both directions
-    before compaction, while ``for_indices`` calls operate on affected ids in
-    the already-updated ``lh`` table and are deduplicated by
-    ``ForIndicesDedupMask``. Their reverse edges are restored after compaction.
+    ``ctx.queried_keys``. Full self-neighbor calls already emit both directions
+    before compaction, while ``queried_keys`` calls operate on affected ids in
+    the already-updated ``keys`` table and are deduplicated by
+    ``QueriedKeysDedupMask``. Their reverse edges are restored after compaction.
 
     Attributes:
-        only_when_for_indices: When ``True``, no-op unless ``ctx.for_indices``
-            is active; ``ctx.rh`` is not involved. Set to ``False`` for
+        only_when_queried_keys: When ``True``, no-op unless ``ctx.queried_keys``
+            is active; ``ctx.queries`` is not involved. Set to ``False`` for
             pipelines whose selector emits only one direction even in full
             calls.
     """
 
-    only_when_for_indices: bool = field(default=True, static=True)
+    only_when_queried_keys: bool = field(default=True, static=True)
 
     def __call__(
         self, edges: Edges[Literal[2]], ctx: PipelineContext
     ) -> Edges[Literal[2]]:
-        if self.only_when_for_indices and ctx.for_indices is None:
+        if self.only_when_queried_keys and ctx.queried_keys is None:
             return edges
 
         indices = edges.indices.indices

--- a/src/kups/core/neighborlist/refine.py
+++ b/src/kups/core/neighborlist/refine.py
@@ -12,7 +12,7 @@ or tighter cutoffs
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, overload
 
 import jax.numpy as jnp
 from jax import Array
@@ -21,7 +21,6 @@ from kups.core.capacity import Capacity
 from kups.core.data import Index, Table
 from kups.core.neighborlist.common import (
     Candidates,
-    edge_rhs_table,
     make_batch_with_mic,
 )
 from kups.core.neighborlist.compact import MaskOnlyCompactor, ReduceCompactor
@@ -31,7 +30,7 @@ from kups.core.neighborlist.masks import (
     ExclusionMask,
     InBoundsMask,
     InclusionMatchMask,
-    TouchesForIndicesMask,
+    TouchesQueriedKeysMask,
 )
 from kups.core.neighborlist.pipeline import Pipeline
 from kups.core.neighborlist.types import (
@@ -48,12 +47,12 @@ from kups.core.utils.jax import dataclass, field, jit
 class PrecomputedEdgesSelector:
     """Selector that wraps precomputed ``Edges`` for both refine variants.
 
-    Precomputed self-graph edges are already in ``lh`` space. A disjoint
-    bipartite ``rh`` call may still use rhs positions for the second column,
-    matching the edge convention of the original candidate set.
+    Precomputed self-graph edges are already in ``keys`` space. A disjoint
+    bipartite ``queries`` call may still use query positions for the second
+    column, matching the edge convention of the original candidate set.
 
     Attributes:
-        candidates: Precomputed edges (indices in lh-space).
+        candidates: Precomputed edges (indices in keys-space).
         recompute_mic_shifts: When ``True``, drop the precomputed shifts and
             recompute minimum-image shifts on the current positions
             (``RefineCutoffNeighborList`` — the precomputed shifts may be
@@ -68,34 +67,34 @@ class PrecomputedEdgesSelector:
     def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
         if self.recompute_mic_shifts:
             indices = self.candidates.indices.indices
-            rhs = edge_rhs_table(ctx)
+            query = ctx.edge_query_table
             raw_candidates = Candidates(
-                lhs=Index(ctx.lh.keys, indices[:, 0]),
-                rhs=Index(rhs.keys, indices[:, 1]),
+                key_idx=Index(ctx.keys.keys, indices[:, 0]),
+                query_idx=Index(query.keys, indices[:, 1]),
             )
-            return make_batch_with_mic(raw_candidates, ctx.lh, rhs, ctx.systems)
+            return make_batch_with_mic(raw_candidates, ctx.keys, query, ctx.systems)
         indices = self.candidates.indices.indices
-        edges = Edges(Index(ctx.lh.keys, indices), self.candidates.shifts)
+        edges = Edges(Index(ctx.keys.keys, indices), self.candidates.shifts)
         return CandidateBatch(
             edges=edges,
             is_minimum_image=jnp.ones((len(self.candidates),), dtype=bool),
-            rhs_keys=edge_rhs_table(ctx).keys,
+            query_keys=ctx.edge_query_table.keys,
         )
 
 
 def _resolve_precomputed_inputs(
-    lh: Table[ParticleId, NeighborListPoints],
-    rh: Table[ParticleId, NeighborListPoints] | None,
-    for_indices: Index[ParticleId] | None,
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints] | None,
+    queried_keys: Index[ParticleId] | None,
 ) -> tuple[
     Table[ParticleId, NeighborListPoints],
     Table[ParticleId, NeighborListPoints] | None,
 ]:
     """Return the tables that precomputed refine candidates address."""
-    assert rh is None or for_indices is None, (
-        "Refine neighbor lists cannot combine rh with for_indices."
+    assert queries is None or queried_keys is None, (
+        "Refine neighbor lists cannot combine queries with queried_keys."
     )
-    return lh, rh
+    return keys, queries
 
 
 @dataclass
@@ -136,27 +135,49 @@ class RefineMaskNeighborList:
 
     candidates: Edges[Literal[2]]
 
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, NeighborListPoints],
+    ) -> Edges[Literal[2]]: ...
+
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[Literal[2]]: ...
+
     @jit
     def __call__(
         self,
-        lh: Table[ParticleId, NeighborListPoints],
+        keys: Table[ParticleId, NeighborListPoints],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, NeighborListPoints] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, NeighborListPoints] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
-        resolved_lh, resolved_rh = _resolve_precomputed_inputs(lh, rh, for_indices)
+        resolved_keys, resolved_queries = _resolve_precomputed_inputs(
+            keys, queries, queried_keys
+        )
         pipeline = Pipeline[Literal[2]](
             selector=PrecomputedEdgesSelector(self.candidates),
             masks=(
                 InBoundsMask(),
                 InclusionMatchMask(),
-                TouchesForIndicesMask(),
+                TouchesQueriedKeysMask(),
                 ExclusionMask(),
             ),
             compactor=MaskOnlyCompactor(),
         )
-        return pipeline(resolved_lh, systems, rh=resolved_rh, for_indices=for_indices)
+        if resolved_queries is not None:
+            return pipeline(resolved_keys, systems, queries=resolved_queries)
+        return pipeline(resolved_keys, systems, queried_keys=queried_keys)
 
 
 @dataclass
@@ -206,20 +227,40 @@ class RefineCutoffNeighborList:
     avg_edges: Capacity[int]
     cutoffs: Table[SystemId, Array]
 
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, NeighborListPoints],
+    ) -> Edges[Literal[2]]: ...
+
+    @overload
+    def __call__(
+        self,
+        keys: Table[ParticleId, NeighborListPoints],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[Literal[2]]: ...
+
     @jit
     def __call__(
         self,
-        lh: Table[ParticleId, NeighborListPoints],
+        keys: Table[ParticleId, NeighborListPoints],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, NeighborListPoints] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, NeighborListPoints] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[Literal[2]]:
-        resolved_lh, resolved_rh = _resolve_precomputed_inputs(lh, rh, for_indices)
+        resolved_keys, resolved_queries = _resolve_precomputed_inputs(
+            keys, queries, queried_keys
+        )
         query_size = (
-            for_indices.size
-            if for_indices is not None
-            else (rh.size if rh is not None else lh.size)
+            queried_keys.size
+            if queried_keys is not None
+            else (queries.size if queries is not None else keys.size)
         )
         cutoffs = Table.broadcast_to(self.cutoffs, systems)
         pipeline = Pipeline[Literal[2]](
@@ -230,9 +271,11 @@ class RefineCutoffNeighborList:
                 InBoundsMask(),
                 InclusionMatchMask(),
                 DistanceCutoffMask(cutoffs=cutoffs),
-                TouchesForIndicesMask(),
+                TouchesQueriedKeysMask(),
                 ExclusionMask(),
             ),
             compactor=ReduceCompactor(avg_edges=self.avg_edges.multiply(query_size)),
         )
-        return pipeline(resolved_lh, systems, rh=resolved_rh, for_indices=for_indices)
+        if resolved_queries is not None:
+            return pipeline(resolved_keys, systems, queries=resolved_queries)
+        return pipeline(resolved_keys, systems, queried_keys=queried_keys)

--- a/src/kups/core/neighborlist/types.py
+++ b/src/kups/core/neighborlist/types.py
@@ -21,7 +21,7 @@ protocol used by the ``from_state`` constructors.
 
 from __future__ import annotations
 
-from typing import Literal, Protocol
+from typing import Literal, Protocol, overload
 
 from jax import Array
 
@@ -60,28 +60,48 @@ class NeighborList[D: int](Protocol):
     parameter tracks the arity of the emitted edge tuples.
     """
 
+    @overload
     def __call__[P: NeighborListPoints](
         self,
-        lh: Table[ParticleId, P],
+        keys: Table[ParticleId, P],
         systems: Table[SystemId, NeighborListSystems],
         *,
-        rh: Table[ParticleId, P] | None = None,
-        for_indices: Index[ParticleId] | None = None,
+        queries: Table[ParticleId, P],
+    ) -> Edges[D]: ...
+    @overload
+    def __call__[P: NeighborListPoints](
+        self,
+        keys: Table[ParticleId, P],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queried_keys: Index[ParticleId] | None = None,
+    ) -> Edges[D]: ...
+    def __call__[P: NeighborListPoints](
+        self,
+        keys: Table[ParticleId, P],
+        systems: Table[SystemId, NeighborListSystems],
+        *,
+        queries: Table[ParticleId, P] | None = None,
+        queried_keys: Index[ParticleId] | None = None,
     ) -> Edges[D]:
         """Find particle groups for a self-graph or bipartite query.
 
+        ``queries`` and ``queried_keys`` are mutually exclusive; the overloads
+        above reject calls that pass both.
+
         Args:
-            lh: Particle table that returned ``Edges`` index into.
-            rh: Optional bipartite query table. Mutually exclusive with
-                ``for_indices``. When omitted, the neighbor list builds a
-                self-graph over ``lh``.
+            keys: Particle table that the returned ``Edges`` index into. With
+                neither ``queries`` nor ``queried_keys``, the neighbor list
+                builds a self-graph over ``keys``.
             systems: Indexed system data with cell information.
-            for_indices: Optional subset of ``lh`` particle ids whose incident
-                self-graph edges should be returned. The caller must already
-                have written any updated particle data into ``lh``.
+            queries: Optional bipartite query table. Each edge then connects a
+                ``keys`` particle to a ``queries`` particle.
+            queried_keys: Optional subset of ``keys`` particle ids whose
+                incident self-graph edges should be returned. The caller must
+                already have written any updated particle data into ``keys``.
 
         Returns:
-            Edges whose columns index ``lh`` for self-graph calls.
+            Edges whose columns index ``keys`` for self-graph calls.
         """
         ...
 
@@ -103,24 +123,24 @@ class CandidateBatch[D: int]:
         is_minimum_image: ``(n,)`` bool — True where the candidate's shift
             equals the minimum-image shift; False for non-MIC replicated
             copies emitted by selectors that handle PBC image expansion.
-        rhs_keys: Pair-specific key vocabulary for the second edge column.
+        query_keys: Pair-specific key vocabulary for the second edge column.
             ``None`` means it uses ``edges.indices.keys``.
     """
 
     edges: Edges[D]
     is_minimum_image: Array
-    rhs_keys: tuple[ParticleId, ...] | None = field(default=None, static=True)
+    query_keys: tuple[ParticleId, ...] | None = field(default=None, static=True)
 
     @property
-    def lh_idx(self) -> Index[ParticleId]:
-        """Pair-specific: lh-side index of shape ``(n,)``. Only meaningful for ``D == 2``."""
+    def key_idx(self) -> Index[ParticleId]:
+        """Pair-specific: key-side index of shape ``(n,)``. Only meaningful for ``D == 2``."""
         return self.edges.indices[:, 0]
 
     @property
-    def rh_idx(self) -> Index[ParticleId]:
-        """Pair-specific: rh-side index of shape ``(n,)``. Only meaningful for ``D == 2``."""
+    def query_idx(self) -> Index[ParticleId]:
+        """Pair-specific: query-side index of shape ``(n,)``. Only meaningful for ``D == 2``."""
         return Index(
-            self.rhs_keys or self.edges.indices.keys,
+            self.query_keys or self.edges.indices.keys,
             self.edges.indices.indices[:, 1],
         )
 
@@ -129,30 +149,51 @@ class CandidateBatch[D: int]:
 class PipelineContext:
     """Read-only inputs shared by every mask and the compactor.
 
-    Positions in ``lh`` and optional ``rh`` are in **fractional** coordinates
-    (transformed by [`_prepare`][kups.core.neighborlist.pipeline._prepare]).
-    There is no ``out_of_bounds`` field — masks/compactors that need an
-    OOB sentinel resolve the rhs table first.
+    Positions in ``keys`` and optional ``queries`` are in **fractional**
+    coordinates (transformed by
+    [`_prepare`][kups.core.neighborlist.pipeline._prepare]). There is no
+    ``out_of_bounds`` field — masks/compactors that need an OOB sentinel resolve
+    the query table first.
 
     Attributes:
-        lh: Left-hand particle table in fractional coords.
-        rh: Right-hand particle table in fractional coords for true bipartite
-            queries. ``None`` for full self-graphs and ``for_indices`` updates.
+        keys: Key particle table in fractional coords (the table the returned
+            ``Edges`` index into).
+        queries: Query particle table in fractional coords for true bipartite
+            queries. ``None`` for full self-graphs and ``queried_keys`` updates.
         systems: Indexed system data with cell information.
-        for_indices: Raw ``lh`` positions to update/query, or ``None`` for a
+        queried_keys: Raw ``keys`` positions to update/query, or ``None`` for a
             full self-graph or bipartite query.
     """
 
-    lh: Table[ParticleId, NeighborListPoints]
-    rh: Table[ParticleId, NeighborListPoints] | None
+    keys: Table[ParticleId, NeighborListPoints]
+    queries: Table[ParticleId, NeighborListPoints] | None
     systems: Table[SystemId, NeighborListSystems]
-    for_indices: Array | None
+    queried_keys: Array | None
 
     @skip_post_init_if_disabled
     def __post_init__(self) -> None:
-        assert self.rh is None or self.for_indices is None, (
-            "PipelineContext cannot combine rh with for_indices."
+        assert self.queries is None or self.queried_keys is None, (
+            "PipelineContext cannot combine queries with queried_keys."
         )
+
+    @property
+    def edge_query_table(self) -> Table[ParticleId, NeighborListPoints]:
+        """Table addressed by the second edge column."""
+        return self.queries if self.queries is not None else self.keys
+
+    @property
+    def query_table(self) -> Table[ParticleId, NeighborListPoints]:
+        """Table used to enumerate query candidates.
+
+        ``queries`` is reserved for true bipartite calls. ``queried_keys``
+        selects a self-graph update subset from ``keys`` and is lifted back to
+        ``keys`` index space before masks and compaction see the batch.
+        """
+        if self.queries is not None:
+            return self.queries
+        if self.queried_keys is None:
+            return self.keys
+        return self.keys.subset(Index(self.keys.keys, self.queried_keys))
 
 
 class CandidateSelector[D: int](Protocol):

--- a/src/kups/potential/classical/blocking.py
+++ b/src/kups/potential/classical/blocking.py
@@ -299,7 +299,7 @@ class BlockingSpheresSumComposer[State, Ptch: Patch[Any]](
         )
 
         neighborlist = probe_neighborlist or neighborlist_factory(cutoffs)
-        edges = neighborlist(nnlist_particles, systems, rh=spheres)
+        edges = neighborlist(nnlist_particles, systems, queries=spheres)
         cell = systems.map_data(lambda s: s.cell)
         groups = self.groups_view(state)
         return Sum(

--- a/src/kups/potential/common/graph.py
+++ b/src/kups/potential/common/graph.py
@@ -244,7 +244,7 @@ class GraphConstructor[
     def __call__(
         self, state: State, patch: Ptch | None, old_graph: bool = False
     ) -> HyperGraph[P, S, Degree]:
-        lh = self.particles(state)
+        keys = self.particles(state)
         systems = self.systems(state)
 
         if patch is not None and self.probe is None:
@@ -257,19 +257,19 @@ class GraphConstructor[
 
         if patch is None:
             nnlist = self.neighborlist(state)
-            edges = nnlist(lh, systems)
+            edges = nnlist(keys, systems)
         else:
             assert self.probe is not None, "Expected probe to be set."
             probe = self.probe(state, patch)
             update = probe.particles
             indices = update.indices
             if not old_graph:
-                lh = lh.update(indices, update.data)
+                keys = keys.update(indices, update.data)
                 nnlist = probe.neighborlist_after
             else:
                 nnlist = probe.neighborlist_before
-            edges = nnlist(lh, systems, for_indices=indices)
-        return HyperGraph(lh, systems, edges)
+            edges = nnlist(keys, systems, queried_keys=indices)
+        return HyperGraph(keys, systems, edges)
 
 
 class GraphPotentialInput(NamedTuple, Generic[Params, Part, Sys, Degree]):

--- a/test/core/neighborlist/_builders.py
+++ b/test/core/neighborlist/_builders.py
@@ -116,7 +116,7 @@ def make_rh(
     lh: Table[ParticleId, SamplePoints],
     update_positions: Array,
     update_batch_mask: Array,
-    for_indices: Array,
+    queried_keys: Array,
     exclusion_ids: Array | None = None,
 ) -> tuple[Table[ParticleId, SamplePoints], Index[ParticleId]]:
     """Create proposed particle data and the affected ``lh`` ids for testing."""
@@ -125,7 +125,7 @@ def make_rh(
     sys_keys = tuple(range(n_sys))
     rh_pi_keys = tuple(ParticleId(i) for i in range(n_rh))
     if exclusion_ids is None:
-        exclusion_ids = for_indices
+        exclusion_ids = queried_keys
     rh_points = SamplePoints(
         positions=update_positions,
         system=Index(sys_keys, update_batch_mask.astype(int)),
@@ -133,8 +133,8 @@ def make_rh(
         exclusion=Index.integer(exclusion_ids.astype(int)),
     )
     rh_indexed = Table(rh_pi_keys, rh_points)
-    for_indices_idx = Index(lh.keys, for_indices.astype(int))
-    return rh_indexed, for_indices_idx
+    queried_keys_idx = Index(lh.keys, queried_keys.astype(int))
+    return rh_indexed, queried_keys_idx
 
 
 def make_edges(
@@ -158,7 +158,7 @@ def make_pipeline_ctx(
     lh: Table[ParticleId, SamplePoints],
     rh: Table[ParticleId, SamplePoints] | None = None,
     cell: Cell | None = None,
-    for_indices: Array | Index[ParticleId] | None = None,
+    queried_keys: Array | Index[ParticleId] | None = None,
 ) -> PipelineContext:
     """Build a ``PipelineContext`` directly for unit-level mask/compactor tests.
 
@@ -166,16 +166,18 @@ def make_pipeline_ctx(
     convention. Using a unit cell (``eye(3)``) keeps real == fractional so
     ``DistanceCutoffMask`` produces the same numbers either way.
     """
-    if for_indices is not None and not isinstance(for_indices, Index):
-        for_indices = Index(lh.keys, for_indices)
-    assert rh is None or for_indices is None
+    if queried_keys is not None and not isinstance(queried_keys, Index):
+        queried_keys = Index(lh.keys, queried_keys)
+    assert rh is None or queried_keys is None
     if cell is None:
         cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None]))
     systems, _ = make_systems(cell, jnp.array([1.0]))
-    for_indices_raw = (
-        for_indices.indices_in(lh.keys) if for_indices is not None else None
+    queried_keys_raw = (
+        queried_keys.indices_in(lh.keys) if queried_keys is not None else None
     )
-    return PipelineContext(lh=lh, rh=rh, systems=systems, for_indices=for_indices_raw)
+    return PipelineContext(
+        keys=lh, queries=rh, systems=systems, queried_keys=queried_keys_raw
+    )
 
 
 def make_batch(
@@ -236,13 +238,13 @@ def make_adaptive_state(n_particles: int, n_systems: int) -> EvalState:
     return EvalState(particles=lh, systems=systems, neighborlist_params=params)
 
 
-def call_with_retry(nl, lh, systems, for_indices=None):
+def call_with_retry(nl, lh, systems, queried_keys=None):
     """Run a neighbor list, growing its capacities until no assertion fails."""
     from kups.core.result import as_result_function
 
     while (
         result := jax.jit(as_result_function(nl))(
-            lh=lh, systems=systems, for_indices=for_indices
+            keys=lh, systems=systems, queried_keys=queried_keys
         )
     ).failed_assertions:
         nl = result.fix_or_raise(nl)

--- a/test/core/neighborlist/integration/test_adaptive.py
+++ b/test/core/neighborlist/integration/test_adaptive.py
@@ -50,7 +50,7 @@ class TestAdaptiveCutoffFactoryEndToEnd:
         nl = adaptive_cutoff_neighborlist_from_state(state, cutoffs)
         assert isinstance(nl, DenseNearestNeighborList)
 
-        adaptive = jax.jit(as_result_function(nl))(lh=lh, systems=systems)
+        adaptive = jax.jit(as_result_function(nl))(keys=lh, systems=systems)
         adaptive.raise_assertion()
 
         ref_nl = DenseNearestNeighborList(
@@ -59,7 +59,7 @@ class TestAdaptiveCutoffFactoryEndToEnd:
             avg_image_candidates=FixedCapacity(900),
             cutoffs=cutoffs,
         )
-        ref = jax.jit(as_result_function(ref_nl))(lh=lh, systems=systems)
+        ref = jax.jit(as_result_function(ref_nl))(keys=lh, systems=systems)
         ref.raise_assertion()
 
         assert valid_edge_set(adaptive.value, 30) == valid_edge_set(ref.value, 30)
@@ -79,6 +79,6 @@ class TestAdaptiveCutoffFactoryEndToEnd:
             jnp.array([2.0]),
         )
 
-        result = jax.jit(as_result_function(nl))(lh=lh, systems=systems)
+        result = jax.jit(as_result_function(nl))(keys=lh, systems=systems)
         result.raise_assertion()
         assert result.value.indices.shape[-1] == 2

--- a/test/core/neighborlist/integration/test_against_ase.py
+++ b/test/core/neighborlist/integration/test_against_ase.py
@@ -90,7 +90,7 @@ def _kups_edges(nl_cls, atoms: ase.Atoms, cutoff: float):
     for _ in range(2):
         nl = nl_cls.from_state(state, cutoff_table)
         result = jax.jit(as_result_function(nl))(
-            lh=state.particles,
+            keys=state.particles,
             systems=state.systems,
         )
         if not result.failed_assertions:

--- a/test/core/neighborlist/integration/test_algorithms.py
+++ b/test/core/neighborlist/integration/test_algorithms.py
@@ -7,7 +7,7 @@ The same body runs for ``DenseNearestNeighborList``, ``CellListNeighborList``,
 and ``AllDenseNearestNeighborList`` via the ``neighbor_list_impl`` fixture, so
 every implementation is held to one behavioural contract: basic search,
 capacity management, exact-cutoff handling, periodic images, multi-system
-isolation, ``for_indices`` self-graph updates, and agreement with a brute-force
+isolation, ``queried_keys`` self-graph updates, and agreement with a brute-force
 reference.
 """
 
@@ -107,17 +107,17 @@ class TestNearestNeighborListImplementations:
             jnp.arange(len(params["batch_mask"])),
         )
 
-        for_indices = None
+        queried_keys = None
         if (update_positions := params.get("update_positions", None)) is not None:
-            for_indices_raw = params.get("for_indices", None)
-            assert for_indices_raw is not None, (
-                "update_positions requires for_indices in the new API"
+            queried_keys_raw = params.get("queried_keys", None)
+            assert queried_keys_raw is not None, (
+                "update_positions requires queried_keys in the new API"
             )
             update_batch_mask = params.get("update_batch_mask", params["batch_mask"])
-            update, for_indices = make_rh(
-                lh, update_positions, update_batch_mask, for_indices_raw
+            update, queried_keys = make_rh(
+                lh, update_positions, update_batch_mask, queried_keys_raw
             )
-            lh = lh.update(for_indices, update.data)
+            lh = lh.update(queried_keys, update.data)
 
         if isinstance(params["cells"], Cell):
             systems, cutoffs = make_systems(params["cells"], params["cutoffs"])
@@ -125,9 +125,9 @@ class TestNearestNeighborListImplementations:
             systems, cutoffs = systems_from_lvecs(params["cells"], params["cutoffs"])
         neighbor_list_instance = instance_factory(cutoffs=cutoffs, **params["extras"])
         result = jax.jit(as_result_function(neighbor_list_instance))(
-            lh=lh,
+            keys=lh,
             systems=systems,
-            for_indices=for_indices,
+            queried_keys=queried_keys,
         )
 
         return result
@@ -229,11 +229,11 @@ class TestNearestNeighborListImplementations:
             if lh_idx < 4 and rh_idx < 4:
                 assert batch_mask[lh_idx] == batch_mask[rh_idx]
 
-    def test_for_indices_update_positions_basic(self, neighbor_list_impl):
-        """Test basic functionality for updated lh positions selected by for_indices."""
+    def test_queried_keys_update_positions_basic(self, neighbor_list_impl):
+        """Test basic functionality for updated lh positions selected by queried_keys."""
         lh_positions = jnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
         update_positions = jnp.array([[1.0, 0.0, 0.0], [3.0, 0.0, 0.0]])
-        for_indices = jnp.array([2, 0])
+        queried_keys = jnp.array([2, 0])
 
         result = self._run_neighbor_search_test(
             neighbor_list_impl,
@@ -241,7 +241,7 @@ class TestNearestNeighborListImplementations:
             update_positions=update_positions,
             batch_mask=jnp.array([0, 0, 0]),
             update_batch_mask=jnp.array([0, 0]),
-            for_indices=for_indices,
+            queried_keys=queried_keys,
             cutoffs=jnp.array([1.5]),
             capacity=20,
         )
@@ -259,7 +259,7 @@ class TestNearestNeighborListImplementations:
         assert (1, 0) in edge_set, f"Expected edge (1, 0) not found in {edge_set}"
         assert (0, 1) in edge_set, f"Expected edge (0, 1) not found in {edge_set}"
 
-    def test_for_indices_update_batch_boundaries(self, neighbor_list_impl):
+    def test_queried_keys_update_batch_boundaries(self, neighbor_list_impl):
         """Test update batch masks: edges found within systems, blocked across systems."""
         lh_positions = jnp.array(
             [
@@ -280,7 +280,7 @@ class TestNearestNeighborListImplementations:
             update_positions=jnp.array([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
             batch_mask=lh_batch,
             update_batch_mask=jnp.array([0, 1]),
-            for_indices=jnp.array([1, 3]),
+            queried_keys=jnp.array([1, 3]),
             cells=lvecs,
             cutoffs=cutoffs,
             capacity=20,
@@ -305,7 +305,7 @@ class TestNearestNeighborListImplementations:
             update_positions=jnp.array([[0.5, 0.0, 0.0], [0.5, 0.0, 0.0]]),
             batch_mask=lh_batch,
             update_batch_mask=jnp.array([1, 0]),  # swapped
-            for_indices=jnp.array([3, 1]),
+            queried_keys=jnp.array([3, 1]),
             cells=lvecs,
             cutoffs=cutoffs,
             capacity=20,
@@ -323,7 +323,7 @@ class TestNearestNeighborListImplementations:
                     f"lhs_batch={lh_batch[lh_idx]}, rhs_batch={lh_batch[rh_idx]}"
                 )
 
-    def test_for_indices_update_positions_asymmetric_search(self, neighbor_list_impl):
+    def test_queried_keys_update_positions_asymmetric_search(self, neighbor_list_impl):
         """Test affected-index search with a subset of updated lh particles."""
         lh_positions = jnp.array(
             [
@@ -339,7 +339,7 @@ class TestNearestNeighborListImplementations:
             ]
         )
         # update[0] -> lh[0], update[1] -> lh[2]: non-adjacent affected ids
-        for_indices = jnp.array([0, 2])
+        queried_keys = jnp.array([0, 2])
 
         result = self._run_neighbor_search_test(
             neighbor_list_impl,
@@ -347,7 +347,7 @@ class TestNearestNeighborListImplementations:
             update_positions=update_positions,
             batch_mask=jnp.array([0, 0, 0]),
             update_batch_mask=jnp.array([0, 0]),
-            for_indices=for_indices,
+            queried_keys=queried_keys,
             cutoffs=jnp.array([1.5]),
             capacity=20,
         )
@@ -363,18 +363,18 @@ class TestNearestNeighborListImplementations:
         assert (1, 2) in edge_set, f"Expected edge (1, 2) not found in {edge_set}"
         assert (2, 1) in edge_set, f"Expected edge (2, 1) not found in {edge_set}"
 
-    def test_for_indices_update_for_subsets(self, neighbor_list_impl):
+    def test_queried_keys_update_for_subsets(self, neighbor_list_impl):
         positions = jnp.array(
             [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [3.0, 0.0, 0.0]]
         )
-        for_indices = jnp.array([0, 2, 1])
+        queried_keys = jnp.array([0, 2, 1])
         result = self._run_neighbor_search_test(
             neighbor_list_impl,
             positions=positions,
             update_positions=positions[:3],
             batch_mask=jnp.array([0, 0, 0, 0]),
             update_batch_mask=jnp.array([0, 0, 0]),
-            for_indices=for_indices,
+            queried_keys=queried_keys,
             cutoffs=jnp.array([2.5]),
             extras={"candidates": 20, "edges": 12, "cells": 256},
         )
@@ -409,10 +409,10 @@ class TestNearestNeighborListImplementations:
             )
         )
 
-    def test_for_indices_prevents_self_interaction(self, neighbor_list_impl):
+    def test_queried_keys_prevents_self_interaction(self, neighbor_list_impl):
         """Test that self-graph updates still prevent self-interactions."""
         positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
-        for_indices = jnp.array([0, 1])
+        queried_keys = jnp.array([0, 1])
 
         result = self._run_neighbor_search_test(
             neighbor_list_impl,
@@ -420,7 +420,7 @@ class TestNearestNeighborListImplementations:
             update_positions=positions,
             batch_mask=jnp.array([0, 0]),
             update_batch_mask=jnp.array([0, 0]),
-            for_indices=for_indices,
+            queried_keys=queried_keys,
             cutoffs=jnp.array([1.5]),
             capacity=20,
         )
@@ -430,13 +430,13 @@ class TestNearestNeighborListImplementations:
         valid_edges = edges.indices.indices[edges.indices.indices[:, 0] < 2]
         valid_edges = valid_edges[valid_edges[:, 1] < 2]
 
-        assert len(valid_edges) > 0, "Should find edges with for_indices"
+        assert len(valid_edges) > 0, "Should find edges with queried_keys"
 
         for i in range(valid_edges.shape[0]):
             lh_idx, rh_idx = valid_edges[i]
             assert lh_idx != rh_idx, f"Found self-interaction: ({lh_idx}, {rh_idx})"
 
-    def test_for_indices_update_arguments_combined(self, neighbor_list_impl):
+    def test_queried_keys_update_arguments_combined(self, neighbor_list_impl):
         """Test updated positions, systems, and affected ids together."""
         lh_positions = jnp.array(
             [
@@ -454,7 +454,7 @@ class TestNearestNeighborListImplementations:
         )
 
         # Affected ids: update[0]->lh[2], update[1]->lh[1], update[2]->lh[0]
-        for_indices = jnp.array([2, 1, 0])
+        queried_keys = jnp.array([2, 1, 0])
 
         result = self._run_neighbor_search_test(
             neighbor_list_impl,
@@ -462,7 +462,7 @@ class TestNearestNeighborListImplementations:
             update_positions=update_positions,
             batch_mask=jnp.array([0, 1, 0]),
             update_batch_mask=jnp.array([0, 1, 0]),
-            for_indices=for_indices,
+            queried_keys=queried_keys,
             cells=jnp.eye(3)[None].repeat(2, axis=0) * 10.0,
             cutoffs=jnp.array([1.5, 1.5]),
             capacity=20,
@@ -537,7 +537,7 @@ class TestNearestNeighborListImplementations:
         )
         positions = positions.at[rh_indices].set(new_positions)
         lh = make_lh(positions, jnp.array([0] * N), jnp.arange(N))
-        for_indices = Index(lh.keys, rh_indices)
+        queried_keys = Index(lh.keys, rh_indices)
 
         _sys, _cut = make_systems(cell, jnp.array([cutoff]))
         neighbor_list_instance = instance_factory(
@@ -545,9 +545,9 @@ class TestNearestNeighborListImplementations:
         )
         while (
             result := jax.jit(as_result_function(neighbor_list_instance))(
-                lh=lh,
+                keys=lh,
                 systems=_sys,
-                for_indices=for_indices,
+                queried_keys=queried_keys,
             )
         ).failed_assertions:
             neighbor_list_instance = result.fix_or_raise(neighbor_list_instance)
@@ -610,7 +610,7 @@ class TestNearestNeighborListImplementations:
         nl_1 = instance_factory(
             candidates=10, edges=10, cells=256, image_candidates=200, cutoffs=_cut_1
         )
-        result_1 = jax.jit(as_result_function(nl_1))(lh=lh_1, systems=_sys_1)
+        result_1 = jax.jit(as_result_function(nl_1))(keys=lh_1, systems=_sys_1)
         result_1.raise_assertion()
         valid_1 = {
             (int(e[0]), int(e[1]))
@@ -630,7 +630,7 @@ class TestNearestNeighborListImplementations:
         nl_2 = instance_factory(
             candidates=4, edges=53, cells=8, image_candidates=600, cutoffs=_cut_2
         )
-        result_2 = jax.jit(as_result_function(nl_2))(lh=lh_2, systems=_sys_2)
+        result_2 = jax.jit(as_result_function(nl_2))(keys=lh_2, systems=_sys_2)
         result_2.raise_assertion()
         valid_2 = {
             (int(e[0]), int(e[1]))
@@ -661,7 +661,7 @@ class TestNearestNeighborListImplementations:
         )
         while (
             result := jax.jit(as_result_function(neighbor_list_instance))(
-                lh=lh,
+                keys=lh,
                 systems=_sys,
             )
         ).failed_assertions:
@@ -706,7 +706,7 @@ class TestNearestNeighborListImplementations:
             candidates=30, edges=20, cells=256, image_candidates=300, cutoffs=_cut
         )
         result = jax.jit(as_result_function(neighbor_list_instance))(
-            lh=lh,
+            keys=lh,
             systems=_sys,
         )
         result.raise_assertion()
@@ -801,7 +801,7 @@ class TestNearestNeighborListImplementations:
             candidates=4, edges=30, cells=12, image_candidates=200, cutoffs=_cut
         )
         result = jax.jit(as_result_function(neighbor_list_instance))(
-            lh=lh,
+            keys=lh,
             systems=_sys,
         )
         result.raise_assertion()
@@ -837,7 +837,7 @@ class TestNearestNeighborListImplementations:
             candidates=1, edges=16, cells=8, image_candidates=125, cutoffs=_cut
         )
         result = jax.jit(as_result_function(neighbor_list_instance))(
-            lh=lh,
+            keys=lh,
             systems=_sys,
         )
         result.raise_assertion()
@@ -884,7 +884,7 @@ class TestNearestNeighborListImplementations:
             candidates=4, edges=4, cells=8, image_candidates=4, cutoffs=_cut
         )
         result = jax.jit(as_result_function(neighbor_list_instance))(
-            lh=lh,
+            keys=lh,
             systems=_sys,
         )
         result.raise_assertion()
@@ -932,7 +932,7 @@ class TestNearestNeighborListImplementations:
             candidates=4, edges=30, cells=8, image_candidates=200, cutoffs=_cut
         )
         result = jax.jit(as_result_function(neighbor_list_instance))(
-            lh=lh,
+            keys=lh,
             systems=_sys,
         )
         result.raise_assertion()

--- a/test/core/neighborlist/integration/test_changes.py
+++ b/test/core/neighborlist/integration/test_changes.py
@@ -57,19 +57,19 @@ class TestNeighborlistChanges:
         # --- reference: two separate calls ---
         full_new_pos = positions.at[changed_idx].set(new_positions)
         lh_after = make_lh(full_new_pos, batch)
-        for_indices_after = Index(lh_after.keys, changed_idx)
-        ref_after = call_with_retry(nl, lh_after, systems, for_indices_after)
+        queried_keys_after = Index(lh_after.keys, changed_idx)
+        ref_after = call_with_retry(nl, lh_after, systems, queried_keys_after)
 
         lh_before = make_lh(positions, batch)
-        for_indices_before = Index(lh_before.keys, changed_idx)
-        ref_removed = call_with_retry(nl, lh_before, systems, for_indices_before)
+        queried_keys_before = Index(lh_before.keys, changed_idx)
+        ref_removed = call_with_retry(nl, lh_before, systems, queried_keys_before)
 
         # --- combined call ---
         lh = make_lh(positions, batch)
-        rh_table, for_indices = make_rh(
+        rh_table, queried_keys = make_rh(
             lh, new_positions, jnp.zeros(M, dtype=int), changed_idx
         )
-        rh_with_indices = WithIndices(for_indices, rh_table)
+        rh_with_indices = WithIndices(queried_keys, rh_table)
         result = neighborlist_changes(nl, lh, rh_with_indices, systems)
 
         added_set = valid_edge_set(result.added, N)
@@ -104,10 +104,10 @@ class TestNeighborlistChanges:
         nl = self._make_nl(cutoffs)
 
         lh = make_lh(positions, batch)
-        rh_table, for_indices = make_rh(
+        rh_table, queried_keys = make_rh(
             lh, new_pos, jnp.zeros(1, dtype=int), changed_idx
         )
-        rh_with_indices = WithIndices(for_indices, rh_table)
+        rh_with_indices = WithIndices(queried_keys, rh_table)
         result = neighborlist_changes(nl, lh, rh_with_indices, systems)
 
         removed = valid_edge_set(result.removed, 3)
@@ -143,10 +143,10 @@ class TestNeighborlistChanges:
         nl = self._make_nl(cutoffs)
 
         lh = make_lh(positions, batch)
-        rh_table, for_indices = make_rh(
+        rh_table, queried_keys = make_rh(
             lh, new_pos, jnp.zeros(1, dtype=int), changed_idx
         )
-        rh_with_indices = WithIndices(for_indices, rh_table)
+        rh_with_indices = WithIndices(queried_keys, rh_table)
         result = neighborlist_changes(nl, lh, rh_with_indices, systems)
 
         added = valid_edge_set(result.added, 4)
@@ -168,10 +168,10 @@ class TestNeighborlistChanges:
         nl = self._make_nl(cutoffs)
 
         lh = make_lh(positions, batch)
-        rh_table, for_indices = make_rh(
+        rh_table, queried_keys = make_rh(
             lh, new_pos, jnp.zeros(1, dtype=int), changed_idx
         )
-        rh_with_indices = WithIndices(for_indices, rh_table)
+        rh_with_indices = WithIndices(queried_keys, rh_table)
         result = neighborlist_changes(
             nl, lh, rh_with_indices, systems, compaction=compaction
         )
@@ -198,18 +198,18 @@ class TestNeighborlistChanges:
 
         full_new_pos = positions.at[changed_idx].set(new_positions)
         lh_after = make_lh(full_new_pos, batch)
-        for_indices_after = Index(lh_after.keys, changed_idx)
-        ref_after = call_with_retry(nl, lh_after, systems, for_indices_after)
+        queried_keys_after = Index(lh_after.keys, changed_idx)
+        ref_after = call_with_retry(nl, lh_after, systems, queried_keys_after)
         lh_before = make_lh(positions, batch)
-        for_indices_before = Index(lh_before.keys, changed_idx)
-        ref_removed = call_with_retry(nl, lh_before, systems, for_indices_before)
+        queried_keys_before = Index(lh_before.keys, changed_idx)
+        ref_removed = call_with_retry(nl, lh_before, systems, queried_keys_before)
 
         lh = make_lh(positions, batch)
-        rh_table, for_indices = make_rh(
+        rh_table, queried_keys = make_rh(
             lh, new_positions, jnp.zeros(M, dtype=int), changed_idx
         )
         result = neighborlist_changes(
-            nl, lh, WithIndices(for_indices, rh_table), systems
+            nl, lh, WithIndices(queried_keys, rh_table), systems
         )
 
         assert valid_edge_set(result.added, N) == valid_edge_set(ref_after, N)

--- a/test/core/neighborlist/integration/test_periodicity.py
+++ b/test/core/neighborlist/integration/test_periodicity.py
@@ -33,7 +33,7 @@ def _run_cell_list(positions, cell, cutoff):
         avg_image_candidates=FixedCapacity(max(n * n, 8)),
         cutoffs=cutoffs,
     )
-    result = jax.jit(as_result_function(nl))(lh=lh, systems=systems)
+    result = jax.jit(as_result_function(nl))(keys=lh, systems=systems)
     result.raise_assertion()
     return result.value
 
@@ -49,7 +49,7 @@ def _run_dense(positions, cell, cutoff):
         avg_image_candidates=FixedCapacity(max(n * n, 8)),
         cutoffs=cutoffs,
     )
-    result = jax.jit(as_result_function(nl))(lh=lh, systems=systems)
+    result = jax.jit(as_result_function(nl))(keys=lh, systems=systems)
     result.raise_assertion()
     return result.value
 

--- a/test/core/neighborlist/integration/test_refine.py
+++ b/test/core/neighborlist/integration/test_refine.py
@@ -6,7 +6,7 @@
 ``RefineCutoffNeighborList`` re-checks distances against new cutoffs;
 ``RefineMaskNeighborList`` re-applies inclusion/exclusion masks without
 recomputing distances. Both run full pipelines over precomputed edges in
-lh-space, supporting self-graph ``for_indices`` updates and bipartite ``rh``.
+lh-space, supporting self-graph ``queried_keys`` updates and bipartite ``rh``.
 """
 
 import jax
@@ -63,7 +63,7 @@ class TestRefineCutoffNeighborList:
         )
 
         _sys, _cut = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, cutoffs)
-        edges = refinement_nl(lh=lh, systems=_sys)
+        edges = refinement_nl(keys=lh, systems=_sys)
 
         assert len(edges) > 0
         assert edges.degree == 2
@@ -107,17 +107,17 @@ class TestRefineCutoffNeighborList:
         )
 
         _sys, _cut = make_systems(cell, cutoffs)
-        edges = refinement_nl(lh=lh, systems=_sys)
+        edges = refinement_nl(keys=lh, systems=_sys)
         assert len(edges) >= 0
         assert edges.degree == 2
 
-    def test_with_for_indices(self):
+    def test_with_queried_keys(self):
         """Test refinement with affected lh indices."""
         lh_positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
         update_positions = jnp.array([[0.5, 0.0, 0.0], [1.5, 0.0, 0.0]])
         lh = self._create_test_pointset(lh_positions)
 
-        for_indices = jnp.array([1, 2])
+        queried_keys = jnp.array([1, 2])
 
         lh_indices = jnp.array([0, 1])
         rh_indices = jnp.array([0, 1])
@@ -131,20 +131,20 @@ class TestRefineCutoffNeighborList:
             cutoffs=cutoff_table(cutoffs),
         )
 
-        rh_update, for_indices = make_rh(
+        rh_update, queried_keys = make_rh(
             lh,
             update_positions,
             jnp.zeros(len(update_positions), dtype=int),
-            for_indices,
+            queried_keys,
         )
-        lh = lh.update(for_indices, rh_update.data)
+        lh = lh.update(queried_keys, rh_update.data)
         _sys, _cut = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, cutoffs)
-        edges = refinement_nl(lh=lh, systems=_sys, for_indices=for_indices)
+        edges = refinement_nl(keys=lh, systems=_sys, queried_keys=queried_keys)
 
         assert edges.degree == 2
 
-    def test_for_indices_uses_updated_lh_positions_for_cutoff(self):
-        """Precomputed edges are in public lh-space, so for_indices updates must
+    def test_queried_keys_uses_updated_lh_positions_for_cutoff(self):
+        """Precomputed edges are in public lh-space, so queried_keys updates must
         evaluate distances after the updated data has been written to lh."""
         lh_positions = jnp.array(
             [
@@ -154,14 +154,14 @@ class TestRefineCutoffNeighborList:
             ]
         )
         lh = self._create_test_pointset(lh_positions)
-        rh_update, for_indices = make_rh(
+        rh_update, queried_keys = make_rh(
             lh,
             jnp.array([[100.4, 0.0, 0.0]]),
             jnp.zeros(1, dtype=int),
             jnp.array([2]),
             exclusion_ids=jnp.array([20]),
         )
-        lh = lh.update(for_indices, rh_update.data)
+        lh = lh.update(queried_keys, rh_update.data)
         candidates = self._create_candidate_edges(
             jnp.array([1]), jnp.array([2]), n_particles=3
         )
@@ -172,7 +172,7 @@ class TestRefineCutoffNeighborList:
         )
 
         systems, _ = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, jnp.array([1.0]))
-        edges = refinement_nl(lh=lh, systems=systems, for_indices=for_indices)
+        edges = refinement_nl(keys=lh, systems=systems, queried_keys=queried_keys)
 
         npt.assert_array_equal(
             np.asarray(edges.indices.indices[edges.indices.indices[:, 0] < lh.size]),
@@ -180,7 +180,7 @@ class TestRefineCutoffNeighborList:
         )
 
     def test_disjoint_rh_uses_rh_positions_for_cutoff(self):
-        """Without for_indices, the precomputed candidate right column is in
+        """Without queried_keys, the precomputed candidate right column is in
         rh-space and distance checks must use the separate rh table."""
         lh_positions = jnp.array(
             [
@@ -206,14 +206,14 @@ class TestRefineCutoffNeighborList:
         )
         systems, _ = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, jnp.array([1.0]))
 
-        edges = refinement_nl(lh=lh, systems=systems, rh=rh)
+        edges = refinement_nl(keys=lh, systems=systems, queries=rh)
 
         npt.assert_array_equal(
             np.asarray(edges.indices.indices[edges.indices.indices[:, 0] < lh.size]),
             np.array([[1, 0]]),
         )
 
-    def test_for_indices_uses_updated_lh_exclusion_for_cutoff_refinement(self):
+    def test_queried_keys_uses_updated_lh_exclusion_for_cutoff_refinement(self):
         """The cutoff refiner applies exclusion masks after distance filtering,
         so updated lh metadata must be used there too."""
         lh_positions = jnp.array(
@@ -223,14 +223,14 @@ class TestRefineCutoffNeighborList:
             ]
         )
         lh = self._create_test_pointset(lh_positions, exclusion_offset=0)
-        rh_update, for_indices = make_rh(
+        rh_update, queried_keys = make_rh(
             lh,
             jnp.array([[1.0, 0.0, 0.0]]),
             jnp.zeros(1, dtype=int),
             jnp.array([1]),
             exclusion_ids=jnp.array([0]),
         )
-        lh = lh.update(for_indices, rh_update.data)
+        lh = lh.update(queried_keys, rh_update.data)
         candidates = self._create_candidate_edges(
             jnp.array([0]), jnp.array([1]), n_particles=2
         )
@@ -241,7 +241,7 @@ class TestRefineCutoffNeighborList:
         )
         systems, _ = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, jnp.array([2.0]))
 
-        edges = refinement_nl(lh=lh, systems=systems, for_indices=for_indices)
+        edges = refinement_nl(keys=lh, systems=systems, queried_keys=queried_keys)
 
         assert not np.any(np.asarray(edges.indices.indices[:, 0] < lh.size))
 
@@ -263,7 +263,7 @@ class TestRefineCutoffNeighborList:
         )
 
         _sys, _cut = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, cutoffs)
-        edges = refinement_nl(lh=lh, systems=_sys)
+        edges = refinement_nl(keys=lh, systems=_sys)
 
         assert edges.degree == 2
 
@@ -299,7 +299,7 @@ class TestRefineCutoffNeighborList:
         )
 
         _sys, _cut = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, cutoffs)
-        edges = refinement_nl(lh=lh, systems=_sys)
+        edges = refinement_nl(keys=lh, systems=_sys)
 
         assert edges.degree == 2
 
@@ -322,7 +322,7 @@ class TestRefineCutoffNeighborList:
         )
 
         _sys, _cut = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, cutoffs)
-        edges = refinement_nl(lh=lh, systems=_sys)
+        edges = refinement_nl(keys=lh, systems=_sys)
 
         valid_edges = edges.indices.indices[
             edges.indices.indices[:, 0] < len(lh_positions)
@@ -344,7 +344,7 @@ class TestRefineCutoffNeighborList:
                 cutoffs=cutoff_table(jnp.array([2.0])),
             )
             _sys, _cut = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, jnp.array([2.0]))
-            edges = refinement_nl(lh=lh, systems=_sys)
+            edges = refinement_nl(keys=lh, systems=_sys)
 
             if len(edges) > 0:
                 diff_vectors = edges.difference_vectors(lh, _sys)
@@ -374,7 +374,7 @@ class TestRefineCutoffNeighborList:
         )
 
         _sys, _cut = systems_from_lvecs(jnp.eye(3)[None] * 1000.0, jnp.array([10.0]))
-        edges = refinement_nl(lh=lh, systems=_sys)
+        edges = refinement_nl(keys=lh, systems=_sys)
 
         if len(edges) > 0:
             diff_vectors = edges.difference_vectors(lh, _sys)
@@ -399,8 +399,8 @@ class TestRefineMaskNeighborList:
 
     RefineMask is the post-filter used by MCMC. Its precomputed edges carry
     indices in lh-space. For self-graph updates the changed particle data has
-    already been written into lh and for_indices selects affected rows. True
-    bipartite calls pass rh with no for_indices.
+    already been written into lh and queried_keys selects affected rows. True
+    bipartite calls pass rh with no queried_keys.
     """
 
     def test_mcmc_patch_pattern_with_partial_overlap(self):
@@ -410,17 +410,17 @@ class TestRefineMaskNeighborList:
             jnp.zeros(5, dtype=int),
             exclusion_ids=jnp.array([0, 1, 2, 3, 4]),
         )
-        rh_update, for_indices = make_rh(
+        rh_update, queried_keys = make_rh(
             lh, jnp.zeros((2, 3)), jnp.zeros(2, dtype=int), jnp.array([1, 3])
         )
-        lh = lh.update(for_indices, rh_update.data)
+        lh = lh.update(queried_keys, rh_update.data)
         candidates = make_edges(
             jnp.array([0, 2, 1]), jnp.array([1, 3, 4]), n_particles=5
         )
 
         refine_nl = RefineMaskNeighborList(candidates=candidates)
         sys, _ = systems_from_lvecs(jnp.eye(3)[None] * 100.0, jnp.array([10.0]))
-        edges = refine_nl(lh=lh, systems=sys, for_indices=for_indices)
+        edges = refine_nl(keys=lh, systems=sys, queried_keys=queried_keys)
 
         raw = edges.indices.indices
         oob = lh.size
@@ -441,18 +441,18 @@ class TestRefineMaskNeighborList:
             ]
         )
         lh = make_lh(lh_positions, jnp.zeros(4, dtype=int), jnp.arange(4))
-        rh_update, for_indices = make_rh(
+        rh_update, queried_keys = make_rh(
             lh,
             lh_positions[jnp.array([1, 3])],
             jnp.zeros(2, dtype=int),
             jnp.array([1, 3]),
         )
-        lh = lh.update(for_indices, rh_update.data)
+        lh = lh.update(queried_keys, rh_update.data)
         candidates = make_edges(jnp.array([0, 2]), jnp.array([1, 3]), n_particles=4)
 
         refine_nl = RefineMaskNeighborList(candidates=candidates)
         sys, _ = systems_from_lvecs(jnp.eye(3)[None] * 100.0, jnp.array([10.0]))
-        edges = refine_nl(lh=lh, systems=sys, for_indices=for_indices)
+        edges = refine_nl(keys=lh, systems=sys, queried_keys=queried_keys)
 
         raw = edges.indices.indices
         oob = lh.size
@@ -483,54 +483,54 @@ class TestRefineMaskNeighborList:
             jnp.array([10.0, 10.0]),
         )
 
-        edges = refine_nl(lh=lh, systems=systems, rh=rh)
+        edges = refine_nl(keys=lh, systems=systems, queries=rh)
 
         npt.assert_array_equal(np.asarray(edges.indices.indices), np.array([[2, 2]]))
 
-    def test_for_indices_uses_updated_lh_inclusion(self):
+    def test_queried_keys_uses_updated_lh_inclusion(self):
         """Updated lh rows can move inclusion segments before refinement."""
         lh = make_lh(
             jnp.zeros((2, 3)),
             jnp.zeros(2, dtype=int),
             exclusion_ids=jnp.array([0, 1]),
         )
-        rh_update, for_indices = make_rh(
+        rh_update, queried_keys = make_rh(
             lh,
             jnp.zeros((1, 3)),
             jnp.ones(1, dtype=int),
             jnp.array([1]),
             exclusion_ids=jnp.array([1]),
         )
-        lh = lh.update(for_indices, rh_update.data)
+        lh = lh.update(queried_keys, rh_update.data)
         candidates = make_edges(jnp.array([0]), jnp.array([1]), n_particles=2)
         refine_nl = RefineMaskNeighborList(candidates=candidates)
         systems, _ = systems_from_lvecs(
             jnp.eye(3)[None] * 100.0, jnp.array([10.0, 10.0])
         )
 
-        edges = refine_nl(lh=lh, systems=systems, for_indices=for_indices)
+        edges = refine_nl(keys=lh, systems=systems, queried_keys=queried_keys)
 
         npt.assert_array_equal(np.asarray(edges.indices.indices), np.array([[2, 2]]))
 
-    def test_for_indices_uses_updated_lh_exclusion(self):
+    def test_queried_keys_uses_updated_lh_exclusion(self):
         """Updated lh rows can introduce an exclusion before refinement."""
         lh = make_lh(
             jnp.zeros((2, 3)),
             jnp.zeros(2, dtype=int),
             exclusion_ids=jnp.array([0, 1]),
         )
-        rh_update, for_indices = make_rh(
+        rh_update, queried_keys = make_rh(
             lh,
             jnp.zeros((1, 3)),
             jnp.zeros(1, dtype=int),
             jnp.array([1]),
             exclusion_ids=jnp.array([0]),
         )
-        lh = lh.update(for_indices, rh_update.data)
+        lh = lh.update(queried_keys, rh_update.data)
         candidates = make_edges(jnp.array([0]), jnp.array([1]), n_particles=2)
         refine_nl = RefineMaskNeighborList(candidates=candidates)
         systems, _ = systems_from_lvecs(jnp.eye(3)[None] * 100.0, jnp.array([10.0]))
 
-        edges = refine_nl(lh=lh, systems=systems, for_indices=for_indices)
+        edges = refine_nl(keys=lh, systems=systems, queried_keys=queried_keys)
 
         npt.assert_array_equal(np.asarray(edges.indices.indices), np.array([[2, 2]]))

--- a/test/core/neighborlist/test_all_connected.py
+++ b/test/core/neighborlist/test_all_connected.py
@@ -36,7 +36,7 @@ class TestInclusionGroupSelector:
         pairs = {
             (a, b)
             for a, b in zip(
-                batch.lh_idx.indices.tolist(), batch.rh_idx.indices.tolist()
+                batch.key_idx.indices.tolist(), batch.query_idx.indices.tolist()
             )
             if a < 3 and b < 3
         }
@@ -90,7 +90,7 @@ class TestAllConnectedNeighborlist:
         with pytest.raises(AssertionError, match="max_count must be set"):
             all_connected_neighborlist(lh, _systems())
 
-    def test_for_indices_returns_only_touched_pairs(self):
+    def test_queried_keys_returns_only_touched_pairs(self):
         lh = make_lh(
             jnp.zeros((3, 3)),
             jnp.zeros(3, dtype=int),
@@ -98,7 +98,7 @@ class TestAllConnectedNeighborlist:
             inclusion_max_count=3,
         )
         edges = all_connected_neighborlist(
-            lh, _systems(), for_indices=Index(lh.keys, jnp.array([0]))
+            lh, _systems(), queried_keys=Index(lh.keys, jnp.array([0]))
         )
         # Every surviving edge must touch particle 0.
         valid = valid_edge_set(edges, 3)

--- a/test/core/neighborlist/test_all_dense.py
+++ b/test/core/neighborlist/test_all_dense.py
@@ -31,10 +31,10 @@ class TestAllSubselect:
         )
         candidates = _all_subselect(lh, rh, systems)
         nptest.assert_array_equal(
-            np.asarray(candidates.lhs.indices), np.array([0, 0, 1, 1, 2, 2])
+            np.asarray(candidates.key_idx.indices), np.array([0, 0, 1, 1, 2, 2])
         )
         nptest.assert_array_equal(
-            np.asarray(candidates.rhs.indices), np.array([0, 1, 0, 1, 0, 1])
+            np.asarray(candidates.query_idx.indices), np.array([0, 1, 0, 1, 0, 1])
         )
 
 
@@ -53,7 +53,7 @@ class TestMultiSystemWarning:
             cutoffs=cutoff_table(jnp.array([1.0, 1.0])),
         )
         with caplog.at_level(logging.WARNING):
-            result = as_result_function(nl)(lh=lh, systems=systems)
+            result = as_result_function(nl)(keys=lh, systems=systems)
             result.raise_assertion()
         assert "single-system" in caplog.text
 

--- a/test/core/neighborlist/test_cell_list.py
+++ b/test/core/neighborlist/test_cell_list.py
@@ -85,7 +85,8 @@ class TestCellListSubselect:
         pairs = {
             (a, b)
             for a, b in zip(
-                candidates.lhs.indices.tolist(), candidates.rhs.indices.tolist()
+                candidates.key_idx.indices.tolist(),
+                candidates.query_idx.indices.tolist(),
             )
             if a < 3 and b < 3
         }

--- a/test/core/neighborlist/test_common.py
+++ b/test/core/neighborlist/test_common.py
@@ -18,11 +18,9 @@ from kups.core.neighborlist.common import (
     _minimum_image_shifts,
     candidate_image_counts,
     candidates_to_batch,
-    edge_rhs_table,
     lift_query_candidates,
     make_batch_with_mic,
     num_cells,
-    query_table,
     real_distance_sq,
     replicate_for_images,
 )
@@ -104,8 +102,8 @@ class TestGetCandidateImagesIsFinite:
         lh = make_lh(jnp.zeros((1, 3)), jnp.array([0]))
         systems, _ = make_systems(cell, jnp.array([6.0]))
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([0])),
-            rhs=Index(lh.keys, jnp.array([0])),
+            key_idx=Index(lh.keys, jnp.array([0])),
+            query_idx=Index(lh.keys, jnp.array([0])),
         )
         return lh, systems, candidates
 
@@ -140,7 +138,8 @@ class TestReplicateForImages:
         lh = make_lh(jnp.array([p0, p1]), jnp.zeros(2, dtype=int))
         systems, _ = make_systems(cell, jnp.array([cutoff]))
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([0])), rhs=Index(lh.keys, jnp.array([1]))
+            key_idx=Index(lh.keys, jnp.array([0])),
+            query_idx=Index(lh.keys, jnp.array([1])),
         )
         return candidates, lh, systems
 
@@ -172,9 +171,11 @@ class TestReplicateForImages:
         )
         assert len(batch.edges) == 27
         npt.assert_array_equal(
-            np.asarray(batch.lh_idx.indices), np.zeros(27, dtype=int)
+            np.asarray(batch.key_idx.indices), np.zeros(27, dtype=int)
         )
-        npt.assert_array_equal(np.asarray(batch.rh_idx.indices), np.ones(27, dtype=int))
+        npt.assert_array_equal(
+            np.asarray(batch.query_idx.indices), np.ones(27, dtype=int)
+        )
 
     def test_replication_spans_full_integer_stencil(self):
         candidates, lh, systems = self._one_candidate(
@@ -229,8 +230,8 @@ class TestReplicateForImages:
             jnp.array([0, 0, 1, 1]),
         )
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([0, 2])),
-            rhs=Index(lh.keys, jnp.array([1, 3])),
+            key_idx=Index(lh.keys, jnp.array([0, 2])),
+            query_idx=Index(lh.keys, jnp.array([1, 3])),
         )
         batch = replicate_for_images(
             candidates,
@@ -242,9 +243,12 @@ class TestReplicateForImages:
         )
         assert len(batch.edges) == 28
         # First row is the lone system-0 copy; the rest expand the system-1 pair.
-        assert (int(batch.lh_idx.indices[0]), int(batch.rh_idx.indices[0])) == (0, 1)
-        npt.assert_array_equal(np.asarray(batch.lh_idx.indices[1:]), np.full(27, 2))
-        npt.assert_array_equal(np.asarray(batch.rh_idx.indices[1:]), np.full(27, 3))
+        assert (int(batch.key_idx.indices[0]), int(batch.query_idx.indices[0])) == (
+            0,
+            1,
+        )
+        npt.assert_array_equal(np.asarray(batch.key_idx.indices[1:]), np.full(27, 2))
+        npt.assert_array_equal(np.asarray(batch.query_idx.indices[1:]), np.full(27, 3))
         # One minimum image per candidate: the system-0 copy plus system-1's.
         assert int(batch.is_minimum_image.sum()) == 2
         assert bool(batch.is_minimum_image[0])
@@ -258,13 +262,14 @@ class TestReplicateForImages:
         rh = make_lh(jnp.array([[0.9, 0.0, 0.0]]), jnp.zeros(1, dtype=int))
         systems, _ = make_systems(cell, jnp.array([2.0]))
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([0])), rhs=Index(rh.keys, jnp.array([0]))
+            key_idx=Index(lh.keys, jnp.array([0])),
+            query_idx=Index(rh.keys, jnp.array([0])),
         )
         batch = replicate_for_images(
             candidates, lh, rh, systems, cutoff_table(jnp.array([2.0])), None
         )
         npt.assert_array_equal(np.asarray(batch.edges.shifts), [[[-1.0, 0.0, 0.0]]])
-        assert batch.rhs_keys == rh.keys
+        assert batch.query_keys == rh.keys
 
     def test_missing_capacity_with_replication_needed_asserts(self):
         # max_image_candidates=None falls back to a non-growable capacity sized
@@ -288,8 +293,8 @@ class TestMakeBatchWithMic:
         lh = make_lh(positions, jnp.zeros(2, dtype=int))
         systems, _ = make_systems(cell, jnp.array([1.0]))
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([0])),
-            rhs=Index(lh.keys, jnp.array([1])),
+            key_idx=Index(lh.keys, jnp.array([0])),
+            query_idx=Index(lh.keys, jnp.array([1])),
         )
         batch = make_batch_with_mic(candidates, lh, lh, systems)
         # delta = 0.1 - 0.9 = -0.8; round(-0.8) = -1.0 on the periodic axis.
@@ -300,11 +305,11 @@ class TestMakeBatchWithMic:
 
 
 class TestCandidatesToBatch:
-    def test_packs_indices_shifts_and_rhs_keys(self):
+    def test_packs_indices_shifts_and_query_keys(self):
         lh = make_lh(jnp.zeros((3, 3)), jnp.zeros(3, dtype=int))
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([0, 1])),
-            rhs=Index(lh.keys, jnp.array([1, 2])),
+            key_idx=Index(lh.keys, jnp.array([0, 1])),
+            query_idx=Index(lh.keys, jnp.array([1, 2])),
         )
         shifts = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
         batch = candidates_to_batch(candidates, shifts, jnp.array([True, False]))
@@ -312,7 +317,7 @@ class TestCandidatesToBatch:
             np.asarray(batch.edges.indices.indices), np.array([[0, 1], [1, 2]])
         )
         npt.assert_array_equal(np.asarray(batch.edges.shifts[:, 0]), np.asarray(shifts))
-        assert batch.rhs_keys == lh.keys
+        assert batch.query_keys == lh.keys
 
 
 class TestMinimumImageShifts:
@@ -323,7 +328,8 @@ class TestMinimumImageShifts:
         )
         systems, _ = make_systems(cell, jnp.array([1.0]))
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([0])), rhs=Index(lh.keys, jnp.array([1]))
+            key_idx=Index(lh.keys, jnp.array([0])),
+            query_idx=Index(lh.keys, jnp.array([1])),
         )
         shifts = _minimum_image_shifts(candidates, lh, lh, systems)
         # delta = -0.2, nearest image is the in-cell one (shift 0).
@@ -347,37 +353,38 @@ class TestRealDistanceSq:
 
 
 class TestContextTableHelpers:
-    def test_edge_rhs_table_prefers_rh(self):
+    def test_edge_query_table_prefers_queries(self):
         lh = make_lh(jnp.zeros((3, 3)), jnp.zeros(3, dtype=int))
         rh = make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
-        assert edge_rhs_table(make_pipeline_ctx(lh)) is lh
-        assert edge_rhs_table(make_pipeline_ctx(lh, rh)) is rh
+        assert make_pipeline_ctx(lh).edge_query_table is lh
+        assert make_pipeline_ctx(lh, rh).edge_query_table is rh
 
     def test_query_table_self_full_vs_subset_vs_bipartite(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
         rh = make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
-        assert query_table(make_pipeline_ctx(lh)).size == 4
+        assert make_pipeline_ctx(lh).query_table.size == 4
         assert (
-            query_table(make_pipeline_ctx(lh, for_indices=jnp.array([1, 3]))).size == 2
+            make_pipeline_ctx(lh, queried_keys=jnp.array([1, 3])).query_table.size == 2
         )
-        assert query_table(make_pipeline_ctx(lh, rh)) is rh
+        assert make_pipeline_ctx(lh, rh).query_table is rh
 
     def test_lift_query_candidates_remaps_rhs_to_lh_ids(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
-        ctx = make_pipeline_ctx(lh, for_indices=jnp.array([2, 0]))
-        # query-local rhs ids [0, 1] map through for_indices -> lh ids [2, 0].
+        ctx = make_pipeline_ctx(lh, queried_keys=jnp.array([2, 0]))
+        # query-local rhs ids [0, 1] map through queried_keys -> lh ids [2, 0].
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([1, 3])),
-            rhs=Index(lh.keys, jnp.array([0, 1])),
+            key_idx=Index(lh.keys, jnp.array([1, 3])),
+            query_idx=Index(lh.keys, jnp.array([0, 1])),
         )
         lifted = lift_query_candidates(candidates, ctx)
-        npt.assert_array_equal(np.asarray(lifted.lhs.indices), np.array([1, 3]))
-        npt.assert_array_equal(np.asarray(lifted.rhs.indices), np.array([2, 0]))
+        npt.assert_array_equal(np.asarray(lifted.key_idx.indices), np.array([1, 3]))
+        npt.assert_array_equal(np.asarray(lifted.query_idx.indices), np.array([2, 0]))
 
-    def test_lift_query_candidates_noop_without_for_indices(self):
+    def test_lift_query_candidates_noop_without_queried_keys(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
         ctx = make_pipeline_ctx(lh)
         candidates = Candidates(
-            lhs=Index(lh.keys, jnp.array([0])), rhs=Index(lh.keys, jnp.array([1]))
+            key_idx=Index(lh.keys, jnp.array([0])),
+            query_idx=Index(lh.keys, jnp.array([1])),
         )
         assert lift_query_candidates(candidates, ctx) is candidates

--- a/test/core/neighborlist/test_compact.py
+++ b/test/core/neighborlist/test_compact.py
@@ -34,7 +34,7 @@ class TestReduceCompactor:
     def test_compacts_rows_without_mirroring(self):
         """ReduceCompactor only compacts; graph symmetry is postprocessing."""
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
-        ctx = make_pipeline_ctx(lh, for_indices=jnp.array([1, 3]))
+        ctx = make_pipeline_ctx(lh, queried_keys=jnp.array([1, 3]))
         keep = jnp.array([True])
         shifts = jnp.array([[[0.5, 0.0, 0.0]]])
         batch = make_batch(lh.keys, jnp.array([0]), jnp.array([1]), shifts=shifts)
@@ -60,7 +60,7 @@ class TestReduceCompactor:
 class TestMaskOnlyCompactor:
     def test_stamps_oob_on_dropped_entries(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
-        ctx = make_pipeline_ctx(lh, for_indices=jnp.array([1, 3]))
+        ctx = make_pipeline_ctx(lh, queried_keys=jnp.array([1, 3]))
         keep = jnp.array([True, False, True])
         batch = make_batch(lh.keys, jnp.array([0, 1, 2]), jnp.array([1, 3, 3]))
         edges = MaskOnlyCompactor()(keep, batch, ctx)

--- a/test/core/neighborlist/test_dense.py
+++ b/test/core/neighborlist/test_dense.py
@@ -25,7 +25,7 @@ class TestDenseSubselect:
         candidates = _dense_subselect(lh, lh, systems, FixedCapacity(16))
         sys_ids = lh.data.system.indices
         for a, b in zip(
-            candidates.lhs.indices.tolist(), candidates.rhs.indices.tolist()
+            candidates.key_idx.indices.tolist(), candidates.query_idx.indices.tolist()
         ):
             if a < 4 and b < 4:
                 assert sys_ids[a] == sys_ids[b]
@@ -38,7 +38,10 @@ class TestDenseSubselect:
         )
         candidates = _dense_subselect(lh, lh, systems, FixedCapacity(8))
         pairs = set(
-            zip(candidates.lhs.indices.tolist(), candidates.rhs.indices.tolist())
+            zip(
+                candidates.key_idx.indices.tolist(),
+                candidates.query_idx.indices.tolist(),
+            )
         )
         # Single system of 2 particles -> all 4 ordered pairs including self.
         assert {(0, 0), (0, 1), (1, 0), (1, 1)} <= pairs

--- a/test/core/neighborlist/test_fixed.py
+++ b/test/core/neighborlist/test_fixed.py
@@ -52,24 +52,29 @@ class TestEmptyNeighborList:
         assert edges.indices.indices.shape == (0, 3)
         assert edges.shifts.shape == (0, 2, 3)
 
-    def test_rh_or_for_indices_arguments_are_ignored(self):
+    def test_rh_or_queried_keys_arguments_are_ignored(self):
         nl = EmptyNeighborList[Literal[2]](degree=2)
         lh = _simple_lh(4)
         systems = _simple_systems()
         rh = _simple_lh(2)
-        for_indices = Index(lh.keys, jnp.array([0, 2]))
-        assert nl(lh, systems, rh=rh).indices.indices.shape == (0, 2)
-        assert nl(lh, systems, for_indices=for_indices).indices.indices.shape == (0, 2)
+        queried_keys = Index(lh.keys, jnp.array([0, 2]))
+        assert nl(lh, systems, queries=rh).indices.indices.shape == (0, 2)
+        assert nl(lh, systems, queried_keys=queried_keys).indices.indices.shape == (
+            0,
+            2,
+        )
 
-    def test_rh_and_for_indices_are_mutually_exclusive(self):
+    def test_rh_and_queried_keys_are_mutually_exclusive(self):
         nl = EmptyNeighborList[Literal[2]](degree=2)
         lh = _simple_lh(4)
-        with pytest.raises(AssertionError, match="cannot combine rh with for_indices"):
+        with pytest.raises(
+            AssertionError, match="cannot combine queries with queried_keys"
+        ):
             nl(
                 lh,
                 _simple_systems(),
-                rh=_simple_lh(2),
-                for_indices=Index(lh.keys, jnp.array([0, 2])),
+                queries=_simple_lh(2),
+                queried_keys=Index(lh.keys, jnp.array([0, 2])),
             )
 
     def test_keys_come_from_lh(self):
@@ -112,24 +117,24 @@ class TestFixedEdgesNeighborList:
             out.difference_vectors(lh, systems), jnp.array([[[2.0, 0.0, 0.0]]])
         )
 
-    def test_for_indices_filters_without_rh(self):
+    def test_queried_keys_filters_without_rh(self):
         stored = self._edges()
         nl = FixedEdgesNeighborList[Literal[2]](
             indices=stored.indices, avg_edges=FixedCapacity(2)
         )
         lh = _simple_lh(4)
-        for_indices = Index(lh.keys, jnp.array([2]))
-        out = nl(lh, _simple_systems(), for_indices=for_indices)
+        queried_keys = Index(lh.keys, jnp.array([2]))
+        out = nl(lh, _simple_systems(), queried_keys=queried_keys)
         npt.assert_array_equal(out.indices.indices, jnp.array([[1, 2], [2, 3]]))
 
-    def test_for_indices_returns_touched_edges(self):
+    def test_queried_keys_returns_touched_edges(self):
         stored = self._edges()
         nl = FixedEdgesNeighborList[Literal[2]](
             indices=stored.indices, avg_edges=FixedCapacity(2)
         )
         lh = _simple_lh(4)
-        for_indices = Index(lh.keys, jnp.array([2]))
-        out = nl(lh, _simple_systems(), for_indices=for_indices)
+        queried_keys = Index(lh.keys, jnp.array([2]))
+        out = nl(lh, _simple_systems(), queried_keys=queried_keys)
         npt.assert_array_equal(out.indices.indices, jnp.array([[1, 2], [2, 3]]))
         npt.assert_array_equal(out.shifts, jnp.zeros((2, 1, 3), dtype=int))
 
@@ -139,19 +144,19 @@ class TestFixedEdgesNeighborList:
             indices=stored.indices, avg_edges=FixedCapacity(3)
         )
         lh = _simple_lh(4)
-        for_indices = Index(lh.keys, jnp.array([2]))
-        out = nl(lh, _simple_systems(), for_indices=for_indices)
+        queried_keys = Index(lh.keys, jnp.array([2]))
+        out = nl(lh, _simple_systems(), queried_keys=queried_keys)
         npt.assert_array_equal(out.indices.indices, jnp.array([[1, 2], [2, 3], [4, 4]]))
         npt.assert_array_equal(out.shifts[-1], jnp.zeros((1, 3), dtype=int))
 
-    def test_for_indices_multiplies_avg_edges_by_affected_count(self):
+    def test_queried_keys_multiplies_avg_edges_by_affected_count(self):
         stored = self._edges()
         nl = FixedEdgesNeighborList[Literal[2]](
             indices=stored.indices, avg_edges=FixedCapacity(2)
         )
         lh = _simple_lh(4)
-        for_indices = Index(lh.keys, jnp.array([0, 3]))
-        out = nl(lh, _simple_systems(), for_indices=for_indices)
+        queried_keys = Index(lh.keys, jnp.array([0, 3]))
+        out = nl(lh, _simple_systems(), queried_keys=queried_keys)
         npt.assert_array_equal(
             out.indices.indices, jnp.array([[0, 1], [2, 3], [4, 4], [4, 4]])
         )
@@ -160,7 +165,7 @@ class TestFixedEdgesNeighborList:
         stored = self._edges()
         nl = FixedEdgesNeighborList[Literal[2]](indices=stored.indices)
         with pytest.raises(AssertionError, match="only supports self-graph"):
-            nl(_simple_lh(4), _simple_systems(), rh=_simple_lh(1))
+            nl(_simple_lh(4), _simple_systems(), queries=_simple_lh(1))
 
     def test_patch_call_capacity_assertion(self):
         stored = self._edges()
@@ -168,9 +173,9 @@ class TestFixedEdgesNeighborList:
             indices=stored.indices, avg_edges=FixedCapacity(1)
         )
         lh = _simple_lh(4)
-        for_indices = Index(lh.keys, jnp.array([2]))
+        queried_keys = Index(lh.keys, jnp.array([2]))
         result = as_result_function(nl)(
-            lh=lh, systems=_simple_systems(), for_indices=for_indices
+            keys=lh, systems=_simple_systems(), queried_keys=queried_keys
         )
         with pytest.raises(CapacityError):
             result.raise_assertion()
@@ -183,8 +188,8 @@ class TestFixedEdgesNeighborList:
             indices=edges.indices, avg_edges=FixedCapacity(3)
         )
         lh = _simple_lh(5)
-        for_indices = Index(lh.keys, jnp.array([0]))
-        out = nl(lh, _simple_systems(), for_indices=for_indices)
+        queried_keys = Index(lh.keys, jnp.array([0]))
+        out = nl(lh, _simple_systems(), queried_keys=queried_keys)
         npt.assert_array_equal(
             out.indices.indices, jnp.array([[0, 1, 2], [0, 4, 3], [5, 5, 5]])
         )

--- a/test/core/neighborlist/test_masks.py
+++ b/test/core/neighborlist/test_masks.py
@@ -5,7 +5,7 @@
 
 Each mask is a pure ``(batch, ctx) -> bool array`` function. Tests drive masks
 with directly-constructed contexts and candidate batches, covering both the
-self-graph (``rh=None``) and bipartite (``rh`` set) branches.
+self-graph (``queries=None``) and bipartite (``queries`` set) branches.
 """
 
 import jax.numpy as jnp
@@ -15,10 +15,10 @@ from kups.core.data.table import Table
 from kups.core.neighborlist.masks import (
     DistanceCutoffMask,
     ExclusionMask,
-    ForIndicesDedupMask,
     InBoundsMask,
     InclusionMatchMask,
-    TouchesForIndicesMask,
+    QueriedKeysDedupMask,
+    TouchesQueriedKeysMask,
 )
 
 from ._builders import make_batch, make_lh, make_pipeline_ctx
@@ -54,36 +54,36 @@ class TestInclusionMatchMask:
         assert result.tolist() == [True, False, False, True]
 
 
-class TestForIndicesDedupMask:
-    def test_no_for_indices_returns_all_true(self):
+class TestQueriedKeysDedupMask:
+    def test_no_queried_keys_returns_all_true(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
         ctx = make_pipeline_ctx(lh)
         batch = make_batch(lh.keys, jnp.array([0, 1, 2]), jnp.array([1, 2, 3]))
-        result = ForIndicesDedupMask()(batch, ctx)
+        result = QueriedKeysDedupMask()(batch, ctx)
         assert result.tolist() == [True, True, True]
 
-    def test_drops_self_pair_with_for_indices(self):
+    def test_drops_self_pair_with_queried_keys(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
-        ctx = make_pipeline_ctx(lh, for_indices=jnp.array([1, 3]))
+        ctx = make_pipeline_ctx(lh, queried_keys=jnp.array([1, 3]))
         batch = make_batch(lh.keys, jnp.array([0, 1, 3]), jnp.array([1, 3, 1]))
-        result = ForIndicesDedupMask()(batch, ctx)
+        result = QueriedKeysDedupMask()(batch, ctx)
         assert result.tolist() == [True, False, True]
 
 
-class TestTouchesForIndicesMask:
-    def test_no_for_indices_keeps_every_row(self):
+class TestTouchesQueriedKeysMask:
+    def test_no_queried_keys_keeps_every_row(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
         ctx = make_pipeline_ctx(lh)
         batch = make_batch(lh.keys, jnp.array([0, 1, 2]), jnp.array([1, 2, 3]))
-        result = TouchesForIndicesMask()(batch, ctx)
+        result = TouchesQueriedKeysMask()(batch, ctx)
         assert result.tolist() == [True, True, True]
 
     def test_keeps_rows_touching_affected_ids(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
-        ctx = make_pipeline_ctx(lh, for_indices=jnp.array([2]))
+        ctx = make_pipeline_ctx(lh, queried_keys=jnp.array([2]))
         # Affected id is 2: keep rows whose either endpoint is 2.
         batch = make_batch(lh.keys, jnp.array([0, 1, 2]), jnp.array([1, 2, 3]))
-        result = TouchesForIndicesMask()(batch, ctx)
+        result = TouchesQueriedKeysMask()(batch, ctx)
         assert result.tolist() == [False, True, True]
 
 

--- a/test/core/neighborlist/test_pipeline.py
+++ b/test/core/neighborlist/test_pipeline.py
@@ -29,24 +29,26 @@ class TestPrepare:
         systems, _ = systems_from_lvecs(jnp.eye(3)[None] * 10.0, jnp.array([1.0]))
         ctx = _prepare(lh, None, systems, None)
         npt.assert_allclose(
-            np.asarray(ctx.lh.data.positions), np.array([[0.5, 0.0, 0.0]]), atol=1e-6
+            np.asarray(ctx.keys.data.positions), np.array([[0.5, 0.0, 0.0]]), atol=1e-6
         )
 
-    def test_resolves_for_indices_to_raw_array(self):
+    def test_resolves_queried_keys_to_raw_array(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
         systems, _ = make_systems(
             PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None])), jnp.array([1.0])
         )
         ctx = _prepare(lh, None, systems, Index(lh.keys, jnp.array([1, 3])))
-        npt.assert_array_equal(np.asarray(ctx.for_indices), np.array([1, 3]))
+        npt.assert_array_equal(np.asarray(ctx.queried_keys), np.array([1, 3]))
 
-    def test_rejects_rh_and_for_indices_together(self):
+    def test_rejects_rh_and_queried_keys_together(self):
         lh = make_lh(jnp.zeros((3, 3)), jnp.zeros(3, dtype=int))
         rh = make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
         systems, _ = make_systems(
             PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None])), jnp.array([1.0])
         )
-        with pytest.raises(AssertionError, match="cannot combine rh with for_indices"):
+        with pytest.raises(
+            AssertionError, match="cannot combine queries with queried_keys"
+        ):
             _prepare(lh, rh, systems, Index(lh.keys, jnp.array([0, 1])))
 
 
@@ -84,8 +86,8 @@ class TestPipelineComposition:
             masks=(),
             compactor=ReduceCompactor(avg_edges=FixedCapacity(1)),
             postprocessors=(
-                MirrorPairEdges(only_when_for_indices=False),
-                MirrorPairEdges(only_when_for_indices=False),
+                MirrorPairEdges(only_when_queried_keys=False),
+                MirrorPairEdges(only_when_queried_keys=False),
             ),
         )
         edges = pipeline(lh, systems)

--- a/test/core/neighborlist/test_postprocess.py
+++ b/test/core/neighborlist/test_postprocess.py
@@ -15,9 +15,9 @@ from ._builders import make_batch, make_edges, make_lh, make_pipeline_ctx
 
 
 class TestMirrorPairEdges:
-    def test_mirrors_each_edge_with_reverse_when_for_indices_set(self):
+    def test_mirrors_each_edge_with_reverse_when_queried_keys_set(self):
         lh = make_lh(jnp.zeros((4, 3)), jnp.zeros(4, dtype=int))
-        ctx = make_pipeline_ctx(lh, for_indices=jnp.array([1, 3]))
+        ctx = make_pipeline_ctx(lh, queried_keys=jnp.array([1, 3]))
         keep = jnp.array([True])
         shifts = jnp.array([[[0.5, 0.0, 0.0]]])
         batch = make_batch(lh.keys, jnp.array([0]), jnp.array([1]), shifts=shifts)
@@ -31,7 +31,7 @@ class TestMirrorPairEdges:
             np.array([[[0.5, 0.0, 0.0]], [[-0.5, -0.0, -0.0]]]),
         )
 
-    def test_noop_without_for_indices_by_default(self):
+    def test_noop_without_queried_keys_by_default(self):
         lh = make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
         ctx = make_pipeline_ctx(lh)
         edges = make_edges(
@@ -44,7 +44,7 @@ class TestMirrorPairEdges:
         npt.assert_array_equal(np.asarray(out.indices.indices), np.array([[0, 1]]))
         npt.assert_allclose(np.asarray(out.shifts), np.array([[[0.25, 0.0, 0.0]]]))
 
-    def test_only_when_for_indices_false_mirrors_unconditionally(self):
+    def test_only_when_queried_keys_false_mirrors_unconditionally(self):
         lh = make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
         ctx = make_pipeline_ctx(lh)
         edges = make_edges(
@@ -53,7 +53,7 @@ class TestMirrorPairEdges:
             n_particles=2,
             shifts=jnp.array([[0.25, 0.0, 0.0]]),
         )
-        out = MirrorPairEdges(only_when_for_indices=False)(edges, ctx)
+        out = MirrorPairEdges(only_when_queried_keys=False)(edges, ctx)
         npt.assert_array_equal(
             np.asarray(out.indices.indices), np.array([[0, 1], [1, 0]])
         )

--- a/test/core/neighborlist/test_types.py
+++ b/test/core/neighborlist/test_types.py
@@ -17,45 +17,47 @@ from ._builders import make_batch, make_lh, make_systems
 
 
 class TestCandidateBatch:
-    def test_lh_and_rh_idx_default_to_edge_keys(self):
+    def test_key_and_query_idx_default_to_edge_keys(self):
         keys = (ParticleId(0), ParticleId(1), ParticleId(2))
         batch = make_batch(keys, jnp.array([0, 1]), jnp.array([2, 0]))
-        npt.assert_array_equal(batch.lh_idx.indices, jnp.array([0, 1]))
-        npt.assert_array_equal(batch.rh_idx.indices, jnp.array([2, 0]))
-        assert batch.lh_idx.keys == keys
-        assert batch.rh_idx.keys == keys
+        npt.assert_array_equal(batch.key_idx.indices, jnp.array([0, 1]))
+        npt.assert_array_equal(batch.query_idx.indices, jnp.array([2, 0]))
+        assert batch.key_idx.keys == keys
+        assert batch.query_idx.keys == keys
 
-    def test_rhs_keys_override_addresses_rh_column(self):
+    def test_query_keys_override_addresses_query_column(self):
         lh_keys = (ParticleId(0), ParticleId(1))
         rh_keys = (ParticleId(5), ParticleId(6), ParticleId(7))
         edges = Edges(Index(lh_keys, jnp.array([[0, 2]])), jnp.zeros((1, 1, 3)))
         batch = CandidateBatch(
-            edges=edges, is_minimum_image=jnp.ones((1,), dtype=bool), rhs_keys=rh_keys
+            edges=edges, is_minimum_image=jnp.ones((1,), dtype=bool), query_keys=rh_keys
         )
-        # lh side uses edge keys; rh side resolves against the override vocabulary.
-        assert batch.lh_idx.keys == lh_keys
-        assert batch.rh_idx.keys == rh_keys
-        npt.assert_array_equal(batch.rh_idx.indices, jnp.array([2]))
+        # key side uses edge keys; query side resolves against the override vocabulary.
+        assert batch.key_idx.keys == lh_keys
+        assert batch.query_idx.keys == rh_keys
+        npt.assert_array_equal(batch.query_idx.indices, jnp.array([2]))
 
 
 class TestPipelineContext:
-    def test_rejects_rh_and_for_indices_together(self):
+    def test_rejects_rh_and_queried_keys_together(self):
         lh = make_lh(jnp.zeros((3, 3)), jnp.zeros(3, dtype=int))
         rh = make_lh(jnp.zeros((2, 3)), jnp.zeros(2, dtype=int))
         systems, _ = make_systems(
             PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None])), jnp.array([1.0])
         )
-        with pytest.raises(AssertionError, match="cannot combine rh with for_indices"):
+        with pytest.raises(
+            AssertionError, match="cannot combine queries with queried_keys"
+        ):
             PipelineContext(
-                lh=lh, rh=rh, systems=systems, for_indices=jnp.array([0, 1])
+                keys=lh, queries=rh, systems=systems, queried_keys=jnp.array([0, 1])
             )
 
-    def test_allows_for_indices_without_rh(self):
+    def test_allows_queried_keys_without_rh(self):
         lh = make_lh(jnp.zeros((3, 3)), jnp.zeros(3, dtype=int))
         systems, _ = make_systems(
             PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None])), jnp.array([1.0])
         )
         ctx = PipelineContext(
-            lh=lh, rh=None, systems=systems, for_indices=jnp.array([0, 2])
+            keys=lh, queries=None, systems=systems, queried_keys=jnp.array([0, 2])
         )
-        npt.assert_array_equal(ctx.for_indices, jnp.array([0, 2]))
+        npt.assert_array_equal(ctx.queried_keys, jnp.array([0, 2]))

--- a/test/potential/test_graph.py
+++ b/test/potential/test_graph.py
@@ -593,21 +593,21 @@ class _RecordingNeighborList:
         self.shifts = shifts
         self.calls = []
 
-    def __call__(self, lh, systems, *, rh=None, for_indices=None):
+    def __call__(self, keys, systems, *, queries=None, queried_keys=None):
         del systems
-        self.calls.append((rh, for_indices))
+        self.calls.append((queries, queried_keys))
         return Edges(
-            indices=Index(lh.keys, self.edge_indices),
+            indices=Index(keys.keys, self.edge_indices),
             shifts=self.shifts,
         )
 
-    def assert_incremental_call(self, expected_for_indices):
+    def assert_incremental_call(self, expected_queried_keys):
         assert len(self.calls) == 1
-        rh, for_indices = self.calls[0]
-        assert rh is None
-        assert for_indices is not None
-        assert for_indices.keys == expected_for_indices.keys
-        npt.assert_array_equal(for_indices.indices, expected_for_indices.indices)
+        queries, queried_keys = self.calls[0]
+        assert queries is None
+        assert queried_keys is not None
+        assert queried_keys.keys == expected_queried_keys.keys
+        npt.assert_array_equal(queried_keys.indices, expected_queried_keys.indices)
 
 
 class TestGraphConstructorEmptyWithPatch:


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

# PR Description

Renamed neighbor list API parameters from `lh`/`rh`/`for_indices` to `keys`/`queries`/`queried_keys` respectively to improve semantic clarity: `keys` represents the self-graph/output table, `queries` denotes bipartite query tables, and `queried_keys` specifies affected particle indices for self-graph updates.