### PR TITLE
feat: Add `Lens.then` for post-write state invariants via `ThenLens`

### DIFF
--- a/src/kups/core/lens.py
+++ b/src/kups/core/lens.py
@@ -116,8 +116,14 @@ class Update[S, R](Protocol):
     def __call__[S2](self: Update[S2, R], state: S2, /, value: R) -> S2: ...
 
 
-type Modifier[R] = Callable[[R], R]
-"""Type alias for a function that transforms a value."""
+type Endo[X] = View[X, X]
+"""An endomorphism: a function from a type back into itself.
+
+Used as the focused-value transform in [`apply`][kups.core.lens.Lens.apply] and
+as the post-set state transform in [`then`][kups.core.lens.Lens.then].
+Endomorphisms form a monoid under composition, so several can be combined into
+one before being passed in.
+"""
 
 
 class _NOT_SET_TYPE(enum.Enum):
@@ -209,7 +215,7 @@ class Lens(Protocol[S, R]):
         """
         ...
 
-    def apply[S2, R2](self: Lens[S2, R2], state: S2, /, modifier: Modifier[R2]) -> S2:
+    def apply[S2, R2](self: Lens[S2, R2], state: S2, /, modifier: Endo[R2]) -> S2:
         """Apply a modifier function to the focused value.
 
         Args:
@@ -270,6 +276,26 @@ class Lens(Protocol[S, R]):
 
         Returns:
             A new lens that composes this lens with the provided lens/view
+        """
+        ...
+
+    def then[S2](self: Lens[S2, R], after: Endo[S2]) -> Lens[S2, R]:
+        """Re-establish a whole-state invariant after every write.
+
+        Returns a lens with the same getter whose setter post-composes the
+        write with ``after``: ``set(s, r) == after(set(s, r))``. Reads are
+        unaffected — the rewrite is one-directional. ``apply``/``at``/``merge``
+        inherit it because they route through ``set``.
+
+        ``after`` only sees the post-set state, so it must depend on that state
+        alone, be idempotent, and write only fields disjoint from this lens's
+        focus (so reads still round-trip).
+
+        Args:
+            after: State endomorphism applied after each write.
+
+        Returns:
+            A lens whose writes restore the invariant.
         """
         ...
 
@@ -345,7 +371,7 @@ class BoundLens(Protocol[S, R]):
         """
         ...
 
-    def apply[R2](self: BoundLens[S, R2], modifier: Modifier[R2]) -> S:
+    def apply[R2](self: BoundLens[S, R2], modifier: Endo[R2]) -> S:
         """Apply a modifier function to the focused value in the bound data structure.
 
         Args:
@@ -400,6 +426,20 @@ class BoundLens(Protocol[S, R]):
         """
         ...
 
+    def then[S2](self: BoundLens[S2, R], after: Endo[S2]) -> BoundLens[S2, R]:
+        """Re-establish a whole-state invariant after every write.
+
+        Bound counterpart of [`Lens.then`][kups.core.lens.Lens.then]: the
+        getter is unchanged and every write is post-composed with ``after``.
+
+        Args:
+            after: State endomorphism applied after each write.
+
+        Returns:
+            A bound lens whose writes restore the invariant.
+        """
+        ...
+
 
 class BaseLens(Lens[S, R], abc.ABC):
     """Base class for lens implementations."""
@@ -410,7 +450,7 @@ class BaseLens(Lens[S, R], abc.ABC):
         return NestedLens(self, SimpleLens(view(where)))
 
     @override
-    def apply[S2](self: BaseLens[S2, R], state: S2, modifier: Modifier[R]) -> S2:
+    def apply[S2, R2](self: BaseLens[S2, R2], state: S2, modifier: Endo[R2]) -> S2:
         """Apply a modifier function to the focused value."""
         return self.set(state, modifier(self.get(state)))
 
@@ -435,6 +475,10 @@ class BaseLens(Lens[S, R], abc.ABC):
     def nest[U, R2](self: Lens[S, R2], other: Lens[R2, U]) -> Lens[S, U]:
         view_func = other.get if isinstance(other, Lens) else other
         return self.focus(view_func)
+
+    @override
+    def then[S2](self: BaseLens[S2, R], after: Endo[S2]) -> Lens[S2, R]:
+        return ThenLens(self, after)
 
     @overload
     def __call__[S2, R2](self: Lens[S2, R2], state: S2, /, value: R2) -> S2: ...
@@ -556,6 +600,29 @@ class NestedLens(BaseLens[S, R2], Generic[S, R, R2]):
 
 
 @dataclass
+class ThenLens(BaseLens[S, R]):
+    """A lens whose setter re-establishes a whole-state invariant.
+
+    Wraps ``inner`` and post-composes every write with ``after`` (an
+    [Endo][kups.core.lens.Endo] on the state): ``set(s, r) ==
+    after(inner.set(s, r))``. The getter is unchanged, so the rewrite is
+    one-directional (write side only). Constructed via
+    [`then`][kups.core.lens.Lens.then].
+    """
+
+    inner: Lens[S, R] = field(static=True)
+    after: Endo[S] = field(static=True)
+
+    @override
+    def get[S2](self: ThenLens[S2, R], state: S2) -> R:
+        return self.inner.get(state)
+
+    @override
+    def set[S2, R2](self: ThenLens[S2, R2], state: S2, value: R2) -> S2:
+        return self.after(self.inner.set(state, value))
+
+
+@dataclass
 class SimpleBoundLens(BoundLens[S, R]):
     """A lens that has been bound to a specific data structure instance.
 
@@ -582,7 +649,7 @@ class SimpleBoundLens(BoundLens[S, R]):
         return self.lens.set(self.target, value)
 
     @override
-    def apply(self, modifier: Modifier[R]) -> S:
+    def apply[R2](self: SimpleBoundLens[S, R2], modifier: Endo[R2]) -> S:
         """Apply a modifier to the focused value in the bound target."""
         return self.lens.set(self.target, modifier(self.lens.get(self.target)))
 
@@ -604,6 +671,11 @@ class SimpleBoundLens(BoundLens[S, R]):
     ) -> BoundLens[S, U]:
         """Nest another lens or view within this bound lens."""
         return self.lens.nest(other).bind(self.target)
+
+    @override
+    def then[S2](self: SimpleBoundLens[S2, R], after: Endo[S2]) -> BoundLens[S2, R]:
+        """Re-establish a whole-state invariant after every write."""
+        return self.lens.then(after).bind(self.target)
 
     @overload
     def __call__[R2](self: SimpleBoundLens[S, R2], value: R2) -> S: ...

--- a/test/core/test_lens.py
+++ b/test/core/test_lens.py
@@ -13,13 +13,13 @@ from jax import Array
 
 from kups.core.data import Table
 from kups.core.lens import (
+    Endo,
     HasLensFields,
     IndexLens,
     LambdaLens,
     Lens,
     LensField,
     MergedLens,
-    Modifier,
     SimpleBoundLens,
     SimpleLens,
     TreePathView,
@@ -59,6 +59,27 @@ class Company:
     name: str
     employees: jax.Array  # Array of employee IDs
     scores: jax.Array  # Array of performance scores
+
+
+@dataclass
+class Coupled:
+    """State with derived fields, for ``then`` tests.
+
+    Invariants: ``cartesian == fractional * scale`` and ``total == sum(cartesian)``.
+    """
+
+    fractional: jax.Array
+    scale: jax.Array
+    cartesian: jax.Array
+    total: jax.Array
+
+
+def _recompute_cartesian(s: Coupled) -> Coupled:
+    return bind(s, lambda x: x.cartesian).set(s.fractional * s.scale)
+
+
+def _recompute_total(s: Coupled) -> Coupled:
+    return bind(s, lambda x: x.total).set(s.cartesian.sum())
 
 
 @pytest.fixture
@@ -291,6 +312,71 @@ class TestNestedLens:
         assert first_char_lens.get(person) == "1"
 
 
+class TestThenLens:
+    """Tests for the ``then`` combinator (write-side state invariants)."""
+
+    @pytest.fixture
+    def state(self) -> Coupled:
+        # consistent: cartesian == fractional * scale, total == sum(cartesian)
+        return Coupled(
+            fractional=jnp.array([0.5, 0.25]),
+            scale=jnp.array(4.0),
+            cartesian=jnp.array([2.0, 1.0]),
+            total=jnp.array(3.0),
+        )
+
+    def test_set_restores_invariant(self, state: Coupled):
+        scale_lens = lens(lambda s: s.scale, cls=Coupled).then(_recompute_cartesian)
+        out = scale_lens.set(state, jnp.array(8.0))
+        npt.assert_array_equal(out.scale, jnp.array(8.0))
+        npt.assert_array_equal(out.cartesian, jnp.array([4.0, 2.0]))
+
+    def test_get_is_one_directional(self):
+        # An inconsistent cartesian is ignored by get — only the focus is read.
+        s = Coupled(
+            jnp.array([0.5]), jnp.array(4.0), jnp.array([999.0]), jnp.array(0.0)
+        )
+        scale_lens = lens(lambda s: s.scale, cls=Coupled).then(_recompute_cartesian)
+        assert scale_lens.get(s) == 4.0
+        # ...and a set still returns what was put (PutGet holds, disjoint focus).
+        assert scale_lens.get(scale_lens.set(s, jnp.array(2.0))) == 2.0
+
+    def test_apply_is_normalized(self, state: Coupled):
+        scale_lens = lens(lambda s: s.scale, cls=Coupled).then(_recompute_cartesian)
+        out = scale_lens.apply(state, lambda v: v * 2)  # 4 -> 8
+        npt.assert_array_equal(out.cartesian, jnp.array([4.0, 2.0]))
+
+    def test_chained_then_runs_in_order(self, state: Coupled):
+        # total depends on cartesian, so a stale total proves wrong ordering.
+        scale_lens = (
+            lens(lambda s: s.scale, cls=Coupled)
+            .then(_recompute_cartesian)
+            .then(_recompute_total)
+        )
+        out = scale_lens.set(state, jnp.array(8.0))
+        npt.assert_array_equal(out.cartesian, jnp.array([4.0, 2.0]))
+        npt.assert_array_equal(out.total, jnp.array(6.0))
+
+    def test_bound_then(self, state: Coupled):
+        out = (
+            bind(state)
+            .focus(lambda s: s.scale)
+            .then(_recompute_cartesian)
+            .set(jnp.array(8.0))
+        )
+        npt.assert_array_equal(out.cartesian, jnp.array([4.0, 2.0]))
+
+    def test_works_in_jit(self, state: Coupled):
+        scale_lens = lens(lambda s: s.scale, cls=Coupled).then(_recompute_cartesian)
+
+        @jax.jit
+        def f(s: Coupled, v: Array) -> Coupled:
+            return scale_lens.set(s, v)
+
+        out = f(state, jnp.array(8.0))
+        npt.assert_array_equal(out.cartesian, jnp.array([4.0, 2.0]))
+
+
 class TestBoundLens:
     """Tests for bound lens functionality."""
 
@@ -509,13 +595,13 @@ class TestTypeCompatibility:
         new_company = employees_lens.set(company, new_employees)
         npt.assert_array_equal(new_company.employees, new_employees)
 
-    def test_modifier_type_alias(self):
-        """Test that Modifier type alias works correctly."""
+    def test_endo_type_alias(self):
+        """Test that Endo type alias works correctly."""
 
-        def apply_modifier(value: int, mod: Modifier[int]) -> int:
-            return mod(value)
+        def apply_endo(value: int, f: Endo[int]) -> int:
+            return f(value)
 
-        result = apply_modifier(5, lambda x: x * 2)
+        result = apply_endo(5, lambda x: x * 2)
         assert result == 10
 
     def test_lens_with_complex_data_structures(self):


### PR DESCRIPTION
Adds a `then` combinator to `Lens` and `BoundLens` that post-composes a state endomorphism (`Endo[S]`) with every write, allowing whole-state invariants to be re-established after each `set`, `apply`, `at`, or `merge` call. Reads are unaffected.

The implementation introduces:

- The `Endo[S]` type alias for a `View[S, S]` (a function from state to state).
- `ThenLens`, a new `BaseLens` subclass that delegates `get` to its inner lens and wraps `set` with the provided endomorphism.
- `then` on `BaseLens` constructing a `ThenLens`, and on `SimpleBoundLens` delegating to the unbound lens before rebinding.
- `then` on both `Lens` and `BoundLens` protocols.

Multiple `then` calls chain in left-to-right order, so dependent invariants (e.g. recomputing `cartesian` before recomputing `total`) compose correctly. Tests cover single and chained invariants, the one-directional read guarantee, `apply`, bound lens usage, and JIT compatibility.  
  
Closes #172