### PR TITLE
chore: ignore local dev directories (benchmarks, plans, tooling)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,10 @@ docs/reference
 *.log
 *.dat
 
+# local development
+.bedrock/
+plans/
+bench/
+benchmarks/
+.vscode-annotator/
+.mcp.json


### PR DESCRIPTION
Ignore local-only working directories so they no longer appear as untracked: `benchmarks/`, `plans/`, `.bedrock/`, `.vscode-annotator/`, `.mcp.json`.

Base of a 6-PR stack landing the MD-performance work (csvr_npt_1eval, Verlet-skin, fused nonbonded, PME, forces-only NVE/NVT).