### PR TITLE
refactor: Use `materialize` and `sum_over` in `WrapStep` and `CSVRStep`

### DIFF
--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -916,6 +916,9 @@ class Cell(Sliceable, Generic[_P]):
     def __mul__(self, other: Array | float | int) -> Self:
         return bind(self, lambda c: c.frame).set(self.frame * other)
 
+    def materialize(self) -> Self:
+        return bind(self, lambda c: c.frame).set(self.frame.materialize())
+
     @overload
     @staticmethod
     def from_pbc(frame: Frame, pbc: Periodic3D) -> PeriodicCell: ...

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -595,11 +595,7 @@ class CSVRStep[State](Propagator[State]):
             particles.data.momenta, particles.data.masses
         )
         # K: total kinetic energy per system [energy]
-        kinetic_energy_current = jax.ops.segment_sum(
-            per_particle_ke,
-            particles.data.system.indices,
-            particles.data.system.num_labels,
-        )
+        kinetic_energy_current = particles.data.system.sum_over(per_particle_ke).data
         # K_target = N_dof·kT/2 [energy]
         kinetic_energy_target = degrees_of_freedom * target_thermal_energy / 2
 
@@ -1210,8 +1206,10 @@ class WrapStep[State](Propagator[State]):
         del key
         par_lens = self.particles.bind(state)
         par = par_lens.get()
-        cells = self.systems(state)[par.data.system]
-        new_positions = cells.cell.wrap(par.data.positions)
+        cells = self.systems(state).map_data(lambda x: x.cell.materialize())[
+            par.data.system
+        ]
+        new_positions = cells.wrap(par.data.positions)
         return par_lens.focus(lambda p: p.data.positions).set(new_positions)
 
 
@@ -1397,7 +1395,11 @@ def make_md_step_from_state[State](
         ValueError: If ``integrator`` is not one of the supported keys.
     """
     flow = WrapFlow(
-        state.focus(lambda x: x.systems[x.particles.data.system].cell),
+        state.focus(
+            lambda x: x.systems.map_data(lambda x: x.cell.materialize())[
+                x.particles.data.system
+            ]
+        ),
         euclidean_flow,
     )
     particles_lens = state.focus(lambda x: x.particles)


### PR DESCRIPTION
This PR introduces a `materialize()` method on `Cell` that delegates to the underlying frame's `materialize()` call, mirroring the existing pattern used by other `Cell` operations like `__mul__`.

The `WrapStep` propagator and `make_md_step_from_state` are updated to call `materialize()` on cells before wrapping particle positions. Previously, `WrapStep` accessed `.cell` directly from the system and called `.wrap()` on it; now it materializes the cell first via `map_data`, then indexes into the result and calls `.wrap()` directly on the cell object. This ensures that any lazy or symbolic cell representation is fully realized before being used for position wrapping.

The CSVR thermostat step is also updated to use `particles.data.system.sum_over(...).data` instead of `jax.ops.segment_sum` directly, aligning it with the higher-level system abstraction for per-system reductions.