### PR TITLE
fix: preserve inner lens setter in Lens.nest

### DIFF
--- a/src/kups/core/lens.py
+++ b/src/kups/core/lens.py
@@ -257,17 +257,17 @@ class Lens(Protocol[S, R]):
         ...
 
     def nest[U, S2, R2](self: Lens[S2, R2], other: Lens[R2, U]) -> Lens[S2, U]:
-        """Nest another lens or view within this lens.
+        """Compose this lens with an inner lens, preserving the inner lens's setter.
 
-        This provides an alternative to focus() that works with both lenses and views.
-        When given a lens, it extracts the view from it; when given a view directly,
-        it uses it as-is.
+        Unlike focus(), which infers a setter by tracing the path of a getter, nest
+        threads the inner lens's own get and set. For a bare getter (no setter),
+        use focus() instead.
 
         Args:
-            other: Either a lens or view to nest within this lens
+            other: The inner lens to compose within this lens
 
         Returns:
-            A new lens that composes this lens with the provided lens/view
+            A new lens that composes this lens with the inner lens
         """
         ...
 
@@ -384,17 +384,17 @@ class BoundLens(Protocol[S, R]):
         ...
 
     def nest[U, R2](self: BoundLens[S, R2], other: Lens[R2, U]) -> BoundLens[S, U]:
-        """Nest another lens or view within this bound lens.
+        """Compose this bound lens with an inner lens, preserving its setter.
 
-        This provides an alternative to focus() that works with both lenses and views.
-        When given a lens, it extracts the view from it; when given a view directly,
-        it uses it as-is.
+        Unlike focus(), which infers a setter by tracing the path of a getter, nest
+        threads the inner lens's own get and set. For a bare getter (no setter),
+        use focus() instead.
 
         Args:
-            other: Either a lens or view to nest within this lens
+            other: The inner lens to compose within this bound lens
 
         Returns:
-            A new bound lens that composes this lens with the provided lens/view
+            A new bound lens that composes this lens with the inner lens
         """
         ...
 
@@ -423,8 +423,12 @@ class BaseLens(Lens[S, R], abc.ABC):
         return MergedLens(self, other)
 
     def nest[U, R2](self: Lens[S, R2], other: Lens[R2, U]) -> Lens[S, U]:
-        view_func = other.get if isinstance(other, Lens) else other
-        return self.focus(view_func)
+        if not isinstance(other, Lens):
+            raise TypeError(
+                f"nest requires a Lens, got {type(other).__name__}. "
+                "Use .focus(view) to compose a bare getter."
+            )
+        return NestedLens(self, other)
 
     @overload
     def __call__[S2, R2](self: Lens[S2, R2], state: S2, /, value: R2) -> S2: ...
@@ -577,7 +581,7 @@ class SimpleBoundLens(BoundLens[S, R]):
     def nest[U, R2](
         self: SimpleBoundLens[S, R2], other: Lens[R2, U]
     ) -> BoundLens[S, U]:
-        """Nest another lens or view within this bound lens."""
+        """Compose this bound lens with an inner lens, preserving its setter."""
         return self.lens.nest(other).bind(self.target)
 
     @overload

--- a/test/core/test_lens.py
+++ b/test/core/test_lens.py
@@ -3,6 +3,7 @@
 
 """Tests for lens functionality."""
 
+from dataclasses import replace
 from typing import Any
 
 import jax
@@ -289,6 +290,64 @@ class TestNestedLens:
         first_char_lens = street_lens.focus(get_first_char)
 
         assert first_char_lens.get(person) == "1"
+
+    def test_nest_preserves_custom_setter(self, person):
+        """nest must thread the inner lens's setter, not re-infer one from the path.
+
+        The inner setter has a side effect (clearing ``city``) that a path-traced
+        setter cannot reproduce. Dropping the setter would leave ``city`` untouched.
+        """
+
+        def get_address(p: Person) -> Address:
+            return p.address
+
+        def get_street(a: Address) -> str:
+            return a.street
+
+        def set_street_and_clear_city(a: Address, value: str) -> Address:
+            return replace(a, street=value, city="")
+
+        outer = lens(get_address)
+        inner = LambdaLens(view(get_street), set_street_and_clear_city)
+
+        result = outer.nest(inner).set(person, "456 Oak Ave")
+
+        assert result.address.street == "456 Oak Ave"
+        assert result.address.city == ""  # side effect from the inner setter
+        assert person.address.city == "Anytown"  # original untouched
+
+    def test_nest_index_lens(self, company):
+        """nesting an IndexLens (computed getter) must use its scatter setter.
+
+        Path-tracing rejects the IndexLens getter, so the old focus-based nest
+        raised on set; threading the IndexLens directly scatters correctly.
+        """
+
+        def get_scores(c: Company) -> Array:
+            return c.scores
+
+        def identity(a: Array) -> Array:
+            return a
+
+        outer = lens(get_scores)
+        inner = lens(identity).at(jnp.array([0, 2]))
+        nested = outer.nest(inner)
+
+        npt.assert_array_equal(nested.get(company), jnp.array([85.5, 78.5]))
+
+        updated = nested.set(company, jnp.array([1.0, 2.0]))
+        npt.assert_array_equal(updated.scores, jnp.array([1.0, 92.0, 2.0, 88.0]))
+
+    def test_nest_rejects_bare_view(self, person):
+        """nest requires a Lens; a bare view must raise instead of silently routing."""
+
+        def get_address(p: Person) -> Address:
+            return p.address
+
+        outer = lens(get_address)
+
+        with pytest.raises(TypeError, match="nest requires a Lens"):
+            outer.nest(view(lambda a: a))  # type: ignore[arg-type]
 
 
 class TestBoundLens:


### PR DESCRIPTION
`nest` kept only the inner lens's getter and re-inferred a setter via `focus` path-tracing, dropping custom setters; `IndexLens`'s computed getter made it raise.

Now returns `NestedLens(self, other)` (threads get and set) and rejects non-`Lens` args with `TypeError`. `SimpleBoundLens.nest` inherits via delegation.

Closes #174