### PR TITLE
feat: add csvr_npt_1eval integrator (drop redundant post-barostat eval)

### DIFF
--- a/src/kups/application/md/data.py
+++ b/src/kups/application/md/data.py
@@ -261,7 +261,12 @@ class MdParameters(BaseModel):
     minimum_scale_factor: float
     """Minimum allowed box scaling factor per barostat step (dimensionless)."""
     integrator: Integrator
-    """Integration algorithm to use."""
+    """Integration algorithm to use.
+
+    ``"csvr_npt_1eval"`` is ``"csvr_npt"`` with the post-barostat force/stress eval
+    dropped, halving the derivative evaluations per step; it is only accurate for slow
+    barostats and isotropic cells. See `make_csvr_npt_step`.
+    """
     initialize_momenta: bool = False
     """If True, initialize momenta from Maxwell-Boltzmann distribution."""
 
@@ -382,7 +387,7 @@ def _build_integrator_params(
                     [config.thermostat_time_constant * FEMTO_SECOND]
                 ),
             )
-        case "csvr_npt":
+        case "csvr_npt" | "csvr_npt_1eval":
             return CSVRNPTParams(
                 time_step=time_step,
                 temperature=temperature,

--- a/src/kups/application/md/integrators.py
+++ b/src/kups/application/md/integrators.py
@@ -109,7 +109,7 @@ def make_md_step_from_state[State](
 def make_md_step_from_state[State](
     state: Lens[State, IsState[_MDParticleData, IsMDSystemNPT]],
     derivative_computation: Propagator[State],
-    integrator: Literal["csvr_npt"],
+    integrator: Literal["csvr_npt", "csvr_npt_1eval"],
     *,
     parameters: None = None,
 ) -> Propagator[State]: ...
@@ -149,7 +149,7 @@ def make_md_step_from_state[State](
 def make_md_step_from_state[State](
     state: Lens[State, IsState[_MDParticleData, IsMDSystemNPTBase]],
     derivative_computation: Propagator[State],
-    integrator: Literal["csvr_npt"],
+    integrator: Literal["csvr_npt", "csvr_npt_1eval"],
     *,
     parameters: IsCSVRNPTParams,
 ) -> Propagator[State]: ...
@@ -198,6 +198,10 @@ def make_md_step_from_state[State](
     - ``"csvr_npt"`` — [CSVR-NPT][kups.md.integrators.make_csvr_npt_step]
       (NPT via CSVR thermostat with barostat). Requires
       ``integrator_params: IsCSVRNPTParams`` and a ``cell_gradients`` leaf on each system.
+    - ``"csvr_npt_1eval"`` — as ``"csvr_npt"``, but with the post-barostat
+      force/stress eval dropped, halving the derivative evaluations per step. Only
+      accurate for slow barostats and isotropic cells; see
+      [``refresh_after_barostat``][kups.md.integrators.make_csvr_npt_step].
     - ``"baoab_npt_langevin"`` — [BAOAB NPT Langevin][kups.md.integrators.make_baoab_npt_langevin_step]
       (Gao–Fang–Wang JCP 2016 fully-flexible-cell NPT). Requires
       ``integrator_params: IsBAOABNPTLangevinParams`` plus ``cell_momentum``
@@ -247,9 +251,13 @@ def make_md_step_from_state[State](
             return make_csvr_step(
                 particles_lens, systems_lens, derivative_computation, flow
             )
-        case "csvr_npt":
+        case "csvr_npt" | "csvr_npt_1eval":
             return make_csvr_npt_step(
-                particles_lens, systems_lens, derivative_computation, flow
+                particles_lens,
+                systems_lens,
+                derivative_computation,
+                flow,
+                refresh_after_barostat=integrator == "csvr_npt",
             )
         case "baoab_npt_langevin":
             return make_baoab_npt_langevin_step(

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -62,7 +62,12 @@ type Pressure = Array
 type Stress = Array
 
 type Integrator = Literal[
-    "verlet", "baoab_langevin", "csvr", "csvr_npt", "baoab_npt_langevin"
+    "verlet",
+    "baoab_langevin",
+    "csvr",
+    "csvr_npt",
+    "csvr_npt_1eval",
+    "baoab_npt_langevin",
 ]
 
 # χ constant in the Gao-Fang-Wang NPT Langevin barostat-pressure term
@@ -887,6 +892,7 @@ def make_csvr_npt_step[State](
     systems: Lens[State, Table[SystemId, IsMDSystemNPT]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
+    refresh_after_barostat: bool = True,
 ) -> SequentialPropagator[State]:
     r"""Create NPT integrator for isothermal-isobaric (NPT) ensemble sampling.
 
@@ -904,7 +910,8 @@ def make_csvr_npt_step[State](
         - Compute $\mathbf{F}(t+\Delta t)$ — force evaluation
         - $\mathbf{p}(t+\Delta t) = \mathbf{p}(t+\Delta t/2) + \mathbf{F}(t+\Delta t) \cdot \Delta t/2$ — half momentum step
     3. Stochastic cell rescaling (pressure control)
-    4. Recompute forces and stress after box/position scaling
+    4. Recompute forces and stress after box/position scaling (unless
+       ``refresh_after_barostat`` is False)
 
     Args:
         particles: Lens to get/set indexed particle data (momenta $\\mathbf{p}$, positions $\\mathbf{r}$,
@@ -915,6 +922,12 @@ def make_csvr_npt_step[State](
             degrees of freedom $N_{\\text{dof}}$, thermostat time constant $\\tau_T$)
         derivative_computation: Propagator to compute forces $\\mathbf{F}$ and stress tensor $\\mathbf{W}$ from state
         flow: Flow operator for position updates (handles boundary conditions)
+        refresh_after_barostat: If True (default), recompute $\\mathbf{F}$ and $\\mathbf{W}$
+            after the barostat rescale, costing two derivative evaluations per step. If
+            False, the next step's first half-kick instead reuses the pre-rescale forces,
+            halving the cost. The resulting force error grows with $|\\mu - 1|$, so only
+            drop the refresh for slow barostats ($\\tau_P \\gg \\Delta t$) and isotropic
+            cells.
 
     Returns:
         SequentialPropagator implementing the CSVR-NPT algorithm
@@ -933,17 +946,19 @@ def make_csvr_npt_step[State](
     params_half: View[State, Table[SystemId, IsCSVRNPTParams]] = pipe(
         systems.get, _half_time_params
     )
-    return SequentialPropagator(
-        (
-            CSVRStep(particles, params),
-            MomentumStep(particles, params_half),
-            PositionStep(particles, params, flow),
-            derivative_computation,
-            MomentumStep(particles, params_half),
-            StochasticCellRescalingStep(particles, systems),
-            derivative_computation,
-        )
-    )
+    # Pressure control is unaffected by refresh_after_barostat either way: the barostat
+    # consumes the fresh pre-rescale stress produced by the eval above it.
+    steps: list[Propagator[State]] = [
+        CSVRStep(particles, params),
+        MomentumStep(particles, params_half),
+        PositionStep(particles, params, flow),
+        derivative_computation,
+        MomentumStep(particles, params_half),
+        StochasticCellRescalingStep(particles, systems),
+    ]
+    if refresh_after_barostat:
+        steps.append(derivative_computation)
+    return SequentialPropagator(tuple(steps))
 
 
 # =============================================================================

--- a/test/application/md/test_integrators.py
+++ b/test/application/md/test_integrators.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import jax
 import jax.numpy as jnp
+import pytest
 from jax import Array
 
 from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
@@ -686,27 +687,43 @@ class TestNVTPhysics:
 
 
 class TestCSVRNPTPhysics:
-    _integrator = None
-    _deriv = None
+    _integrators = {}
 
     @classmethod
-    def _get_integrator(cls):
-        if cls._integrator is None:
-            cls._deriv = create_npt_derivative_computation()
-            cls._integrator = make_csvr_npt_step(
+    def _get_integrator(cls, refresh_after_barostat: bool = True):
+        if refresh_after_barostat not in cls._integrators:
+            cls._integrators[refresh_after_barostat] = make_csvr_npt_step(
                 particles=NPTState.particles,
                 systems=NPTState.systems,
-                derivative_computation=cls._deriv,
+                derivative_computation=create_npt_derivative_computation(),
                 flow=euclidean_flow,
+                refresh_after_barostat=refresh_after_barostat,
             )
-        return cls._integrator
+        return cls._integrators[refresh_after_barostat]
 
-    def test_temperature_control_with_barostat(self):
+    def test_refresh_after_barostat_halves_derivative_evals(self):
+        deriv = create_npt_derivative_computation()
+
+        def n_derivative_evals(refresh_after_barostat: bool) -> int:
+            step = make_csvr_npt_step(
+                particles=NPTState.particles,
+                systems=NPTState.systems,
+                derivative_computation=deriv,
+                flow=euclidean_flow,
+                refresh_after_barostat=refresh_after_barostat,
+            )
+            return sum(p is deriv for p in step.propagators)
+
+        assert n_derivative_evals(refresh_after_barostat=True) == 2
+        assert n_derivative_evals(refresh_after_barostat=False) == 1
+
+    @pytest.mark.parametrize("refresh_after_barostat", [True, False])
+    def test_temperature_control_with_barostat(self, refresh_after_barostat: bool):
         n_particles, kT_target = 5, 1.2
         state = create_npt_system(
             n_particles=n_particles, box_size=5.0, kT=kT_target, tau_t=0.1, tau_p=2.0
         )
-        integrator = self._get_integrator()
+        integrator = self._get_integrator(refresh_after_barostat)
 
         _, temps = run_simulation(
             integrator,
@@ -718,11 +735,12 @@ class TestCSVRNPTPhysics:
         )
         assert_temperature(jnp.mean(temps), kT_target, 0.15, "NPT ")
 
-    def test_volume_fluctuations(self):
+    @pytest.mark.parametrize("refresh_after_barostat", [True, False])
+    def test_volume_fluctuations(self, refresh_after_barostat: bool):
         state = create_npt_system(
             n_particles=5, box_size=5.0, kT=1.0, tau_t=0.1, tau_p=1.0
         )
-        integrator = self._get_integrator()
+        integrator = self._get_integrator(refresh_after_barostat)
 
         _, volumes = run_simulation(
             integrator,


### PR DESCRIPTION
## What

`make_csvr_npt_step` gains a `refresh_after_barostat` flag (default `True`, behaviour unchanged). With it `False`, the post-barostat force/stress evaluation is dropped and the next step's first half-kick reuses the pre-rescale forces, so each step costs **one derivative evaluation instead of two**. Pressure control is unaffected either way: the barostat consumes the fresh pre-rescale stress.

Exposed to configs as the `csvr_npt_1eval` integrator key, which shares `csvr_npt`'s parameters and state protocol (implemented by widening the existing `csvr_npt` overloads rather than adding two more to an already 9-overload function).

## Accuracy caveat

The force error grows with `|mu - 1|`, so this is only accurate for slow barostats and isotropic cells. This is documented on the flag.

## Tests

- The duplicated "1eval" physics tests are folded into the existing CSVR-NPT tests via `parametrize`.
- The old `len(one.propagators) == len(two.propagators) - 1` structural check is replaced with a test of the actual claim: 2 derivative evaluations per step → 1.

## Notes

- Rebased onto current `main` (post-#211 unified `md.py`, integrators in `kups/application/md/integrators.py`); green on ruff, pyrefly, pre-commit, and `test/application/ test/md/` (202 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
