### PR TITLE
refactor: Merge `relax` config into `run`, remove `RelaxParameters`

### DIFF
--- a/examples/relax_mace.yaml
+++ b/examples/relax_mace.yaml
@@ -1,7 +1,11 @@
 inp_files:
   - host/RUBTAK.cif
 model_path: hf://CuspAI/kUPS-mace-jax/mace-mpa-0-medium_32.zip
-relax:
+run:
+  out_file: relax_mace.h5
+  max_steps: 1000
+  force_tolerance: 0.001   # eV/Å
+  seed: null
   optimizer:
     - transform: scale_by_ase_lbfgs
       memory_size: 100
@@ -10,9 +14,4 @@ relax:
       max_step_size: 0.2
     - transform: scale
       step_size: -1
-  optimize_cell: false
-run:
-  out_file: relax_mace.h5
-  max_steps: 1000
-  force_tolerance: 0.001   # eV/Å
-  seed: null
+  optimize_cell: true

--- a/examples/relax_orb.yaml
+++ b/examples/relax_orb.yaml
@@ -1,7 +1,11 @@
 inp_files:
   - host/RUBTAK.cif
 model_path: hf://CuspAI/kUPS-orb-jax/orb_v3_conservative_inf_omat.zip
-relax:
+run:
+  out_file: relax_orb.h5
+  max_steps: 1000
+  force_tolerance: 0.001   # eV/Å
+  seed: null
   optimizer:
     - transform: scale_by_ase_lbfgs
       memory_size: 100
@@ -11,8 +15,3 @@ relax:
     - transform: scale
       step_size: -1
   optimize_cell: false
-run:
-  out_file: relax_orb.h5
-  max_steps: 1000
-  force_tolerance: 0.001   # eV/Å
-  seed: null

--- a/examples/relax_torch_mace.yaml
+++ b/examples/relax_torch_mace.yaml
@@ -5,7 +5,11 @@ model:
   model_path: ./mace-mpa-0-medium.model
   device: cuda
   dtype: float32
-relax:
+run:
+  out_file: relax_torch_mace.h5
+  max_steps: 1000
+  force_tolerance: 0.001   # eV/Å
+  seed: null
   optimizer:
     - transform: scale_by_ase_lbfgs
       memory_size: 100
@@ -15,8 +19,3 @@ relax:
     - transform: scale
       step_size: -1
   optimize_cell: false
-run:
-  out_file: relax_torch_mace.h5
-  max_steps: 1000
-  force_tolerance: 0.001   # eV/Å
-  seed: null

--- a/examples/relax_torch_uma.yaml
+++ b/examples/relax_torch_uma.yaml
@@ -6,7 +6,11 @@ model:
   device: cuda
   task_name: omat            # one of: omat, omol, oc20, odac, omc
   inference_settings: turbo  # one of: default, turbo
-relax:
+run:
+  out_file: relax_torch_uma.h5
+  max_steps: 1000
+  force_tolerance: 0.001   # eV/Å
+  seed: null
   optimizer:
     - transform: scale_by_ase_lbfgs
       memory_size: 100
@@ -16,8 +20,3 @@ relax:
     - transform: scale
       step_size: -1
   optimize_cell: false
-run:
-  out_file: relax_torch_uma.h5
-  max_steps: 1000
-  force_tolerance: 0.001   # eV/Å
-  seed: null

--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -76,11 +76,6 @@ class RelaxRunConfig(BaseModel):
     """Random seed. None for time-based."""
     force_tolerance: float
     """Convergence threshold for max atomic force (eV/Å)."""
-
-
-class RelaxParameters(BaseModel):
-    """Optimiser configuration for relaxation."""
-
     optimizer: TransformationConfig
     """List of Optax transform specifications passed to `make_optimizer`."""
     optimize_cell: bool

--- a/src/kups/application/relaxation/simulation.py
+++ b/src/kups/application/relaxation/simulation.py
@@ -195,9 +195,10 @@ def run_relax[State: IsRelaxState](
         cell = s.systems.data.cell
         cell_grad = cell.frame.vectors_gradient(s.systems.data.cell_gradients.frame)
         max_cell_grad = jnp.max(jnp.abs(cell_grad))
-        return (max_force < config.force_tolerance) & (
-            max_cell_grad < config.force_tolerance
-        )
+        result = max_force < config.force_tolerance
+        if config.optimize_cell:
+            result = result & (max_cell_grad < config.force_tolerance)
+        return result
 
     def converged(s: State) -> bool:
         return bool(converged_value(s))

--- a/src/kups/application/simulations/relax_lj.py
+++ b/src/kups/application/simulations/relax_lj.py
@@ -19,7 +19,6 @@ from pydantic import BaseModel
 
 from kups.application.relaxation.analysis import analyze_relax_file
 from kups.application.relaxation.data import (
-    RelaxParameters,
     RelaxParticles,
     RelaxRunConfig,
     RelaxSystems,
@@ -59,7 +58,6 @@ class Config(BaseModel):
     """Top-level configuration for LJ relaxation."""
 
     run: RelaxRunConfig
-    relax: RelaxParameters
     lj: LjConfig
     inp_file: str | Path
 
@@ -115,12 +113,12 @@ def run(config: Config) -> None:
     """
     key = jax.random.key(config.run.seed or time.time_ns())
     state_lens = identity_lens(RelaxLjState)
-    optimizer = make_optimizer(config.relax.optimizer)
+    optimizer = make_optimizer(config.run.optimizer)
     potential = make_lennard_jones_from_state(
         state_lens, compute_position_and_cell_gradients=True
     )
     propagator, opt_init = make_relax_propagator(
-        state_lens, potential, optimizer, config.relax.optimize_cell
+        state_lens, potential, optimizer, config.run.optimize_cell
     )
     state = init_state(config, opt_init)
     logging.info("Starting relaxation")

--- a/src/kups/application/simulations/relax_mlff.py
+++ b/src/kups/application/simulations/relax_mlff.py
@@ -20,7 +20,6 @@ from pydantic import BaseModel
 
 from kups.application.relaxation.analysis import analyze_relax_file
 from kups.application.relaxation.data import (
-    RelaxParameters,
     RelaxParticles,
     RelaxRunConfig,
     RelaxSystems,
@@ -53,7 +52,6 @@ logging.basicConfig(
 
 class Config(BaseModel):
     run: RelaxRunConfig
-    relax: RelaxParameters
     inp_files: tuple[str | Path, ...]
     model_path: str | Path
 
@@ -110,12 +108,12 @@ def run(config: Config) -> None:
     """
     key = jax.random.key(config.run.seed or time.time_ns())
     state_lens = identity_lens(RelaxMlffState)
-    optimizer = make_optimizer(config.relax.optimizer)
+    optimizer = make_optimizer(config.run.optimizer)
     potential = make_tojaxed_from_state(
         state_lens, compute_position_and_cell_gradients=True
     )
     propagator, opt_init = make_relax_propagator(
-        state_lens, potential, optimizer, config.relax.optimize_cell
+        state_lens, potential, optimizer, config.run.optimize_cell
     )
     state = init_state(config, opt_init)
     logging.info("Starting relaxation")

--- a/src/kups/application/simulations/relax_torch.py
+++ b/src/kups/application/simulations/relax_torch.py
@@ -21,7 +21,6 @@ from pydantic import BaseModel, Field
 
 from kups.application.relaxation.analysis import analyze_relax_file
 from kups.application.relaxation.data import (
-    RelaxParameters,
     RelaxParticles,
     RelaxRunConfig,
     RelaxSystems,
@@ -85,7 +84,6 @@ class Config(BaseModel):
     """Top-level configuration for torch-MLFF relaxation runs."""
 
     run: RelaxRunConfig
-    relax: RelaxParameters
     inp_files: tuple[str | Path, ...]
     model: ModelConfig
 
@@ -153,12 +151,12 @@ def run(config: Config) -> None:
     """Run a torch-MLFF relaxation."""
     key = jax.random.key(config.run.seed or time.time_ns())
     state_lens = identity_lens(RelaxTorchState)
-    optimizer = make_optimizer(config.relax.optimizer)
+    optimizer = make_optimizer(config.run.optimizer)
     potential = make_torch_mliap_from_state(
         state_lens, compute_position_and_cell_gradients=True
     )
     propagator, opt_init = make_relax_propagator(
-        state_lens, potential, optimizer, config.relax.optimize_cell
+        state_lens, potential, optimizer, config.run.optimize_cell
     )
     state = init_state(config, opt_init)
     logging.info("Starting relaxation")

--- a/test/application/test_relax_lj.py
+++ b/test/application/test_relax_lj.py
@@ -12,7 +12,7 @@ import numpy.testing as npt
 import pytest
 
 from kups.application.relaxation.analysis import analyze_relax_file
-from kups.application.relaxation.data import RelaxParameters, RelaxRunConfig
+from kups.application.relaxation.data import RelaxRunConfig
 from kups.application.relaxation.simulation import make_relax_propagator
 from kups.application.simulations.relax_lj import (
     Config,
@@ -70,9 +70,10 @@ def _tmp_h5() -> str:
 def _config(out_file: str, inp_file: str, *, optimize_cell: bool = False) -> Config:
     return Config(
         run=RelaxRunConfig(
-            out_file=out_file, max_steps=5, seed=42, force_tolerance=0.5
-        ),
-        relax=RelaxParameters(
+            out_file=out_file,
+            max_steps=5,
+            seed=42,
+            force_tolerance=0.5,
             optimizer=[
                 {"transform": "scale_by_ase_lbfgs", "memory_size": 10, "alpha": 70},
                 {"transform": "max_step_size", "max_step_size": 0.2},
@@ -112,7 +113,7 @@ def _build_propagator(optimize_cell: bool):
     """Build an LJ relaxation propagator and its initial state."""
     config = _config(_tmp_h5(), _ar_cif(rattle=0.1), optimize_cell=optimize_cell)
     state_lens = identity_lens(RelaxLjState)
-    optimizer = make_optimizer(config.relax.optimizer)
+    optimizer = make_optimizer(config.run.optimizer)
     potential = make_lennard_jones_from_state(
         state_lens, compute_position_and_cell_gradients=True
     )


### PR DESCRIPTION
The `relax` configuration block has been merged into the `run` block, eliminating the separate `RelaxParameters` model. Optimizer and `optimize_cell` settings are now specified directly under `run` in all config files and simulation entry points.

Additionally, the convergence check in `run_relax` has been fixed so that cell gradient convergence is only required when `optimize_cell` is `True`. Previously, cell gradients were always checked regardless of whether cell optimization was enabled, which could prevent convergence in fixed-cell relaxations.

The `relax_mace.yaml` example has also been updated to use `optimize_cell: true`.