### PR TITLE
feat: Add total lattice gradient and per-axis periodicity masking for variable-cell relaxation

### DIFF
--- a/src/kups/application/md/simulation.py
+++ b/src/kups/application/md/simulation.py
@@ -26,6 +26,7 @@ from kups.core.potential import (
     CachedPotential,
     EmptyType,
     MappedPotential,
+    MappedPotentialInput,
     Potential,
     PotentialAsPropagator,
     PotentialOut,
@@ -38,7 +39,6 @@ from kups.core.propagator import (
 )
 from kups.core.storage import HDF5StorageWriter
 from kups.core.typing import IsState, ParticleId, SystemId
-from kups.core.utils.functools import identity
 from kups.core.utils.jax import key_chain
 from kups.md.integrators import Integrator, make_md_step_from_state
 
@@ -70,6 +70,20 @@ class IsMdState(IsState[MDParticles, MDSystems], Protocol):
     def step(self) -> Array: ...
 
 
+def potential_map(
+    input: MappedPotentialInput[IsMdState, IsMdGradients, Any],
+) -> PotentialOut[tuple[Array, Cell[AnyPeriodicity]], EmptyType]:
+    """Map the full potential output to the specific gradients needed for MD."""
+    return PotentialOut(
+        input.potential_out.total_energies,
+        (
+            input.potential_out.gradients.positions.data,
+            input.potential_out.gradients.cell.data,
+        ),
+        EMPTY,
+    )
+
+
 def make_md_propagator[State: IsMdState, Grad: IsMdGradients](
     state_lens: Lens[State, State],
     integrator: Integrator,
@@ -85,9 +99,7 @@ def make_md_propagator[State: IsMdState, Grad: IsMdGradients](
     Returns:
         Propagator that advances the state by one MD step.
     """
-    mapped_potential = MappedPotential(
-        potential, lambda x: (x.positions.data, x.cell.data), identity
-    )
+    mapped_potential = MappedPotential(potential, potential_map)
     derivative_computation = PotentialAsPropagator(
         CachedPotential(
             mapped_potential,

--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import ase
 import jax.numpy as jnp
@@ -18,7 +17,7 @@ from kups.application.utils.particles import (
     default_exclusion,
     particles_from_ase,
 )
-from kups.core.cell import Cell
+from kups.core.cell import AnyPeriodicity, Cell
 from kups.core.data import Table
 from kups.core.data.index import Index
 from kups.core.typing import ExclusionId, ParticleId, SystemId
@@ -54,9 +53,9 @@ class RelaxParticles(Particles):
 class RelaxSystems:
     """System-level data for structure relaxation."""
 
-    cell: Cell[Any]
+    cell: Cell[AnyPeriodicity]
     """Cell geometry, batched with shape (1,)."""
-    cell_gradients: Cell[Any]
+    cell_gradients: Cell[AnyPeriodicity]
     """Energy gradient w.r.t. the cell, stored on the same
     :class:`~kups.core.cell.Frame` as :attr:`cell` (i.e. the 6 lower-triangular
     entries of ``∂U/∂h`` for a :class:`~kups.core.cell.TriclinicFrame`). Stress

--- a/src/kups/application/relaxation/simulation.py
+++ b/src/kups/application/relaxation/simulation.py
@@ -25,6 +25,7 @@ from kups.core.potential import (
     CachedPotential,
     EmptyType,
     MappedPotential,
+    MappedPotentialInput,
     Potential,
     PotentialOut,
 )
@@ -37,6 +38,8 @@ from kups.core.propagator import (
 from kups.core.storage import HDF5StorageWriter
 from kups.core.typing import IsState, ParticleId, SystemId
 from kups.core.utils.functools import identity
+from kups.core.utils.jax import jit
+from kups.observables.stress import total_lattice_gradient
 from kups.relaxation.optimizer import Optimizer
 from kups.relaxation.propagator import RelaxationPropagator
 
@@ -69,6 +72,26 @@ class OptInit(Protocol):
     ) -> optax.OptState: ...
 
 
+def potential_out_map(
+    input: MappedPotentialInput[IsRelaxState, IsRelaxGradients, Any],
+) -> PotentialOut[tuple[Array, Cell[AnyPeriodicity]], Any]:
+    """Compute the total lattice gradient from the potential output."""
+    position_gradients, cell_gradients = (
+        input.potential_out.gradients.positions,
+        input.potential_out.gradients.cell,
+    )
+    total = total_lattice_gradient(
+        input.state.particles.data.positions,
+        position_gradients.data,
+        input.state.systems.map_data(lambda s: s.cell),
+        cell_gradients,
+        input.state.particles.data.system,
+    )
+    return PotentialOut(
+        input.potential_out.total_energies, (position_gradients.data, total.data), EMPTY
+    )
+
+
 def make_relax_propagator[State: IsRelaxState, Gradients: IsRelaxGradients](
     state_lens: Lens[State, State],
     potential: Potential[State, Gradients, EmptyType, Any],
@@ -89,9 +112,7 @@ def make_relax_propagator[State: IsRelaxState, Gradients: IsRelaxGradients](
         optimisation step and *opt_init* initialises the optimizer state.
     """
     # Cache the gradient and forces within the state
-    pot = MappedPotential(
-        potential, lambda x: (x.positions.data, x.cell.data), identity
-    )
+    pot = MappedPotential(potential, potential_out_map)
     pot = CachedPotential(
         pot,
         lens(
@@ -124,8 +145,19 @@ def make_relax_propagator[State: IsRelaxState, Gradients: IsRelaxGradients](
             indices = (particles.data.system, systems.index)
             return optimizer.init(prop_view(params), prop_view(indices))  # type: ignore
 
+        def potential_map(
+            input: MappedPotentialInput[
+                State, tuple[Array, Cell[AnyPeriodicity]], EmptyType
+            ],
+        ) -> PotentialOut[T, EmptyType]:
+            return PotentialOut(
+                input.potential_out.total_energies,
+                prop_view(input.potential_out.gradients),
+                EMPTY,
+            )
+
         return RelaxationPropagator(
-            potential=MappedPotential(pot, prop_view, identity),
+            potential=MappedPotential(pot, potential_map),
             property=prop_lens,
             opt_state=state_lens.focus(lambda x: x.opt_state),
             optimizer=optimizer,
@@ -145,7 +177,7 @@ def make_relax_propagator[State: IsRelaxState, Gradients: IsRelaxGradients](
 def run_relax[State: IsRelaxState](
     key: Array, propagator: Propagator[State], state: State, config: RelaxRunConfig
 ) -> State:
-    """Run structure relaxation with early stopping on force convergence.
+    """Run structure relaxation with early stopping on convergence.
 
     Args:
         key: JAX PRNG key.
@@ -157,10 +189,18 @@ def run_relax[State: IsRelaxState](
         Final relaxation state after convergence or ``max_steps``.
     """
 
+    @jit
+    def converged_value(s: State) -> Array:
+        max_force = jnp.max(jnp.linalg.norm(s.particles.data.forces, axis=-1))
+        cell = s.systems.data.cell
+        cell_grad = cell.frame.vectors_gradient(s.systems.data.cell_gradients.frame)
+        max_cell_grad = jnp.max(jnp.abs(cell_grad))
+        return (max_force < config.force_tolerance) & (
+            max_cell_grad < config.force_tolerance
+        )
+
     def converged(s: State) -> bool:
-        forces = s.particles.data.forces
-        max_force = jnp.max(jnp.linalg.norm(forces, axis=-1))
-        return bool(max_force < config.force_tolerance)
+        return bool(converged_value(s))
 
     def _postfix(s: State) -> dict[str, Any]:
         e = jnp.asarray(s.systems.data.potential_energy).sum()

--- a/src/kups/core/potential.py
+++ b/src/kups/core/potential.py
@@ -20,7 +20,7 @@ enabling modular force field composition (e.g., bonded + non-bonded + Coulomb).
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any, NamedTuple, Protocol
 
 import jax
 import jax.numpy as jnp
@@ -411,6 +411,11 @@ class CachedPotential[State, Gradients, Hessians, StatePatch: Patch[Any]](
         return self.cache.get(state)
 
 
+class MappedPotentialInput[State, InGrad, InHess](NamedTuple):
+    state: State
+    potential_out: PotentialOut[InGrad, InHess]
+
+
 @dataclass
 class MappedPotential[State, InGrad, OutGrad, InHess, OutHess, StatePatch: Patch[Any]](
     Potential[State, OutGrad, OutHess, StatePatch]
@@ -441,18 +446,16 @@ class MappedPotential[State, InGrad, OutGrad, InHess, OutHess, StatePatch: Patch
     """
 
     potential: Potential[State, InGrad, InHess, StatePatch] = field(static=True)
-    gradient_map: View[InGrad, OutGrad] = field(static=True)
-    hessian_map: View[InHess, OutHess] = field(static=True)
+    mapping: View[
+        MappedPotentialInput[State, InGrad, InHess], PotentialOut[OutGrad, OutHess]
+    ] = field(static=True)
 
     def __call__(
         self, state: State, patch: StatePatch | None = None
     ) -> WithPatch[PotentialOut[OutGrad, OutHess], Patch[State]]:
         result = self.potential(state, patch)
-        mapped_out = PotentialOut(
-            total_energies=result.data.total_energies,
-            gradients=self.gradient_map(result.data.gradients),
-            hessians=self.hessian_map(result.data.hessians),
-        )
+        input = MappedPotentialInput(state, result.data)
+        mapped_out = self.mapping(input)
         return WithPatch(mapped_out, result.patch)
 
 

--- a/src/kups/mcmc/probability.py
+++ b/src/kups/mcmc/probability.py
@@ -35,7 +35,6 @@ from kups.core.lens import Lens, View
 from kups.core.patch import ComposedPatch, IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY,
-    EMPTY_LENS,
     CachedPotential,
     EmptyType,
     MappedPotential,
@@ -323,7 +322,12 @@ def make_boltzmann_probability_ratio[State, Move: Patch[Any]](
         ready to be called with ``(state, patch)``.
     """
     potential = CachedPotential(
-        MappedPotential(potential, EMPTY_LENS, EMPTY_LENS),
+        MappedPotential(
+            potential,
+            lambda input: PotentialOut(
+                input.potential_out.total_energies, EMPTY, EMPTY
+            ),
+        ),
         state.focus(
             lambda x: PotentialOut(
                 x.systems.map_data(lambda x: x.potential_energy), EMPTY, EMPTY

--- a/src/kups/observables/stress.py
+++ b/src/kups/observables/stress.py
@@ -7,14 +7,15 @@ Stress is the symmetric (3, 3) tensor
 
     σ = -1/V sym[Σ_i r_i ⊗ ∂U/∂r_i + h^T · ∂U/∂h]
 
-Only the 6 lower-triangular entries of ``∂U/∂h`` are stored (the cell's
-parameter DoF; see :class:`kups.core.cell.TriclinicFrame`). For
-lower-triangular ``h``, the lower triangle of ``h^T · ∂U/∂h`` depends only
-on the lower triangle of ``∂U/∂h``: since ``h[k, i] = 0`` for ``k < i``,
-the sum ``(h^T·g)[i, j] = Σ_{k≥i} h[k, i]·g[k, j]`` for ``j ≤ i`` touches
-only ``g[k, j]`` with ``k ≥ i ≥ j``, i.e. lower-triangular entries. The
-upper triangle of ``σ`` is filled by symmetry — the full 3×3 cell virial
-is never materialized.
+Only the lower-triangular entries of ``∂U/∂h`` are stored -- the parameter
+degrees of freedom of a lower-triangular cell ``h`` -- so the full 3×3 cell
+virial is never materialized; the upper triangle of ``σ`` is filled by symmetry.
+
+Per-axis periodicity is honoured: components touching a non-periodic
+(vacuum/bounding-box) axis are zeroed, so an isolated cluster has zero stress
+and a slab keeps only its in-plane block. The volume divisor is the full cell
+volume ``|det h|`` (LAMMPS convention: a slab's stress is diluted by its vacuum
+extent).
 """
 
 from __future__ import annotations
@@ -25,8 +26,9 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.cell import Cell, Periodic3D
+from kups.core.cell import AnyPeriodicity, Cell
 from kups.core.data import Index, Table
+from kups.core.lens import bind
 from kups.core.typing import (
     GroupId,
     HasCell,
@@ -37,6 +39,7 @@ from kups.core.typing import (
     ParticleId,
     SystemId,
 )
+from kups.core.utils.jax import tree_map
 
 
 @runtime_checkable
@@ -48,11 +51,12 @@ class IsVirialParticles(HasPositions, HasSystemIndex, Protocol):
 
 
 @runtime_checkable
-class IsVirialSystems(HasCell[Periodic3D], Protocol):
-    """Systems with cell gradients ∂U/∂h (stored lower-triangular)."""
+class IsVirialSystems(HasCell[AnyPeriodicity], Protocol):
+    """Systems with a cell (any periodicity) and cell gradients ∂U/∂h
+    (stored lower-triangular)."""
 
     @property
-    def cell_gradients(self) -> Cell[Periodic3D]: ...
+    def cell_gradients(self) -> Cell[AnyPeriodicity]: ...
 
 
 @runtime_checkable
@@ -94,20 +98,32 @@ def _lower_sym_cell_virial(vectors: Array, vector_gradients: Array) -> Array:
     return jnp.tril(vectors.mT @ vector_gradients)
 
 
+def _periodic_mask(cell: Cell[AnyPeriodicity]) -> Array:
+    """Outer product of the per-axis periodicity flags, shape ``(3, 3)``.
+
+    ``σ_ab`` is conjugate to a strain deforming axis ``a`` along axis ``b``,
+    a lattice strain only when both axes are periodic; the whole row and
+    column of a non-periodic axis are zeroed. The mask is symmetric, so it
+    preserves the symmetry of ``σ``.
+    """
+    mask = jnp.array(cell.periodic)
+    return mask[:, None] * mask[None, :]
+
+
 def _stress_via_virial_theorem(
     position_gradients: Array,
     vector_gradients: Array,
     positions: Array,
-    vectors: Array,
+    cell: Cell[AnyPeriodicity],
     system: Index[SystemId],
 ) -> Array:
-    """σ = −1/V sym[Σ_i r_i ⊗ ∂U/∂r_i + h^T · ∂U/∂h]."""
+    """σ = −1/V sym[Σ_i r_i ⊗ ∂U/∂r_i + h^T · ∂U/∂h], zeroed on non-periodic axes."""
     pos_outer = system.sum_over(position_gradients[:, None] * positions[..., None]).data
     pos_lower = jnp.tril(pos_outer)
-    cell_lower = _lower_sym_cell_virial(vectors, vector_gradients)
-    volume = jnp.abs(jnp.linalg.det(vectors))[..., None, None]
-    sigma_lower = -(pos_lower + cell_lower) / volume
-    return _symmetrize_from_lower(sigma_lower)
+    cell_lower = _lower_sym_cell_virial(cell.vectors, vector_gradients)
+    volume = cell.volume[..., None, None]
+    sigma = _symmetrize_from_lower(-(pos_lower + cell_lower) / volume)
+    return sigma * _periodic_mask(cell)
 
 
 def _molecular_stress_via_virial_theorem(
@@ -115,10 +131,9 @@ def _molecular_stress_via_virial_theorem(
     vector_gradients: Array,
     positions: Array,
     group: Index[GroupId],
-    group_cells: Cell[Periodic3D],
+    group_cells: Cell[AnyPeriodicity],
     system: Index[SystemId],
-    system_vectors: Array,
-    system_volume: Array,
+    system_cell: Cell[AnyPeriodicity],
 ) -> Array:
     """Molecular virial stress using center-of-mass positions (RASPA convention)."""
     num_groups = group.num_labels
@@ -141,10 +156,10 @@ def _molecular_stress_via_virial_theorem(
         position_gradients[:, None] * (positions - rel_pos)[..., None]
     ).data
     pos_lower = jnp.tril(pos_outer)
-    cell_lower = _lower_sym_cell_virial(system_vectors, vector_gradients)
-    volume = system_volume[..., None, None]
-    sigma_lower = -(pos_lower + cell_lower) / volume
-    return _symmetrize_from_lower(sigma_lower)
+    cell_lower = _lower_sym_cell_virial(system_cell.vectors, vector_gradients)
+    volume = system_cell.volume[..., None, None]
+    sigma = _symmetrize_from_lower(-(pos_lower + cell_lower) / volume)
+    return sigma * _periodic_mask(system_cell)
 
 
 def stress_via_virial_theorem(
@@ -165,10 +180,56 @@ def stress_via_virial_theorem(
         particles.data.position_gradients,
         cell.frame.vectors_gradient(systems.data.cell_gradients.frame),
         particles.data.positions,
-        cell.vectors,
+        cell,
         particles.data.system,
     )
     return Table(systems.keys, stress)
+
+
+def total_lattice_gradient[C: Cell[AnyPeriodicity]](
+    positions: Array,
+    position_gradients: Array,
+    cell: Table[SystemId, C],
+    partial_lattice_gradient: Table[SystemId, C],
+    system: Index[SystemId],
+) -> Table[SystemId, C]:
+    """Total lattice gradient ``∂E/∂h|_r + h⁻ᵀ·Σ_i r_i ⊗ ∂E/∂r_i``, in frame parameters.
+
+    A potential reports the *partial* gradient ``∂E/∂h|_r``, taken at fixed
+    Cartesian positions. Variable-cell relaxation needs the *total* derivative,
+    with atoms riding the cell at fixed fractional coordinates; this adds the
+    position-virial term ``h⁻ᵀ·Σ_i r_i ⊗ ∂E/∂r_i``. Stress is unchanged either way.
+
+    Non-periodic axes carry no atoms -- a slab/vacuum basis vector is a
+    bounding-box edge, not a translation -- so their coupling rows are dropped via
+    the cell's [`periodic`][kups.core.cell.Cell] mask.
+
+    Args:
+        positions: Real-space positions ``r_i``, shape ``(n, 3)``.
+        position_gradients: ``∂E/∂r_i``, shape ``(n, 3)``.
+        cell: Per-system cells ``h`` (supply ``h⁻¹``, the Jacobian, and per-axis
+            periodicity); fixes the returned cell type.
+        partial_lattice_gradient: ``∂E/∂h|_r`` as per-system gradient cells.
+        system: Per-particle system index, replicating ``cell`` to particles and
+            summing the position virial per system.
+
+    Returns:
+        Total lattice gradient as ``Table[SystemId, C]`` of ``cell``'s type.
+    """
+
+    @Table.transform
+    def compose_gradient(cell: C, coupling: Array, partial: C) -> C:
+        # A non-periodic basis vector is a bounding-box edge, not a translation,
+        # so its row carries no atoms -- drop the coupling there.
+        coupling = coupling * jnp.array(cell.periodic)[:, None]
+        coupling_gradient = cell.frame.parameter_gradient(coupling)
+        return bind(partial, lambda c: c.frame).apply(
+            lambda f: tree_map(jnp.add, f, coupling_gradient)
+        )
+
+    outer = positions[:, :, None] * position_gradients[:, None, :]  # r_i ⊗ ∂E/∂r_i
+    coupling = system.sum_over(cell[system].inverse_vectors.mT @ outer)
+    return compose_gradient(cell, coupling, partial_lattice_gradient)
 
 
 def molecular_stress_via_virial_theorem(
@@ -195,8 +256,7 @@ def molecular_stress_via_virial_theorem(
         particles.data.group,
         group_cells,
         particles.data.system,
-        cell.vectors,
-        cell.volume,
+        cell,
     )
     return Table(systems.keys, stress)
 

--- a/test/application/test_relax_lj.py
+++ b/test/application/test_relax_lj.py
@@ -6,12 +6,24 @@
 import tempfile
 
 import ase.build
+import jax
 import jax.numpy as jnp
+import numpy.testing as npt
 import pytest
 
 from kups.application.relaxation.analysis import analyze_relax_file
 from kups.application.relaxation.data import RelaxParameters, RelaxRunConfig
-from kups.application.simulations.relax_lj import Config, LjConfig, run
+from kups.application.relaxation.simulation import make_relax_propagator
+from kups.application.simulations.relax_lj import (
+    Config,
+    LjConfig,
+    RelaxLjState,
+    init_state,
+    run,
+)
+from kups.core.lens import identity_lens
+from kups.potential.classical.lennard_jones import make_lennard_jones_from_state
+from kups.relaxation.config import make_optimizer
 
 
 def _ar_cif(rattle: float) -> str:
@@ -55,7 +67,7 @@ def _tmp_h5() -> str:
     return f.name
 
 
-def _config(out_file: str, inp_file: str) -> Config:
+def _config(out_file: str, inp_file: str, *, optimize_cell: bool = False) -> Config:
     return Config(
         run=RelaxRunConfig(
             out_file=out_file, max_steps=5, seed=42, force_tolerance=0.5
@@ -66,7 +78,7 @@ def _config(out_file: str, inp_file: str) -> Config:
                 {"transform": "max_step_size", "max_step_size": 0.2},
                 {"transform": "scale", "step_size": -1},
             ],
-            optimize_cell=False,
+            optimize_cell=optimize_cell,
         ),
         lj=LjConfig(
             tail_correction=False,
@@ -94,3 +106,40 @@ class TestRun:
         assert jnp.isfinite(jnp.asarray(result.final_energy)).item()
         assert jnp.isfinite(jnp.asarray(result.final_max_force)).item()
         assert result.n_steps >= 1
+
+
+def _build_propagator(optimize_cell: bool):
+    """Build an LJ relaxation propagator and its initial state."""
+    config = _config(_tmp_h5(), _ar_cif(rattle=0.1), optimize_cell=optimize_cell)
+    state_lens = identity_lens(RelaxLjState)
+    optimizer = make_optimizer(config.relax.optimizer)
+    potential = make_lennard_jones_from_state(
+        state_lens, compute_position_and_cell_gradients=True
+    )
+    propagator, opt_init = make_relax_propagator(
+        state_lens, potential, optimizer, optimize_cell
+    )
+    return propagator, init_state(config, opt_init)
+
+
+class TestCellRelaxation:
+    """``optimize_cell`` drives the lattice vectors via the total cell gradient."""
+
+    def test_cell_moves_only_when_optimizing_cell(self):
+        # optimize_cell=True: the cell relaxes (total lattice gradient is non-zero
+        # for the off-equilibrium fcc-Ar cell).
+        prop, state = _build_propagator(optimize_cell=True)
+        stepped = prop(jax.random.key(0), state)
+        assert not jnp.allclose(
+            stepped.systems.data.cell.vectors, state.systems.data.cell.vectors
+        )
+
+        # optimize_cell=False: positions move but the cell is held fixed.
+        prop0, state0 = _build_propagator(optimize_cell=False)
+        stepped0 = prop0(jax.random.key(0), state0)
+        npt.assert_array_equal(
+            stepped0.systems.data.cell.vectors, state0.systems.data.cell.vectors
+        )
+        assert not jnp.allclose(
+            stepped0.particles.data.positions, state0.particles.data.positions
+        )

--- a/test/core/test_potential.py
+++ b/test/core/test_potential.py
@@ -591,9 +591,12 @@ class TestMappedPotential:
         potential = MockPotential()
 
         mapped = MappedPotential(
-            potential=potential,
-            gradient_map=lambda g: g["pos"][0],
-            hessian_map=lambda h: h,
+            potential,
+            lambda inp: PotentialOut(
+                inp.potential_out.total_energies,
+                inp.potential_out.gradients["pos"][0],
+                inp.potential_out.hessians,
+            ),
         )
 
         result = mapped({"positions": jnp.zeros((2, 2))})
@@ -609,9 +612,12 @@ class TestMappedPotential:
         potential = MockPotential()
 
         mapped = MappedPotential(
-            potential=potential,
-            gradient_map=lambda g: g,
-            hessian_map=lambda h: h["pos"][0, 0],
+            potential,
+            lambda inp: PotentialOut(
+                inp.potential_out.total_energies,
+                inp.potential_out.gradients,
+                inp.potential_out.hessians["pos"][0, 0],
+            ),
         )
 
         result = mapped({"positions": jnp.zeros((2, 2))})
@@ -623,9 +629,12 @@ class TestMappedPotential:
         potential = MockPotential()
 
         mapped = MappedPotential(
-            potential=potential,
-            gradient_map=lambda g: g["pos"].sum(),
-            hessian_map=lambda h: h["pos"].sum(),
+            potential,
+            lambda inp: PotentialOut(
+                inp.potential_out.total_energies,
+                inp.potential_out.gradients["pos"].sum(),
+                inp.potential_out.hessians["pos"].sum(),
+            ),
         )
 
         result = mapped({"positions": jnp.zeros((2, 2))})
@@ -638,9 +647,10 @@ class TestMappedPotential:
         potential = MockPotential(energy_multiplier=5.0)
 
         mapped = MappedPotential(
-            potential=potential,
-            gradient_map=lambda g: jnp.array(0.0),
-            hessian_map=lambda h: jnp.array(0.0),
+            potential,
+            lambda inp: PotentialOut(
+                inp.potential_out.total_energies, jnp.array(0.0), jnp.array(0.0)
+            ),
         )
 
         result = mapped({"positions": jnp.zeros((2, 2))})
@@ -653,11 +663,7 @@ class TestMappedPotential:
         """Test that patch is passed through unchanged."""
         potential = MockPotential()
 
-        mapped = MappedPotential(
-            potential=potential,
-            gradient_map=lambda g: g,
-            hessian_map=lambda h: h,
-        )
+        mapped = MappedPotential(potential, lambda inp: inp.potential_out)
 
         result = mapped({"positions": jnp.zeros((2, 2))})
 
@@ -668,9 +674,12 @@ class TestMappedPotential:
         potential = MockPotential()
 
         mapped = MappedPotential(
-            potential=potential,
-            gradient_map=lambda g: g["pos"][0],
-            hessian_map=lambda h: h["pos"][0],
+            potential,
+            lambda inp: PotentialOut(
+                inp.potential_out.total_energies,
+                inp.potential_out.gradients["pos"][0],
+                inp.potential_out.hessians["pos"][0],
+            ),
         )
 
         jitted = jax.jit(mapped)
@@ -685,9 +694,12 @@ class TestMappedPotential:
 
         summed = sum_potentials(p1, p2)
         mapped = MappedPotential(
-            potential=summed,
-            gradient_map=lambda g: g["pos"][0],
-            hessian_map=lambda h: h,
+            summed,
+            lambda inp: PotentialOut(
+                inp.potential_out.total_energies,
+                inp.potential_out.gradients["pos"][0],
+                inp.potential_out.hessians,
+            ),
         )
 
         result = mapped({"positions": jnp.zeros((2, 2))})

--- a/test/observables/test_stress.py
+++ b/test/observables/test_stress.py
@@ -11,11 +11,20 @@ import numpy as np
 import numpy.testing as npt
 from jax import Array
 
-from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
+from kups.core.cell import (
+    AnyPeriodicity,
+    Cell,
+    PeriodicCell,
+    TriclinicFrame,
+    VacuumCell,
+)
 from kups.core.data import Index, Table
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass
-from kups.observables.stress import stress_via_virial_theorem
+from kups.observables.stress import (
+    stress_via_virial_theorem,
+    total_lattice_gradient,
+)
 
 
 @dataclass
@@ -27,19 +36,21 @@ class _VirialParticles:
 
 @dataclass
 class _VirialSystems:
-    cell: Cell
-    cell_gradients: Cell
+    cell: Cell[AnyPeriodicity]
+    cell_gradients: Cell[AnyPeriodicity]
 
 
 def _make_systems(
-    lattice_vectors: Array, lattice_grad: Array | None = None
+    lattice_vectors: Array,
+    lattice_grad: Array | None = None,
+    pbc: tuple[bool, bool, bool] = (True, True, True),
 ) -> Table[SystemId, _VirialSystems]:
     """Helper: Table with cell and cell-gradient for each row of
     ``lattice_vectors`` (one system per leading-axis entry)."""
     if lattice_grad is None:
         lattice_grad = jnp.zeros_like(lattice_vectors)
-    cell = PeriodicCell(TriclinicFrame.from_matrix(lattice_vectors))
-    cell_grad = PeriodicCell(TriclinicFrame.from_matrix(lattice_grad))
+    cell = Cell.from_pbc(TriclinicFrame.from_matrix(lattice_vectors), pbc)
+    cell_grad = Cell.from_pbc(TriclinicFrame.from_matrix(lattice_grad), pbc)
     n = lattice_vectors.shape[0]
     keys = tuple(SystemId(i) for i in range(n))
     return Table(keys, _VirialSystems(cell=cell, cell_gradients=cell_grad))
@@ -181,3 +192,108 @@ class TestStressViaVirialTheorem:
         systems = _make_systems(lv, lattice_grad)
         result = jax.jit(stress_via_virial_theorem)(particles, systems)
         npt.assert_allclose(result.data[0], result.data[0].T, atol=1e-10)
+
+    def test_vacuum_cell_has_zero_stress(self):
+        """A fully non-periodic (vacuum) cell has no lattice-strain DOF, so every
+        stress component is zeroed regardless of the particle/cell gradients."""
+        positions = jnp.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        lv = jnp.eye(3)[None] * 2.0
+        lattice_grad = jnp.eye(3)[None] * 3.0
+        particles = _make_particles(positions)
+        systems = _make_systems(lv, lattice_grad, pbc=(False, False, False))
+        result = jax.jit(stress_via_virial_theorem)(particles, systems)
+        npt.assert_allclose(result.data, 0.0, atol=1e-12)
+
+    def test_slab_zeroes_non_periodic_row_and_column(self):
+        """A slab periodic in x,y keeps only the in-plane 2×2 block: the z row and
+        column are zeroed, and the in-plane block matches the fully periodic
+        result (same frame, hence same volume and virial)."""
+        positions = jnp.array([[1.0, 2.0, 3.0], [0.5, -1.0, 0.7]])
+        lv = jnp.eye(3)[None] * 2.0
+        lattice_grad = jnp.tril(
+            jnp.array([[[1.0, 0.0, 0.0], [0.5, 2.0, 0.0], [0.3, -0.4, 1.5]]])
+        )
+        particles = _make_particles(positions)
+        slab = jax.jit(stress_via_virial_theorem)(
+            particles, _make_systems(lv, lattice_grad, pbc=(True, True, False))
+        ).data[0]
+        full = jax.jit(stress_via_virial_theorem)(
+            particles, _make_systems(lv, lattice_grad)
+        ).data[0]
+        npt.assert_allclose(slab[2, :], 0.0, atol=1e-12)
+        npt.assert_allclose(slab[:, 2], 0.0, atol=1e-12)
+        npt.assert_allclose(slab[:2, :2], full[:2, :2], atol=1e-12)
+
+
+_H_TRICLINIC = jnp.array([[[2.0, 0.0, 0.0], [0.7, 1.9, 0.0], [0.3, -0.5, 2.4]]])
+
+
+def _periodic(frame: TriclinicFrame) -> Table[SystemId, PeriodicCell]:
+    return Table((SystemId(0),), PeriodicCell(frame))
+
+
+class TestTotalLatticeGradient:
+    """total = ∂E/∂h|_r + h⁻ᵀ·Σ rᵢ⊗∂E/∂rᵢ, dropping non-periodic lattice vectors."""
+
+    def test_reduces_to_partial_at_zero_force(self):
+        """With ∂E/∂rᵢ = 0 the coupling term vanishes: total == partial."""
+        cell = _periodic(TriclinicFrame.from_matrix(_H_TRICLINIC))
+        partial = _periodic(TriclinicFrame.from_matrix(jnp.tril(jnp.ones((1, 3, 3)))))
+        positions = jnp.array([[0.5, 1.0, -0.3], [1.2, 0.1, 0.8]])
+        system = Index((SystemId(0),), jnp.zeros(2, dtype=int))
+        total = total_lattice_gradient(
+            positions, jnp.zeros((2, 3)), cell, partial, system
+        )
+        npt.assert_allclose(
+            total.data.frame.vectors, partial.data.frame.vectors, atol=1e-12
+        )
+
+    def test_matches_autodiff_through_fixed_fractional(self):
+        """Validate against ``jax.grad`` of ``E(s@h, h)`` with fractional ``s`` held
+        fixed -- the definition of the total lattice gradient."""
+        rng = np.random.default_rng(3)
+        frame = TriclinicFrame.from_matrix(_H_TRICLINIC)
+        positions = jnp.asarray(rng.standard_normal((5, 3)))
+        system = Index((SystemId(0),), jnp.zeros(5, dtype=int))
+        c = 0.37
+
+        def energy(fr: TriclinicFrame, r: Array) -> Array:
+            return 0.5 * (r**2).sum() + c * (fr.vectors**2).sum()
+
+        partial = jax.grad(lambda fr: energy(fr, positions))(frame)
+        g = jax.grad(lambda r: energy(frame, r))(positions)
+        total = total_lattice_gradient(
+            positions, g, _periodic(frame), _periodic(partial), system
+        )
+
+        s = frame.to_fractional(positions)  # fixed fractional coordinates
+        total_ref = jax.grad(lambda fr: energy(fr, fr.to_real(s)))(frame)
+        npt.assert_allclose(total.data.frame.vectors, total_ref.vectors, atol=1e-10)
+
+    def test_non_periodic_axes_drop_the_coupling(self):
+        """A non-periodic basis vector carries no atoms: an open cell drops the
+        coupling entirely (total == partial), a periodic one does not."""
+        rng = np.random.default_rng(4)
+        frame = TriclinicFrame.from_matrix(_H_TRICLINIC)
+        partial_frame = TriclinicFrame.from_matrix(
+            jnp.tril(jnp.asarray(rng.standard_normal((1, 3, 3))))
+        )
+        positions = jnp.asarray(rng.standard_normal((4, 3)))
+        g = jnp.asarray(rng.standard_normal((4, 3)))
+        system = Index((SystemId(0),), jnp.zeros(4, dtype=int))
+
+        vacuum = total_lattice_gradient(
+            positions,
+            g,
+            Table((SystemId(0),), VacuumCell(frame)),
+            Table((SystemId(0),), VacuumCell(partial_frame)),
+            system,
+        )
+        npt.assert_allclose(
+            vacuum.data.frame.vectors, partial_frame.vectors, atol=1e-12
+        )
+
+        periodic = total_lattice_gradient(
+            positions, g, _periodic(frame), _periodic(partial_frame), system
+        )
+        assert not jnp.allclose(periodic.data.frame.vectors, partial_frame.vectors)


### PR DESCRIPTION
## Variable-Cell Relaxation with Per-Axis Periodicity Support

### Overview

This PR extends structure relaxation to support variable-cell optimisation and adds correct handling of per-axis periodicity throughout the stress and lattice gradient machinery.

### `MappedPotential` API Refactor

`MappedPotential` previously accepted separate `gradient_map` and `hessian_map` callables. These have been replaced with a single `mapping` callable that receives a `MappedPotentialInput` named tuple containing both the current `state` and the full `PotentialOut`. This gives mapping functions access to the state (e.g. positions, cell) when computing derived quantities, which is required for the total lattice gradient.

### Total Lattice Gradient

A new `total_lattice_gradient` function in `kups/observables/stress.py` computes the total derivative `∂E/∂h` at fixed fractional coordinates, adding the position-virial coupling term `h⁻ᵀ·Σᵢ rᵢ⊗∂E/∂rᵢ` to the partial gradient reported by the potential. Non-periodic axes are masked out so that vacuum/bounding-box basis vectors do not accumulate spurious coupling.

### Variable-Cell Relaxation

The relaxation propagator now applies `total_lattice_gradient` when mapping potential output, replacing the previous pass-through of the raw cell gradient. The convergence check in `run_relax` has been extended to include the maximum absolute cell gradient alongside the maximum force, using a single `force_tolerance` threshold for both.

### Per-Axis Periodicity in Stress

`stress_via_virial_theorem` and `_molecular_stress_via_virial_theorem` now accept `Cell[AnyPeriodicity]` instead of `Cell[Periodic3D]`. A `_periodic_mask` helper zeros stress components on non-periodic axes, so isolated clusters produce zero stress and slabs retain only their in-plane block. `IsVirialSystems` and `RelaxSystems` have been updated accordingly.

### Tests

- `TestCellRelaxation` verifies that `optimize_cell=True` moves the lattice vectors while `optimize_cell=False` holds them fixed.
- `TestTotalLatticeGradient` validates the coupling term against `jax.grad` through fixed-fractional-coordinate energy evaluation, checks that zero forces reduce to the partial gradient, and confirms that non-periodic axes drop the coupling entirely.
- `TestStressViaVirialTheorem` gains cases for a fully non-periodic (vacuum) cell producing zero stress and a slab geometry zeroing the non-periodic row and column while preserving the in-plane block.  
  
Closes #160