### PR TITLE
feat: Add neutralizing-background correction for non-charge-neutral Ewald systems

### DIFF
--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -11,6 +11,7 @@ updates via cached structure factors for efficient Monte Carlo.
 from __future__ import annotations
 
 import functools
+import warnings
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -588,15 +589,40 @@ def structure_factor[State](
     return sk, patch
 
 
+def ewald_net_charge_energy(inp: EwaldLongRangeInput[Any]) -> Table[SystemId, Energy]:
+    """Neutralizing-background correction for systems with nonzero net charge.
+
+    Math: ``E_net = -(pi / (2 * V * alpha^2)) * Q^2 * TO_STANDARD_UNITS`` where
+    ``Q = sum_i q_i`` is the per-system net charge and ``V`` the cell volume.
+
+    Replaces the omitted (divergent) ``k = 0`` term of the reciprocal sum with a
+    uniform neutralizing background, restoring independence of the total energy
+    from ``alpha``. Vanishes for charge-neutral systems. Position-independent (no
+    forces) but volume-dependent, so it contributes to the virial/pressure.
+    """
+    particles = inp.point_cloud.particles.data
+    sys_idx = inp.point_cloud.systems.index
+    net_charge = jax.ops.segment_sum(
+        particles.charges,
+        particles.system.indices,
+        inp.point_cloud.batch_size,
+        mode="drop",
+    )
+    alpha = inp.parameters.alpha[sys_idx]
+    energies = -jnp.pi / (2 * inp.volume * alpha**2) * net_charge**2 * TO_STANDARD_UNITS
+    return Table.arange(energies, label=SystemId)
+
+
 def ewald_long_range_energy[State](
     inp: EwaldLongRangeInput[State],
 ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
     """Reciprocal-space (long-range) Ewald energy.
 
-    Math: ``E_lr = TO_STANDARD_UNITS * sum_k P(k) * |S(k)|^2``.
+    Math: ``E_lr = TO_STANDARD_UNITS * sum_k P(k) * |S(k)|^2 + E_net``.
 
-    Wraps ``structure_factor`` + ``long_range`` and returns a cache patch
-    for structure factor updates on MC accept/reject.
+    Wraps ``structure_factor`` + ``long_range``, adds the neutralizing-background
+    correction (``ewald_net_charge_energy``) for nonzero net charge, and returns a
+    cache patch for structure factor updates on MC accept/reject.
     """
     structure_out, patch = structure_factor(inp)
     energy = long_range(inp, structure_out)
@@ -604,7 +630,8 @@ def ewald_long_range_energy[State](
         f"Expected energy shape {(inp.point_cloud.batch_size,)} but got {energy.shape}."
     )
     energy = energy * TO_STANDARD_UNITS
-    return WithPatch(Table.arange(energy, label=SystemId), patch)
+    total = ewald_net_charge_energy(inp).map_data(lambda e_net: e_net + energy)
+    return WithPatch(total, patch)
 
 
 @dataclass
@@ -1222,6 +1249,13 @@ def estimate_ewald_parameters(
     # Note: only runs on a single system, not a batch of systems.
     # Input validation
     charges_np = np.asarray(charges)
+    net_charge = float(charges_np.astype(np.float64).sum())
+    if abs(net_charge) > 1e-6:
+        warnings.warn(
+            f"System is not charge neutral (net charge {net_charge:.4g} e); "
+            "the neutralizing-background correction will be applied.",
+            stacklevel=2,
+        )
     volume = np.asarray(cell.volume)
     Q2 = np.vdot(charges_np, charges_np)
     N = charges.size

--- a/test/potential/test_ewald.py
+++ b/test/potential/test_ewald.py
@@ -28,9 +28,11 @@ from kups.potential.classical.ewald import (
     EwaldParameters,
     estimate_ewald_parameters,
     ewald_long_range_energy,
+    ewald_net_charge_energy,
     ewald_self_interaction_energy,
     ewald_short_range_energy,
     kvecs_from_kmax,
+    prefactor,
 )
 from kups.potential.common.graph import GraphPotentialInput, HyperGraph, PointCloud
 
@@ -338,6 +340,88 @@ class TestEwald:
             total_energy[0] / TO_STANDARD_UNITS,
             rtol=eps,
         )
+
+    def test_net_charge_energy_closed_form(self):
+        """E_net matches -(pi / (2 V alpha^2)) * Q^2 in standard units."""
+        L = 10.0
+        positions = jnp.array([[0.0, 0.0, 0.0], [3.0, 3.0, 3.0], [6.0, 6.0, 6.0]])
+        charges = jnp.array([1.0, 1.0, 0.5])  # Q = 2.5
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3, dtype=float) * L))
+        alpha = 0.4
+        params = EwaldParameters(
+            alpha=Table((SystemId(0),), jnp.array([alpha])),
+            cutoff=Table((SystemId(0),), jnp.array([5.0])),
+            # net-charge term ignores k-vectors; a dummy shift suffices.
+            reciprocal_lattice_shifts=Table(
+                (SystemId(0),), jnp.zeros((1, 1, 3), dtype=int)
+            ),
+        )
+        pdata = _make_particle_data(positions, charges, n_systems=1)
+        particles = Table.arange(pdata, label=ParticleId)
+        systems = _make_systems(cell[None], jnp.array([5.0]))
+        inp = EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+
+        e_net = ewald_net_charge_energy(inp).data[0]
+        Q, V = 2.5, L**3
+        expected = -jnp.pi / (2 * V * alpha**2) * Q**2 * TO_STANDARD_UNITS
+        npt.assert_allclose(e_net, expected, rtol=1e-6)
+
+    def test_zero_kvector_excluded(self):
+        """The k=0 reciprocal mode is excluded (prefactor 0); net charge replaces it."""
+        L = 10.0
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3, dtype=float) * L))
+        shifts = jnp.array([[[0, 0, 0], [1, 0, 0], [1, 1, 0]]])  # (0,0,0) first
+        params = EwaldParameters(
+            alpha=Table((SystemId(0),), jnp.array([0.4])),
+            cutoff=Table((SystemId(0),), jnp.array([5.0])),
+            reciprocal_lattice_shifts=Table((SystemId(0),), shifts),
+        )
+        pdata = _make_particle_data(jnp.zeros((1, 3)), jnp.array([1.0]), n_systems=1)
+        particles = Table.arange(pdata, label=ParticleId)
+        systems = _make_systems(cell[None], jnp.array([5.0]))
+        inp = EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+
+        pref = prefactor(inp)
+        npt.assert_array_equal(pref[0, 0], jnp.asarray(0.0))
+        assert bool(jnp.all(pref[0, 1:] > 0))
+
+    def test_net_charge_total_energy_alpha_stable(self):
+        """For Q != 0 the total energy is finite and ~independent of alpha.
+
+        The neutralizing-background correction restores alpha-independence of the
+        total Ewald energy; doubling alpha leaves the (converged) total unchanged.
+        """
+        L = 12.0
+        positions = jnp.array([[0.0, 0.0, 0.0], [6.0, 6.0, 6.0]])
+        charges = jnp.array([1.0, 1.0])  # Q = 2, non-neutral
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3, dtype=float) * L))
+
+        rc = 5.0
+        kvecs = kvecs_from_kmax(cell, 6.0)  # large enough for alpha up to 1.0
+        pdata = _make_particle_data(positions, charges, n_systems=1)
+        particles = Table.arange(pdata, label=ParticleId)
+        systems = _make_systems(cell[None], jnp.array([rc]))
+        edges = _build_neighborlist(particles, systems, len(charges))
+        graph = HyperGraph(particles=particles, systems=systems, edges=edges)
+
+        def total_energy(alpha: float) -> Array:
+            params = EwaldParameters(
+                alpha=Table((SystemId(0),), jnp.array([alpha])),
+                cutoff=Table((SystemId(0),), jnp.array([rc])),
+                reciprocal_lattice_shifts=Table((SystemId(0),), kvecs[None]),
+            )
+            sr_inp = GraphPotentialInput(params, graph)
+            lr_inp = EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+            return (
+                ewald_short_range_energy(sr_inp).data.data[0]
+                + ewald_long_range_energy(lr_inp).data.data[0]
+                + ewald_self_interaction_energy(sr_inp).data.data[0]
+            )
+
+        e_lo = total_energy(0.5)
+        e_hi = total_energy(1.0)  # alpha doubled
+        assert bool(jnp.isfinite(e_lo)) and bool(jnp.isfinite(e_hi))
+        npt.assert_allclose(e_lo, e_hi, atol=5e-3, rtol=1e-3)
 
 
 class TestEwaldParametersMake:


### PR DESCRIPTION
Adds a neutralizing-background correction to the Ewald long-range energy for systems with nonzero net charge. The omitted `k = 0` reciprocal term is replaced by `E_net = -(π / (2Vα²)) * Q²`, which restores α-independence of the total energy and prevents divergence. This correction is position-independent and contributes to the virial/pressure.

`ewald_net_charge_energy` is introduced as a standalone function and is automatically included in `ewald_long_range_energy`. A warning is emitted from `estimate_ewald_parameters` when a non-neutral system is detected.

Tests verify the closed-form expression for `E_net`, confirm that the `k = 0` prefactor is zero (so the correction is not double-counted), and check that the total Ewald energy is finite and α-stable for a non-neutral two-particle system.