### PR TITLE
feat: Add `Compression` policy and auto-batched block writes to `HDF5StorageWriter`

### DIFF
--- a/src/kups/core/storage.py
+++ b/src/kups/core/storage.py
@@ -6,21 +6,24 @@
 Provides async-writing :class:`HDF5StorageWriter` (Logger protocol) and
 :class:`HDF5StorageReader` for reading back logged data.  Logging frequency
 is controlled via :class:`LoggingFrequency` implementations (:class:`Once`,
-:class:`EveryNStep`).
+:class:`EveryNStep`); per-group chunking and compression are controlled via
+:class:`Compression`.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import math
 import pickle
 import queue
 import threading
+from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
 from types import EllipsisType
-from typing import Any, Protocol, Self, cast, override
+from typing import Any, Literal, Protocol, Self, cast, override
 
 import h5py
 import jax
@@ -84,6 +87,64 @@ class EveryNStep(LoggingFrequency):
         return step // self.n
 
 
+_DEFAULT_CHUNK_BYTES = 1 << 20  # ~1 MiB; chunk- and batch-sizing target
+_MAX_AUTO_BATCH = 128  # cap so cheap (small-frame) groups still flush periodically
+
+
+@dataclass(frozen=True)
+class Compression:
+    """HDF5 compression and chunking policy for a logging group.
+
+    Datasets are chunked along the leading (time) axis so each chunk is roughly
+    ``target_chunk_bytes``: large per-frame arrays get about single-frame chunks
+    (keeping random-frame reads cheap) while small or repeated-across-time fields
+    get many-frame chunks (capturing cross-step redundancy without per-chunk
+    bloat). Scalar datasets are stored uncompressed.
+
+    Args:
+        codec: HDF5 compression filter, ``"gzip"`` or ``"lzf"``.
+        level: gzip level (0-9); ignored for lzf.
+        shuffle: Enable the byte-shuffle filter. Helps float arrays; may slightly
+            reduce the ratio on highly repetitive data.
+        target_chunk_bytes: Approximate per-chunk size in bytes.
+    """
+
+    codec: Literal["gzip", "lzf"] = "gzip"
+    level: int = 4
+    shuffle: bool = True
+    target_chunk_bytes: int = _DEFAULT_CHUNK_BYTES
+
+    def dataset_kwargs(
+        self, leading_dims: tuple[int, ...], shape: tuple[int, ...], itemsize: int
+    ) -> dict[str, Any]:
+        """Build ``create_dataset`` keyword arguments for one array leaf.
+
+        Args:
+            leading_dims: Leading (time) dimensions prepended to ``shape``.
+            shape: Shape of a single logged value.
+            itemsize: Bytes per element.
+        """
+        if not leading_dims + shape:  # scalar: cannot chunk or compress
+            return {}
+        kwargs: dict[str, Any] = {
+            "chunks": self._chunk_shape(leading_dims, shape, itemsize),
+            "shuffle": self.shuffle,
+            "compression": self.codec,
+        }
+        if self.codec == "gzip":
+            kwargs["compression_opts"] = self.level
+        return kwargs
+
+    def _chunk_shape(
+        self, leading_dims: tuple[int, ...], shape: tuple[int, ...], itemsize: int
+    ) -> tuple[int, ...]:
+        if not leading_dims:  # logged once: one chunk spanning the whole array
+            return shape
+        frame_bytes = max(itemsize * math.prod(shape), 1)
+        frames = max(1, min(leading_dims[0], self.target_chunk_bytes // frame_bytes))
+        return (frames, *shape)
+
+
 @dataclass(frozen=True)
 class WriterGroupConfig[State, Storage]:
     """Configuration for a single logging group.
@@ -91,10 +152,13 @@ class WriterGroupConfig[State, Storage]:
     Args:
         view: A lens that extracts Storage data from the full State.
         logging_frequency: Controls when this data should be logged.
+        compression: Compression/chunking policy, or ``None`` to store
+            uncompressed contiguous datasets.
     """
 
     view: View[State, Storage]
     logging_frequency: LoggingFrequency
+    compression: Compression | None = field(default_factory=Compression, kw_only=True)
 
 
 @dataclass(frozen=True)
@@ -102,6 +166,26 @@ class GroupWriters[State, Storage](WriterGroupConfig[State, Storage]):
     """Internal class combining a WriterGroupConfig with its initialized HDF5 writer."""
 
     writer: Hdf5ObjWriter[Storage]
+
+    @cached_property
+    def batch_size(self) -> int:
+        """Steps to buffer before a block write, sized so the largest leaf writes
+        about one chunk per flush (capped so cheap groups still flush periodically).
+        ``1`` for groups logged once (no time axis).
+        """
+        if not self.logging_frequency.leading_shape(1):  # logged once: no time axis
+            return 1
+        target = (
+            self.compression.target_chunk_bytes
+            if self.compression
+            else _DEFAULT_CHUNK_BYTES
+        )
+        datasets = self.writer.datasets
+        frame_bytes = max(
+            (ds.dtype.itemsize * math.prod(ds.shape[1:]) for ds in datasets), default=1
+        )
+        num_frames = min((ds.shape[0] for ds in datasets), default=1)
+        return max(1, min(num_frames, _MAX_AUTO_BATCH, target // max(frame_bytes, 1)))
 
 
 @dataclass
@@ -119,6 +203,12 @@ class HDF5StorageWriter[State, WriterConfig]:
 
     The writer opens the file and starts a background I/O thread on ``__enter__``,
     and flushes, records ``actual_steps``, and closes the file on ``__exit__``.
+
+    The background thread buffers each group's steps and writes them in contiguous
+    blocks to amortise per-write overhead (the dominant cost of single-step writes).
+    The block size is chosen per group so the largest leaf writes about one chunk
+    per flush, bounding the buffer to roughly one chunk regardless of system size;
+    buffers are flushed on ``__exit__``.
     """
 
     out_path: str | Path
@@ -195,6 +285,7 @@ def _init_group_writers[S, WC](
     confs_and_paths, conf_structure = jax.tree.flatten_with_path(
         config, is_leaf=lambda x: isinstance(x, WriterGroupConfig)
     )
+    confs_and_paths: list[tuple[tuple[int, ...], WriterGroupConfig[S, Any]]]
     assert all(isinstance(c[1], WriterGroupConfig) for c in confs_and_paths), (
         "All leaves of WriterConfig must be WriterGroupConfig"
     )
@@ -209,8 +300,17 @@ def _init_group_writers[S, WC](
         group = hdf5_file.create_group(group_name)
         view = jit(group_config.view)
         leading_dims = group_config.logging_frequency.leading_shape(total_steps)
-        writer = Hdf5ObjWriter.init(group, view(state), leading_dims)
-        group_writers.append(GroupWriters(view, group_config.logging_frequency, writer))
+        writer = Hdf5ObjWriter.init(
+            group, view(state), leading_dims, group_config.compression
+        )
+        group_writers.append(
+            GroupWriters(
+                view,
+                group_config.logging_frequency,
+                writer,
+                compression=group_config.compression,
+            )
+        )
         group_names.append(group_name)
     hdf5_file.attrs["group_names"] = json.dumps(group_names)
     return group_writers
@@ -224,7 +324,10 @@ class Hdf5ObjWriter[Storage]:
 
     @staticmethod
     def init[S](
-        hdf5_group: h5py.Group, state: S, leading_dims: tuple[int, ...]
+        hdf5_group: h5py.Group,
+        state: S,
+        leading_dims: tuple[int, ...],
+        compression: Compression | None = None,
     ) -> Hdf5ObjWriter[S]:
         datasets: list[h5py.Dataset] = []
         paths: list[str] = []
@@ -235,8 +338,15 @@ class Hdf5ObjWriter[Storage]:
                 )
             name = "array" + "".join(map(str, path))
             dataset_shape = leading_dims + tensor.shape
+            ds_kwargs: dict[str, Any] = {}
+            if compression is not None:
+                ds_kwargs = compression.dataset_kwargs(
+                    leading_dims, tensor.shape, np.dtype(tensor.dtype).itemsize
+                )
             datasets.append(
-                hdf5_group.create_dataset(name, shape=dataset_shape, dtype=tensor.dtype)
+                hdf5_group.create_dataset(
+                    name, shape=dataset_shape, dtype=tensor.dtype, **ds_kwargs
+                )
             )
             paths.append(name)
         hdf5_group.attrs["data_class_name"] = type(state).__qualname__
@@ -248,6 +358,17 @@ class Hdf5ObjWriter[Storage]:
     def write(self, state: Storage, index: Index) -> None:
         for dataset, value in zip(self.datasets, jax.tree.leaves(state)):
             dataset[index] = np.asarray(value)
+
+    def write_block(self, states: list[Storage], start: int) -> None:
+        """Write a contiguous block of states to ``[start : start + len(states)]``.
+
+        Stacks each leaf across ``states`` and writes one slice per dataset,
+        amortising the per-call overhead of single-step writes.
+        """
+        leaves = [jax.tree.leaves(s) for s in states]
+        stop = start + len(states)
+        for j, dataset in enumerate(self.datasets):
+            dataset[start:stop] = np.stack([np.asarray(step[j]) for step in leaves])
 
 
 @dataclass
@@ -354,11 +475,20 @@ class GroupReader[Storage]:
 
 @dataclass
 class BackgroundWriter[State, WriterConfig]:
-    """Background thread worker that asynchronously writes pre-extracted data to HDF5."""
+    """Background thread worker that asynchronously writes pre-extracted data to HDF5.
+
+    When a group's batch size is >1 its per-step data is buffered and written in
+    contiguous blocks, amortising per-write overhead. Buffers are flushed when full
+    and once more when the thread stops.
+    """
 
     storage_writer: HDF5StorageWriter[State, WriterConfig]
     data_queue: queue.Queue[list[tuple[int, Index, Any]]]
     running: threading.Event
+    # Per-group buffer of (dataset_index, data) pending a block write.
+    _buffers: defaultdict[int, list[tuple[Index, Any]]] = field(
+        default_factory=lambda: defaultdict(list), repr=False
+    )
 
     def start(self) -> None:
         """Main loop for the background writer thread."""
@@ -366,23 +496,52 @@ class BackgroundWriter[State, WriterConfig]:
         while self.running.is_set():
             try:
                 to_log = self.data_queue.get(timeout=1.0)
-                self.storage_writer._write(to_log)
-                self.data_queue.task_done()
             except queue.Empty:
                 continue
+            try:
+                self._buffer(to_log)
             except Exception as e:
                 logging.error(f"Error processing data: {e}")
+            finally:
+                self.data_queue.task_done()
+        self._flush_all()  # drain remaining buffers on shutdown
         logging.info("Writer thread stopped")
 
     def write(self, state: State, step: int) -> None:
         """Queue state data for asynchronous writing to HDF5."""
         self.data_queue.put(self.storage_writer._prepare_write(state, step))
 
-    def stop(self) -> None:
-        """Stop the background writer thread gracefully."""
-        self.flush()
-        self.running.clear()
+    def _buffer(self, to_log: list[tuple[int, Index, Any]]) -> None:
+        group_writers = self.storage_writer._group_writers
+        for i, index, data in to_log:
+            buffer = self._buffers[i]
+            buffer.append((index, data))
+            if len(buffer) >= group_writers[i].batch_size:
+                self._flush_group(i)
 
-    def flush(self) -> None:
-        """Wait for all queued write operations to complete."""
+    def _flush_group(self, i: int) -> None:
+        buffer = self._buffers.get(i)
+        if not buffer:
+            return
+        writer = self.storage_writer._group_writers[i].writer
+        indices = [index for index, _ in buffer]
+        first = indices[0]
+        if (
+            len(buffer) > 1
+            and isinstance(first, int)
+            and all(x == first + k for k, x in enumerate(indices))
+        ):
+            writer.write_block([data for _, data in buffer], first)
+        else:
+            for index, data in buffer:
+                writer.write(data, index)
+        buffer.clear()
+
+    def _flush_all(self) -> None:
+        for i in list(self._buffers):
+            self._flush_group(i)
+
+    def stop(self) -> None:
+        """Drain the queue, then signal the thread to flush buffers and stop."""
         self.data_queue.join()
+        self.running.clear()

--- a/test/core/test_storage.py
+++ b/test/core/test_storage.py
@@ -5,6 +5,7 @@
 
 import tempfile
 
+import h5py
 import jax
 import jax.numpy as jnp
 import numpy.testing as npt
@@ -12,6 +13,7 @@ import pytest
 
 from kups.core.lens import view
 from kups.core.storage import (
+    Compression,
     EveryNStep,
     GroupReader,
     HDF5StorageReader,
@@ -171,8 +173,6 @@ class TestHDF5StorageWriter:
             for i in range(5):
                 writer.log(simple_state, i)
 
-        import h5py
-
         with h5py.File(temp_file, "r") as f:
             assert f.attrs["actual_steps"] == 5
 
@@ -310,3 +310,152 @@ class TestIntegration:
 
             if os.path.exists(nested_path):
                 os.unlink(nested_path)
+
+
+def _array_dataset(group: h5py.Group) -> h5py.Dataset:
+    name = next(k for k in group.keys() if k.startswith("array"))
+    return group[name]  # type: ignore[return-value]
+
+
+class TestCompression:
+    def test_dataset_kwargs_sizing(self):
+        """Per-leaf chunk sizing: time-axis target, scalars uncompressed."""
+        c = Compression(target_chunk_bytes=1 << 20)
+        # Large per-frame array: chunk holds target_bytes // frame_bytes frames.
+        kw = c.dataset_kwargs((1000,), (1326, 3), itemsize=8)
+        assert kw["chunks"] == ((1 << 20) // (1326 * 3 * 8), 1326, 3)
+        assert kw == {
+            **kw,
+            "compression": "gzip",
+            "compression_opts": 4,
+            "shuffle": True,
+        }
+        # Scalar-per-step: single chunk spanning the whole time axis.
+        assert c.dataset_kwargs((1000,), (), itemsize=8)["chunks"] == (1000,)
+        # Logged once (no time axis): one chunk spanning the whole array.
+        assert c.dataset_kwargs((), (4, 3), itemsize=8)["chunks"] == (4, 3)
+        # Rank-0 scalar: cannot chunk, so uncompressed.
+        assert c.dataset_kwargs((), (), itemsize=8) == {}
+
+    def test_lzf_has_no_level(self):
+        kw = Compression(codec="lzf").dataset_kwargs((10,), (5,), itemsize=8)
+        assert kw["compression"] == "lzf"
+        assert "compression_opts" not in kw
+
+    def test_roundtrip_and_filters_applied(self, temp_file: str):
+        """Default compression round-trips and lands gzip+shuffle+chunks on datasets."""
+        state = SimpleState(
+            position=jnp.zeros((64, 3)), velocity=jnp.zeros((64, 3)), energy=1.0
+        )
+        config = WriterGroupConfig(
+            view=view(lambda s: {"pos": s.position}),
+            logging_frequency=EveryNStep(1),
+        )  # default compression == Compression() (gzip + shuffle)
+        writer = HDF5StorageWriter(temp_file, config, state, total_steps=20)
+        with writer:
+            for i in range(20):
+                writer.log(SimpleState(state.position + i, state.velocity, 1.0), i)
+
+        with HDF5StorageReader(temp_file) as reader:
+            pos = reader.focus_group("group")[:]["pos"]
+            assert pos.shape == (20, 64, 3)
+            npt.assert_array_equal(pos[7], state.position + 7)
+
+        with h5py.File(temp_file, "r") as f:
+            ds = _array_dataset(f["group"])  # type: ignore[arg-type]
+            assert ds.compression == "gzip"
+            assert ds.shuffle is True
+            assert ds.chunks is not None and ds.chunks[0] >= 1
+
+    def test_compression_none_is_contiguous(
+        self, simple_state: SimpleState, temp_file: str
+    ):
+        config = WriterGroupConfig(
+            view=view(lambda s: {"pos": s.position}),
+            logging_frequency=EveryNStep(1),
+            compression=None,
+        )
+        writer = HDF5StorageWriter(temp_file, config, simple_state, total_steps=5)
+        with writer:
+            for i in range(5):
+                writer.log(simple_state, i)
+
+        with h5py.File(temp_file, "r") as f:
+            ds = _array_dataset(f["group"])  # type: ignore[arg-type]
+            assert ds.compression is None
+            assert ds.chunks is None
+
+
+class TestAutoBatching:
+    def test_auto_batch_size_property(self, temp_file: str):
+        """GroupWriters.batch_size derives from datasets + compression."""
+        from kups.core.storage import _MAX_AUTO_BATCH
+
+        state = SimpleState(
+            position=jnp.zeros((3000,)), velocity=jnp.zeros((1,)), energy=0.0
+        )
+        expected = (1 << 20) // (state.position.dtype.itemsize * 3000)
+        assert 1 < expected < _MAX_AUTO_BATCH
+
+        # Large per-frame leaf: the chunk-fitting formula binds.
+        cfg = WriterGroupConfig(view(lambda s: {"p": s.position}), EveryNStep(1))
+        with HDF5StorageWriter(temp_file, cfg, state, total_steps=2000) as w:
+            assert w._group_writers[0].batch_size == expected
+
+        # Tiny per-frame leaf: the cap binds.
+        cfg = WriterGroupConfig(view(lambda s: {"e": s.velocity}), EveryNStep(1))
+        with HDF5StorageWriter(temp_file, cfg, state, total_steps=2000) as w:
+            assert w._group_writers[0].batch_size == _MAX_AUTO_BATCH
+
+        # Logged once (no time axis): no batching.
+        cfg = WriterGroupConfig(view(lambda s: {"p": s.position}), Once())
+        with HDF5StorageWriter(temp_file, cfg, state, total_steps=2000) as w:
+            assert w._group_writers[0].batch_size == 1
+
+    def test_auto_batched_roundtrip_multiblock(self, temp_file: str):
+        """Large frames force a small auto batch -> multiple blocks + a partial tail."""
+        n = 60_000  # frame is a big fraction of the 1 MiB target -> batch < num_steps
+        state = SimpleState(
+            position=jnp.zeros((n,)), velocity=jnp.zeros((1,)), energy=0.0
+        )
+        config = WriterGroupConfig(
+            view=view(lambda s: {"pos": s.position}),
+            logging_frequency=EveryNStep(1),
+        )
+        writer = HDF5StorageWriter(temp_file, config, state, total_steps=10)
+        with writer:
+            for i in range(10):
+                writer.log(SimpleState(state.position + i, state.velocity, 0.0), i)
+
+        with HDF5StorageReader(temp_file) as reader:
+            pos = reader.focus_group("group")[:]["pos"]
+            assert pos.shape == (10, n)
+            for i in (0, 4, 9):
+                npt.assert_array_equal(pos[i], state.position + i)
+
+    def test_auto_handles_mixed_once_and_every_n(self, temp_file: str):
+        """Auto batching coexists with a Once group (single Ellipsis-indexed write)."""
+        state = SimpleState(
+            position=jnp.zeros((3,)), velocity=jnp.zeros((3,)), energy=0.0
+        )
+        config = {
+            "traj": WriterGroupConfig(
+                view=view(lambda s: {"pos": s.position}),
+                logging_frequency=EveryNStep(1),
+            ),
+            "init": WriterGroupConfig(
+                view=view(lambda s: {"pos": s.position}),
+                logging_frequency=Once(),
+            ),
+        }
+        writer = HDF5StorageWriter(temp_file, config, state, total_steps=7)
+        with writer:
+            for i in range(7):
+                writer.log(SimpleState(state.position + i, state.velocity, 0.0), i)
+
+        with HDF5StorageReader(temp_file) as reader:
+            traj = reader.focus_group("group['traj']")[:]["pos"]
+            assert traj.shape == (7, 3)
+            npt.assert_array_equal(traj[6], state.position + 6)
+            init = reader.focus_group("group['init']")[...]["pos"]
+            npt.assert_array_equal(init, state.position)


### PR DESCRIPTION
## Add per-group HDF5 compression and auto-batched block writes

Introduces a `Compression` dataclass that controls chunking and compression on a per-group basis, and replaces single-step HDF5 writes with buffered block writes to reduce per-write overhead.

### Compression policy (`Compression`)

- Accepts `codec` (`"gzip"` or `"lzf"`), `level`, `shuffle`, and `target_chunk_bytes`.
- Computes chunk shapes along the leading time axis so each chunk targets approximately `target_chunk_bytes`: large per-frame arrays get single- or few-frame chunks (keeping random-access cheap), while small fields get many-frame chunks (capturing cross-step redundancy). Rank-0 scalars are stored uncompressed and unchunked.
- `lzf` codec omits `compression_opts` since it has no level parameter.
- `WriterGroupConfig` gains a `compression` field defaulting to `Compression()` (gzip level 4 + shuffle). Pass `compression=None` for contiguous, uncompressed datasets.

### Auto-batched block writes

- `GroupWriters` gains a `batch_size` cached property that sizes the write buffer so the largest leaf writes approximately one chunk per flush, capped at `_MAX_AUTO_BATCH` (128) so small-frame groups still flush periodically. Groups logged with `Once` always use `batch_size=1`.
- `Hdf5ObjWriter.write_block` stacks a list of states and writes them as a single contiguous slice per dataset, amortising per-call overhead.
- `BackgroundWriter` buffers incoming steps per group and calls `write_block` when the buffer reaches `batch_size`. Contiguous index sequences are detected and written as a block; non-contiguous indices fall back to single-step writes. All buffers are flushed on thread shutdown.

In our mcmc_rigid.yaml example, this reduces the file log from 1.4GB to 6MB. I tested mcmc_rigid.yaml and an MD simulation with LJ (>400it/s) and found no runtime regression.

Closes #177