### PR TITLE
feat: Add `FrechetFrame` and `triangular_3x3_expm` for ASE-style cell relaxation

### DIFF
--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -17,9 +17,10 @@ from kups.application.utils.particles import (
     default_exclusion,
     particles_from_ase,
 )
-from kups.core.cell import AnyPeriodicity, Cell
+from kups.core.cell import AnyPeriodicity, Cell, FrechetFrame
 from kups.core.data import Table
 from kups.core.data.index import Index
+from kups.core.lens import bind
 from kups.core.typing import ExclusionId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass, field, tree_zeros_like
 from kups.relaxation.config import TransformationConfig
@@ -105,6 +106,12 @@ def relax_state_from_ase(
             system=p.data.system,
             position_gradients=jnp.zeros_like(p.data.positions),
         ),
+    )
+    # cell_factor = atom count (ASE's exp_cell_factor) balances the extensive
+    # cell-virial gradient against the per-atom forces in the joint optimiser.
+    n_atoms = float(p.data.positions.shape[0])
+    cell = bind(cell, lambda x: x.frame).apply(
+        lambda f: FrechetFrame.from_frame(f, cell_factor=n_atoms)
     )
     cell = cell[None]
     systems = Table.arange(

--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -119,13 +119,13 @@ import jax.numpy as jnp
 import numpy as np
 from jax import Array
 from jax.flatten_util import ravel_pytree
-from jax.scipy.linalg import expm
 
 from kups.core.data import Sliceable
 from kups.core.lens import Lens, bind
 from kups.core.utils.jax import dataclass, field
 from kups.core.utils.math import (
     triangular_3x3_det_and_inverse,
+    triangular_3x3_expm,
     triangular_3x3_from_tril,
     triangular_3x3_logm,
     triangular_3x3_matmul,
@@ -568,6 +568,10 @@ class LogTriclinicFrame(BaseFrame, Sliceable):
     tril: Array
 
     @classmethod
+    def from_frame(cls, frame: Frame) -> Self:
+        return cls.from_matrix(frame.vectors)
+
+    @classmethod
     @override
     def from_matrix(cls, vecs: Array) -> Self:
         """Construct from a lower-triangular basis matrix ``L`` (positive
@@ -578,7 +582,7 @@ class LogTriclinicFrame(BaseFrame, Sliceable):
     @property
     @override
     def vectors(self) -> Array:
-        return expm(triangular_3x3_from_tril(self.tril))
+        return triangular_3x3_expm(triangular_3x3_from_tril(self.tril))
 
     @property
     @override
@@ -601,6 +605,76 @@ class LogTriclinicFrame(BaseFrame, Sliceable):
         log_scale = jnp.log(jnp.asarray(other))[..., None]
         diagonal = jnp.array([1.0, 0.0, 1.0, 0.0, 0.0, 1.0])
         return type(self)(self.tril + log_scale * diagonal)
+
+
+@dataclass
+class FrechetFrame(BaseFrame, Sliceable):
+    """Triclinic [Frame][kups.core.cell.Frame] parameterised as a
+    matrix-exponential deformation of a fixed reference frame, after ASE's
+    ``FrechetCellFilter``.
+
+    ``vectors`` is the reference ``base`` right-multiplied by
+    ``expm(A / cell_factor)`` for a lower-triangular ``A`` (its 6 stored
+    elements). Right-multiplication deforms Cartesian space, so ``vectors`` stays
+    lower-triangular and atoms ride the cell at fixed fractional coordinates. The
+    map is unconstrained -- any ``A`` gives a positive-volume basis -- so cell
+    relaxation in ``A`` cannot collapse or invert the cell. ``vectors`` is
+    nonlinear in the parameters, so like
+    [LogTriclinicFrame][kups.core.cell.LogTriclinicFrame] the gradient maps use
+    the general inverse-Jacobian path on [BaseFrame][kups.core.cell.BaseFrame].
+
+    Attributes:
+        tril: Lower-triangular elements ``[A00, A10, A11, A20, A21, A22]`` of
+            ``A``, shape ``(..., 6)``.
+        base: Reference frame; ``A = 0`` reproduces it. Held fixed
+            (stop-gradient) so only ``A`` is optimised.
+        cell_factor: Static stiffening factor (ASE's ``exp_cell_factor``,
+            typically the atom count) scaling the cell gradient by
+            ``1 / cell_factor`` to balance it against the per-atom forces.
+    """
+
+    tril: Array
+    base: Frame
+    cell_factor: float = field(default=1.0, static=True)
+
+    @classmethod
+    def from_frame(cls, frame: Frame, *, cell_factor: float = 1.0) -> Self:
+        return cls(
+            jnp.zeros(frame.vectors.shape[:-2] + (6,), frame.vectors.dtype),
+            frame,
+            cell_factor,
+        )
+
+    @classmethod
+    @override
+    def from_matrix(cls, vecs: Array) -> Self:
+        base = TriclinicFrame.from_matrix(vecs)
+        return cls(jnp.zeros(base.tril.shape, base.tril.dtype), base)
+
+    @property
+    def _base_vectors(self) -> Array:
+        return jax.lax.stop_gradient(self.base.vectors)
+
+    @property
+    @override
+    def vectors(self) -> Array:
+        A = triangular_3x3_from_tril(self.tril)
+        exp_A = triangular_3x3_expm(A / self.cell_factor)
+        # Right-multiply: deform Cartesian space (v -> v @ expm(A/cell_factor)), so
+        # atoms at fixed fractional coordinates ride the cell by the same factor.
+        return self._base_vectors @ exp_A
+
+    @override
+    def tile(self, multiplicities: tuple[int, int, int]) -> Self:
+        # Per-axis row scaling acts on the left of ``vectors`` and has no closed
+        # form in ``A`` (the right factor), so apply it to the reference base.
+        return type(self)(self.tril, self.base.tile(multiplicities), self.cell_factor)
+
+    @override
+    def __mul__(self, other: Array | float | int) -> Self:
+        # Uniform scaling commutes with the right factor: ``s * (base @ expm) ==
+        # (s * base) @ expm``, so scale the base and leave ``A`` untouched.
+        return type(self)(self.tril, self.base * other, self.cell_factor)
 
 
 @dataclass

--- a/src/kups/core/utils/math.py
+++ b/src/kups/core/utils/math.py
@@ -215,6 +215,73 @@ def _ddlog2(x: Array, y: Array, z: Array) -> Array:
     return jnp.where(diff == 0.0, confluent, generic)
 
 
+def _ddexp(x: Array, y: Array) -> Array:
+    """First divided difference of ``exp``: ``(exp x - exp y) / (x - y)``,
+    with the confluent limit ``exp x`` as ``y -> x``. Gradient-safe at ``x == y``."""
+    diff = x - y
+    safe = jnp.where(diff == 0.0, 1.0, diff)
+    return jnp.where(diff == 0.0, jnp.exp(x), (jnp.exp(x) - jnp.exp(y)) / safe)
+
+
+def _ddexp2(x: Array, y: Array, z: Array) -> Array:
+    """Second divided difference of ``exp`` (symmetric in its arguments), with
+    confluent limits when the outer pair or all three coincide."""
+    diff = x - z
+    safe = jnp.where(diff == 0.0, 1.0, diff)
+    generic = (_ddexp(x, y) - _ddexp(y, z)) / safe
+    # x == z: by symmetry exp[x, y, x] = exp[x, x, y] = (exp x - exp[x, y]) / (x - y),
+    # whose own y -> x limit is f''(x) / 2 = exp(x) / 2.
+    diff_xy = x - y
+    safe_xy = jnp.where(diff_xy == 0.0, 1.0, diff_xy)
+    confluent = jnp.where(
+        diff_xy == 0.0, 0.5 * jnp.exp(x), (jnp.exp(x) - _ddexp(x, y)) / safe_xy
+    )
+    return jnp.where(diff == 0.0, confluent, generic)
+
+
+def triangular_3x3_expm(A: Array, *, lower: bool = True) -> Array:
+    r"""Matrix exponential of triangular 3×3 matrices.
+
+    Closed form from the fact that ``B`` and ``A = expm(B)`` commute: the diagonal
+    of ``A`` is ``exp`` of ``B``'s diagonal, and the off-diagonal couplings are
+    divided differences of ``exp`` over the diagonal entries. Using divided
+    differences keeps repeated diagonal entries (e.g. cubic / tetragonal cells)
+    well-conditioned.
+
+    Real and gradient-safe inverse of
+    [triangular_3x3_logm][kups.core.utils.math.triangular_3x3_logm]; agrees with
+    ``jax.scipy.linalg.expm`` on triangular matrices but avoids its Padé
+    scaling-and-squaring iteration.
+
+    Args:
+        A: Array of shape `(..., 3, 3)` containing triangular matrices.
+        lower: Whether matrices are lower (True) or upper (False) triangular.
+
+    Returns:
+        Array of shape `(..., 3, 3)` containing the triangular exponentials.
+    """
+    M = A if lower else jnp.swapaxes(A, -1, -2)
+    d0, d1, d2 = M[..., 0, 0], M[..., 1, 1], M[..., 2, 2]
+    a, b, c = M[..., 1, 0], M[..., 2, 0], M[..., 2, 1]
+    zero = jnp.zeros_like(d0)
+    out = jnp.stack(
+        [
+            jnp.stack([jnp.exp(d0), zero, zero], axis=-1),
+            jnp.stack([a * _ddexp(d0, d1), jnp.exp(d1), zero], axis=-1),
+            jnp.stack(
+                [
+                    b * _ddexp(d0, d2) + a * c * _ddexp2(d0, d1, d2),
+                    c * _ddexp(d1, d2),
+                    jnp.exp(d2),
+                ],
+                axis=-1,
+            ),
+        ],
+        axis=-2,
+    )
+    return out if lower else jnp.swapaxes(out, -1, -2)
+
+
 def triangular_3x3_logm(A: Array, *, lower: bool = True) -> Array:
     r"""Principal matrix logarithm of triangular 3×3 matrices with positive diagonal.
 

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -16,6 +16,7 @@ from kups.core.cell import (
     Cell,
     CoordinateSpace,
     Frame,
+    FrechetFrame,
     LinearFrame,
     LogTriclinicFrame,
     MaterializedFrame,
@@ -716,6 +717,7 @@ _LINEAR_FRAME_CLASSES = [
 _GRAD_FRAME_CLASSES = [
     *_LINEAR_FRAME_CLASSES,
     pytest.param(LogTriclinicFrame, id="log_triclinic"),
+    pytest.param(FrechetFrame, id="frechet"),
     pytest.param(_ExpFrame, id="exp_nonlinear"),
 ]
 
@@ -800,6 +802,7 @@ _GEOMETRY_FRAMES = [
     pytest.param(OrthogonalFrame.from_matrix(_M_ORTHO[None]), id="orthogonal"),
     pytest.param(MaterializedFrame.from_matrix(_M_TRICLINIC[None]), id="materialized"),
     pytest.param(LogTriclinicFrame.from_matrix(_M_TRICLINIC[None]), id="log_triclinic"),
+    pytest.param(FrechetFrame.from_matrix(_M_TRICLINIC[None]), id="frechet"),
 ]
 _frame_case = pytest.mark.parametrize("frame", _GEOMETRY_FRAMES)
 
@@ -909,3 +912,55 @@ class TestLogTriclinicFrame:
         frame = LogTriclinicFrame.from_matrix(jnp.eye(3) * 2.0)
         assert isinstance(frame, BaseFrame)
         assert not isinstance(frame, LinearFrame)
+
+
+class TestFrechetFrame:
+    """Deformation parameterisation: ``vectors == base @ expm(A / cell_factor)``
+    anchored at a fixed reference ``base`` (held stop-gradient, so only ``A`` is
+    optimised)."""
+
+    def test_vectors_is_base_times_expm(self):
+        a = jnp.array([[0.7, 0.0, 0.0], [0.5, 1.1, 0.0], [0.1, 0.2, 1.4]])
+        tril = jnp.array([0.7, 0.5, 1.1, 0.1, 0.2, 1.4])
+        base = TriclinicFrame.from_matrix(_M_TRICLINIC)
+        frame = FrechetFrame(tril, base)
+        # Right-multiplication (Cartesian deformation), matching ASE's
+        # FrechetCellFilter; left-multiplication would recombine lattice vectors.
+        npt.assert_allclose(frame.vectors, base.vectors @ expm(a), atol=1e-6)
+        # base @ expm(A) of two lower-triangular factors stays lower-triangular.
+        npt.assert_allclose(jnp.triu(frame.vectors, 1), 0.0, atol=1e-6)
+
+    def test_from_frame_anchors_at_base(self):
+        """``A = 0`` reproduces the reference frame exactly."""
+        base = TriclinicFrame.from_matrix(_M_TRICLINIC)
+        frame = FrechetFrame.from_frame(base)
+        npt.assert_allclose(frame.tril, 0.0)
+        npt.assert_allclose(frame.vectors, base.vectors, atol=1e-6)
+
+    def test_base_held_fixed_under_gradient(self):
+        """The cartesian→parameter pullback flows entirely into ``A``; the
+        stop-gradient base receives no gradient."""
+        frame = FrechetFrame.from_matrix(_M_TRICLINIC)
+        grad = frame.parameter_gradient(_CELL_GRAD)
+        assert isinstance(grad, FrechetFrame)
+        assert isinstance(grad.base, TriclinicFrame)
+        npt.assert_allclose(grad.base.tril, 0.0, atol=1e-6)
+        assert bool(jnp.any(grad.tril != 0.0))
+
+    def test_cell_factor_stiffens_deformation_and_gradient(self):
+        """``cell_factor`` (ASE's exp_cell_factor) scales the deformation to
+        ``expm(A / cell_factor)`` and divides the parameter gradient by it."""
+        a = jnp.array([[0.3, 0, 0], [0.2, 0.1, 0], [0.05, 0.1, 0.2]])
+        tril = jnp.array([0.3, 0.2, 0.1, 0.05, 0.1, 0.2])
+        base = TriclinicFrame.from_matrix(_M_TRICLINIC)
+        npt.assert_allclose(
+            FrechetFrame(tril, base, cell_factor=4.0).vectors,
+            base.vectors @ expm(a / 4.0),
+            atol=1e-6,
+        )
+        # At A = 0 the deformation Jacobian is the base Jacobian times
+        # 1 / cell_factor, so the parameter gradient scales exactly by it.
+        z = jnp.zeros(6)
+        g1 = FrechetFrame(z, base, cell_factor=1.0).parameter_gradient(_CELL_GRAD).tril
+        g4 = FrechetFrame(z, base, cell_factor=4.0).parameter_gradient(_CELL_GRAD).tril
+        npt.assert_allclose(g4, g1 / 4.0, atol=1e-6)

--- a/test/core/test_math.py
+++ b/test/core/test_math.py
@@ -15,6 +15,7 @@ from kups.core.utils.math import (
     logm,
     next_higher_power,
     triangular_3x3_det_and_inverse,
+    triangular_3x3_expm,
     triangular_3x3_from_tril,
     triangular_3x3_logm,
     triangular_3x3_matmul,
@@ -352,6 +353,49 @@ class TestTriangular3x3Logm:
             jnp.array([[0.8, 0, 0], [0.5, 0.8, 0], [0.3, 0.2, 0.8]])
         )
         grad = jax.grad(lambda m: jnp.sum(triangular_3x3_logm(m)))(lattice)
+        assert bool(jnp.all(jnp.isfinite(grad)))
+
+
+class TestTriangular3x3Expm:
+    @pytest.mark.parametrize(
+        "diagonal",
+        [
+            pytest.param(jnp.array([0.7, 1.1, 1.4]), id="distinct"),
+            pytest.param(jnp.array([0.9, 0.9, 1.4]), id="two-equal"),
+            pytest.param(jnp.array([0.8, 0.8, 0.8]), id="cubic-repeated"),
+        ],
+    )
+    def test_matches_scipy_expm(self, diagonal: jax.Array):
+        """Agrees with ``jax.scipy.linalg.expm``, including the defective
+        repeated-diagonal matrices, and stays lower-triangular."""
+        b = jnp.array(
+            [[diagonal[0], 0, 0], [0.5, diagonal[1], 0], [0.3, 0.2, diagonal[2]]]
+        )
+        out = triangular_3x3_expm(b)
+        npt.assert_allclose(out, jax.scipy.linalg.expm(b), atol=1e-6)
+        npt.assert_allclose(jnp.triu(out, 1), 0.0, atol=1e-10)
+
+    def test_inverse_of_logm(self):
+        """``triangular_3x3_expm`` and ``triangular_3x3_logm`` are inverses."""
+        b = jnp.array([[0.7, 0, 0], [0.5, 1.1, 0], [0.3, 0.2, 1.4]])
+        npt.assert_allclose(triangular_3x3_logm(triangular_3x3_expm(b)), b, atol=1e-6)
+
+    def test_upper_and_batched(self):
+        b = jnp.array([[0.7, 0, 0], [0.5, 1.1, 0], [0.3, 0.2, 1.4]])
+        # Upper-triangular convention is the transpose of the lower one.
+        npt.assert_allclose(
+            triangular_3x3_expm(b.T, lower=False),
+            triangular_3x3_expm(b).T,
+            atol=1e-6,
+        )
+        batched = triangular_3x3_expm(jnp.stack([b, 2 * b]))
+        assert batched.shape == (2, 3, 3)
+        npt.assert_allclose(batched[1], jax.scipy.linalg.expm(2 * b), atol=1e-6)
+
+    def test_gradient_safe_at_repeated_diagonal(self):
+        """No NaN gradients when diagonal entries coincide (cubic cell)."""
+        b = jnp.array([[0.8, 0, 0], [0.5, 0.8, 0], [0.3, 0.2, 0.8]])
+        grad = jax.grad(lambda m: jnp.sum(triangular_3x3_expm(m)))(b)
         assert bool(jnp.all(jnp.isfinite(grad)))
 
 


### PR DESCRIPTION
Add `FrechetFrame` cell parameterisation for joint cell-and-atom relaxation

Introduces `FrechetFrame`, a new triclinic frame type that parameterises the unit cell as a matrix-exponential deformation of a fixed reference frame, mirroring ASE's `FrechetCellFilter`. The cell vectors are computed as `base @ expm(A / cell_factor)`, where `A` is a lower-triangular matrix of 6 optimisable parameters and `base` is held fixed under stop-gradient. Right-multiplying by the exponential deforms Cartesian space so atoms at fixed fractional coordinates ride the cell automatically, and the unconstrained parameterisation prevents cell collapse or inversion during optimisation.

The `cell_factor` (equivalent to ASE's `exp_cell_factor`, set to the atom count in `relax_state_from_ase`) scales the deformation and divides the parameter gradient, balancing the extensive cell-virial gradient against per-atom forces in the joint optimiser.

To support `FrechetFrame`, a closed-form `triangular_3x3_expm` is added as the real, gradient-safe inverse of the existing `triangular_3x3_logm`. It uses first and second divided differences of `exp` over the diagonal entries, which remain well-conditioned when diagonal entries coincide (e.g. cubic or tetragonal cells), avoiding the Padé scaling-and-squaring iteration used by `jax.scipy.linalg.expm`. `LogTriclinicFrame` is updated to use this new implementation. `LogTriclinicFrame` also gains a `from_frame` constructor for consistency.