### PR TITLE
docs: update README `cd` instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pip install kups[cuda]
 
 ```bash
 git clone https://github.com/cusp-ai-oss/kups.git
-cd kups
+cd kUPS
 uv sync
 ```
 


### PR DESCRIPTION
In response to #188. Simple fix (`cd kups` -> `cd kUPS`)