### PR TITLE
feat: wire the Verlet-skin neighbor list into MD

### DIFF
--- a/src/kups/application/md/data.py
+++ b/src/kups/application/md/data.py
@@ -22,7 +22,7 @@ from kups.application.utils.particles import (
 from kups.core.cell import AnyPeriodicity, Cell
 from kups.core.constants import BOLTZMANN_CONSTANT, FEMTO_SECOND, PASCAL
 from kups.core.data import Index, Table
-from kups.core.neighborlist import UniversalNeighborlistParameters
+from kups.core.neighborlist import UniversalNeighborlistParameters, VerletSkinState
 from kups.core.typing import ExclusionId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass, field, tree_zeros_like
 from kups.md.integrators import Integrator
@@ -217,12 +217,17 @@ class MdState:
 
     The potential is built with its parameters at construction time (via the
     adapters' ``parameters=``), so no force-field field lives on the state.
+
+    ``verlet_skin`` (see [kups.core.neighborlist.verlet][]) stays ``None``
+    unless ``MdParameters.verlet_skin > 0``; it is seeded once before the run,
+    so it never flips mid-run and retriggers compilation.
     """
 
     particles: Table[ParticleId, MDParticles]
     systems: Table[SystemId, MDSystems]
     neighborlist_params: UniversalNeighborlistParameters
     step: Array
+    verlet_skin: VerletSkinState | None = None
 
 
 class MdRunConfig(BaseModel):
@@ -264,6 +269,11 @@ class MdParameters(BaseModel):
     """Integration algorithm to use."""
     initialize_momenta: bool = False
     """If True, initialize momenta from Maxwell-Boltzmann distribution."""
+    verlet_skin: float = 0.0
+    """Neighbor-list skin width (Å); ~1.0 is a reasonable start. 0 rebuilds every
+    step; > 0 builds once at ``cutoff + verlet_skin`` and reuses the list until
+    atom motion or cell strain could let a pair enter the cutoff (see
+    [kups.core.neighborlist.verlet][])."""
 
 
 def md_state_from_ase(

--- a/src/kups/application/md/simulation.py
+++ b/src/kups/application/md/simulation.py
@@ -22,6 +22,7 @@ from kups.core.cell import AnyPeriodicity, Cell
 from kups.core.data import Table
 from kups.core.lens import Lens, lens
 from kups.core.logging import CompositeLogger, TqdmLogger
+from kups.core.neighborlist import IsVerletState, VerletSkinPropagator
 from kups.core.potential import (
     EMPTY,
     CachedPotential,
@@ -86,10 +87,17 @@ def potential_map(
     )
 
 
-def make_md_propagator[State: IsMdState, Grad: IsMdGradients](
+class IsVerletMdState(IsMdState, IsVerletState, Protocol):
+    """MD state that can also carry the Verlet-skin neighbor-list group."""
+
+
+def make_md_propagator[State: IsVerletMdState, Grad: IsMdGradients](
     state_lens: Lens[State, State],
     integrator: Integrator,
     potential: Potential[State, Grad, EmptyType, Any],
+    *,
+    verlet_skin: float = 0.0,
+    cutoffs: Table[SystemId, Array] | None = None,
 ) -> Propagator[State]:
     """Build a single MD propagator step with error recovery and step counting.
 
@@ -97,6 +105,13 @@ def make_md_propagator[State: IsMdState, Grad: IsMdGradients](
         state_lens: Lens focusing on the MD sub-state within the full state.
         integrator: Integration algorithm for equations of motion.
         potential: Potential energy function providing forces and gradients.
+        verlet_skin: Neighbor-list skin width (Å). ``0`` (default) leaves the
+            potential's own neighbor-list construction untouched. ``> 0`` wraps
+            the MD step in a
+            [`VerletSkinPropagator`][kups.core.neighborlist.verlet.VerletSkinPropagator],
+            whose docstring states the contract on the potential, the state and
+            the error recovery.
+        cutoffs: True per-system cutoffs; required when ``verlet_skin > 0``.
 
     Returns:
         Propagator that advances the state by one MD step.
@@ -123,14 +138,16 @@ def make_md_propagator[State: IsMdState, Grad: IsMdGradients](
             ),
         )
     )
-    md_propagator = make_md_step_from_state(
+    md_propagator: Propagator[State] = make_md_step_from_state(
         state_lens, derivative_computation, integrator
     )
+    if verlet_skin > 0:
+        assert cutoffs is not None, "verlet_skin > 0 requires cutoffs."
+        md_propagator = VerletSkinPropagator(md_propagator, cutoffs, verlet_skin)
     step_count_propagator = step_counter_propagator(state_lens.focus(lambda x: x.step))
-    propagator = ResetOnErrorPropagator(
+    return ResetOnErrorPropagator(
         SequentialPropagator((md_propagator, step_count_propagator))
     )
-    return propagator
 
 
 def run_md[State: IsMdState](

--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -22,7 +22,7 @@ from kups.core.cell import AnyPeriodicity, Cell, DeformedFrame, MatrixLogFrame
 from kups.core.data import Table
 from kups.core.data.index import Index
 from kups.core.lens import bind
-from kups.core.neighborlist import UniversalNeighborlistParameters
+from kups.core.neighborlist import UniversalNeighborlistParameters, VerletSkinState
 from kups.core.typing import ExclusionId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass, field, tree_zeros_like
 from kups.relaxation.config import TransformationConfig
@@ -76,6 +76,10 @@ class RelaxState:
 
     The potential is built with its parameters at construction time (via the
     adapters' ``parameters=``), so no force-field field lives on the state.
+
+    ``verlet_skin`` (see [kups.core.neighborlist.verlet][]) stays ``None``
+    unless ``RelaxRunConfig.verlet_skin > 0``; it is seeded once before the
+    run, so it never flips mid-run and retriggers compilation.
     """
 
     particles: Table[ParticleId, RelaxParticles]
@@ -83,6 +87,7 @@ class RelaxState:
     neighborlist_params: UniversalNeighborlistParameters
     opt_state: optax.OptState
     step: Array
+    verlet_skin: VerletSkinState | None = None
 
 
 class RelaxRunConfig(BaseModel):
@@ -100,6 +105,11 @@ class RelaxRunConfig(BaseModel):
     """List of Optax transform specifications passed to `make_optimizer`."""
     optimize_cell: bool
     """Whether to also relax lattice vectors."""
+    verlet_skin: float = 0.0
+    """Neighbor-list skin width (Å); ~1.0 is a reasonable start. 0 rebuilds every
+    step; > 0 builds once at ``cutoff + verlet_skin`` and reuses the list until
+    atom motion or cell strain could let a pair enter the cutoff (see
+    [kups.core.neighborlist.verlet][])."""
 
 
 def relax_state_from_ase(

--- a/src/kups/application/relaxation/simulation.py
+++ b/src/kups/application/relaxation/simulation.py
@@ -20,6 +20,7 @@ from kups.application.utils.propagate import make_cycle_function, run_simulation
 from kups.core.data import Table
 from kups.core.lens import Lens, lens
 from kups.core.logging import CompositeLogger, TqdmLogger
+from kups.core.neighborlist import IsVerletState, VerletSkinPropagator
 from kups.core.potential import (
     EMPTY,
     CachedPotential,
@@ -54,6 +55,10 @@ class IsRelaxState(IsState[RelaxParticles, RelaxSystems], Protocol):
     def step(self) -> Array: ...
 
 
+class IsVerletRelaxState(IsRelaxState, IsVerletState, Protocol):
+    """Relaxation state that can also carry the Verlet-skin group."""
+
+
 class OptInit(Protocol):
     """Protocol for initialising an Optax optimizer state from gradients."""
 
@@ -64,11 +69,14 @@ class OptInit(Protocol):
     ) -> optax.OptState: ...
 
 
-def make_relax_propagator[State: IsRelaxState](
+def make_relax_propagator[State: IsVerletRelaxState](
     state_lens: Lens[State, State],
     potential: Potential[State, Any, EmptyType, Any],
     optimizer: Optimizer[PositionsAndCell, Any],
     gradient: Lens[Geometry, PositionsAndCell],
+    *,
+    verlet_skin: float = 0.0,
+    cutoffs: Table[SystemId, Array] | None = None,
 ) -> tuple[Propagator[State], OptInit]:
     """Build a relaxation propagator with step counting and error recovery.
 
@@ -82,6 +90,13 @@ def make_relax_propagator[State: IsRelaxState](
             DOFs (not raw ``(positions, cell)``) so the filter's atoms-ride-the-cell
             coupling is applied on every ``set``; using the raw property would drop
             that coupling and diverge from ASE's cell filters.
+        verlet_skin: Neighbor-list skin width (Å). ``0`` (default) leaves the
+            potential's own neighbor-list construction untouched. ``> 0`` wraps
+            the optimisation step in a
+            [`VerletSkinPropagator`][kups.core.neighborlist.verlet.VerletSkinPropagator],
+            whose docstring states the contract on the potential, the state and
+            the error recovery.
+        cutoffs: True per-system cutoffs; required when ``verlet_skin > 0``.
 
     Returns:
         Tuple of ``(propagator, opt_init)`` where *propagator* performs one
@@ -127,12 +142,15 @@ def make_relax_propagator[State: IsRelaxState](
         return optimizer.init(params, prefix)
 
     pot = CachedPotential(potential, lens(cached_out), cached_index)
-    relax_prop = RelaxationPropagator(
+    relax_prop: Propagator[State] = RelaxationPropagator(
         potential=pot,
         property=lens(to_geometry).nest(gradient),
         opt_state=state_lens.focus(lambda x: x.opt_state),
         optimizer=optimizer,
     )
+    if verlet_skin > 0:
+        assert cutoffs is not None, "verlet_skin > 0 requires cutoffs."
+        relax_prop = VerletSkinPropagator(relax_prop, cutoffs, verlet_skin)
     step_prop = step_counter_propagator(state_lens.focus(lambda x: x.step))
     prop = ResetOnErrorPropagator(SequentialPropagator((relax_prop, step_prop)))
     return prop, opt_init

--- a/src/kups/application/simulations/md.py
+++ b/src/kups/application/simulations/md.py
@@ -43,7 +43,12 @@ from kups.application.simulations.potentials import (
 )
 from kups.core.data import Table
 from kups.core.lens import identity_lens
-from kups.core.neighborlist import UniversalNeighborlistParameters
+from kups.core.neighborlist import (
+    AdaptiveNeighborList,
+    UniversalNeighborlistParameters,
+    VerletSkinState,
+    skin_neighborlist,
+)
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import key_chain
 
@@ -72,8 +77,14 @@ def run(config: Config) -> None:
     seed = config.run.seed or time.time_ns()
     chain = key_chain(jax.random.key(seed))
     state_lens = identity_lens(MdState)
-    potential, cutoff = config.potential.build(state_lens, POSITIONS_AND_CELL)
-    propagator = make_md_propagator(state_lens, config.md.integrator, potential)
+    skin = config.md.verlet_skin
+    potential, cutoff = config.potential.build(
+        state_lens,
+        POSITIONS_AND_CELL,
+        neighborlist_factory=skin_neighborlist
+        if skin > 0
+        else AdaptiveNeighborList.from_state,
+    )
 
     mb_key = next(chain) if config.md.initialize_momenta else None
     all_particles: list[Table[ParticleId, MDParticles]] = []
@@ -95,6 +106,12 @@ def run(config: Config) -> None:
         systems=systems,
         neighborlist_params=neighborlist_params,
         step=jnp.array([0]),
+        verlet_skin=VerletSkinState.seed(particles, systems, cutoff, skin)
+        if skin > 0
+        else None,
+    )
+    propagator = make_md_propagator(
+        state_lens, config.md.integrator, potential, verlet_skin=skin, cutoffs=cutoff
     )
     run_md(next(chain), propagator, state, config.run)
 

--- a/src/kups/application/simulations/relax.py
+++ b/src/kups/application/simulations/relax.py
@@ -41,7 +41,12 @@ from kups.application.simulations.potentials import (
 )
 from kups.core.data import Table
 from kups.core.lens import identity_lens
-from kups.core.neighborlist import UniversalNeighborlistParameters
+from kups.core.neighborlist import (
+    AdaptiveNeighborList,
+    UniversalNeighborlistParameters,
+    VerletSkinState,
+    skin_neighborlist,
+)
 from kups.core.typing import ParticleId, SystemId
 from kups.relaxation.config import make_optimizer
 
@@ -70,9 +75,16 @@ def run(config: Config) -> None:
     state_lens = identity_lens(RelaxState)
     optimizer = make_optimizer(config.run.optimizer)
     gradient = FRECHET_FILTER if config.run.optimize_cell else POSITIONS_ONLY
-    potential, cutoff = config.potential.build(state_lens, gradient)
+    skin = config.run.verlet_skin
+    potential, cutoff = config.potential.build(
+        state_lens,
+        gradient,
+        neighborlist_factory=skin_neighborlist
+        if skin > 0
+        else AdaptiveNeighborList.from_state,
+    )
     propagator, opt_init = make_relax_propagator(
-        state_lens, potential, optimizer, gradient
+        state_lens, potential, optimizer, gradient, verlet_skin=skin, cutoffs=cutoff
     )
 
     all_particles: list[Table[ParticleId, RelaxParticles]] = []
@@ -96,6 +108,9 @@ def run(config: Config) -> None:
         neighborlist_params=neighborlist_params,
         opt_state=opt_state,
         step=jnp.array([0]),
+        verlet_skin=VerletSkinState.seed(particles, systems, cutoff, skin)
+        if skin > 0
+        else None,
     )
     logging.info("Starting relaxation")
     run_relax(key, propagator, state, config.run)

--- a/test/application/_builders.py
+++ b/test/application/_builders.py
@@ -1,0 +1,66 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared builders for the application-level Lennard-Jones integration tests.
+
+Single source of truth for the fcc-argon input structure the MD, relaxation and
+Verlet-skin smoke tests run on, and for the LBFGS optimizer spec the relaxation
+ones relax with.
+"""
+
+from __future__ import annotations
+
+import tempfile
+
+import ase.build
+
+from kups.relaxation.config import TransformationConfig
+
+#: LBFGS direction, clamped step length, descent sign — the spec every
+#: Lennard-Jones relaxation test relaxes with.
+LBFGS_OPTIMIZER: TransformationConfig = [
+    {"transform": "scale_by_ase_lbfgs", "memory_size": 10, "alpha": 70},
+    {"transform": "max_step_size", "max_step_size": 0.2},
+    {"transform": "scale", "step_size": -1},
+]
+
+
+def ar_cif(rattle: float = 0.0, *, cubic: bool = False) -> str:
+    """Write an fcc-argon supercell as a P1 CIF and return the file path.
+
+    Labels are kept uniform (``Ar``) so they match the LJ parameter table;
+    ASE's CIF writer would otherwise uniquify them to ``Ar1``, ``Ar2``, ... The
+    rattle gives an optimizer nonzero forces to act on.
+
+    Args:
+        rattle: Stdev (Å) of the Gaussian displacement applied to every atom;
+            ``0`` leaves the ideal lattice.
+        cubic: Build the conventional cubic cell (32 atoms, ~10.6 Å box, so
+            ``(cutoff + skin) / box`` stays inside the single-image limit for
+            the Verlet-skin tests) instead of the fcc primitive one.
+    """
+    atoms = ase.build.bulk("Ar", "fcc", a=5.3, cubic=cubic) * (2, 2, 2)
+    atoms.rattle(rattle, seed=1)
+    a, b, c, al, be, ga = atoms.cell.cellpar()
+    rows = "\n".join(
+        f"Ar Ar {x:.6f} {y:.6f} {z:.6f}" for x, y, z in atoms.get_scaled_positions()
+    )
+    cif = (
+        f"data_ar\n_cell_length_a {a:.6f}\n_cell_length_b {b:.6f}\n"
+        f"_cell_length_c {c:.6f}\n_cell_angle_alpha {al:.6f}\n"
+        f"_cell_angle_beta {be:.6f}\n_cell_angle_gamma {ga:.6f}\n"
+        "_symmetry_space_group_name_H-M 'P 1'\n_symmetry_Int_Tables_number 1\n"
+        "loop_\n_atom_site_label\n_atom_site_type_symbol\n"
+        f"_atom_site_fract_x\n_atom_site_fract_y\n_atom_site_fract_z\n{rows}\n"
+    )
+    f = tempfile.NamedTemporaryFile(suffix=".cif", delete=False, mode="w")
+    f.write(cif)
+    f.close()
+    return f.name
+
+
+def tmp_h5() -> str:
+    """Path of a fresh, closed temporary ``.h5`` file for a run's output."""
+    f = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
+    f.close()
+    return f.name

--- a/test/application/md/test_verlet.py
+++ b/test/application/md/test_verlet.py
@@ -1,0 +1,284 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""MD integration tests for the Verlet-skin neighbor list.
+
+The rebuild schedule is driven by the real on-device trigger — no hardcoded
+rebuild schedule — and the resulting trajectory is compared against the
+every-step dense path with the same PRNG keys, both per-step and fused into
+blocks. Pure trigger/refine unit tests live in
+``test/core/neighborlist/test_verlet.py``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, cast
+
+import ase.build
+import jax
+import jax.numpy as jnp
+import pytest
+from jax import Array
+
+from kups.application.md.data import (
+    MdParameters,
+    MdRunConfig,
+    MdState,
+    md_state_from_ase,
+)
+from kups.application.md.simulation import make_md_propagator
+from kups.application.potential.classical.lennard_jones import (
+    make_lennard_jones_from_state,
+)
+from kups.application.potential.filter import POSITIONS_AND_CELL
+from kups.application.utils.propagate import make_cycle_function
+from kups.core.data import Table
+from kups.core.lens import identity_lens
+from kups.core.neighborlist import (
+    UniversalNeighborlistParameters,
+    VerletSkinState,
+    skin_neighborlist,
+)
+from kups.core.propagator import LoopPropagator, propagate_and_fix
+from kups.core.typing import SystemId
+from kups.core.utils.jax import key_chain
+from kups.potential.classical.lennard_jones import LennardJonesParameters
+
+from .._builders import ar_cif, tmp_h5
+
+# Ar fcc 3x3x3 -> 108 atoms, ~15.8 A box; (cutoff+skin)/box ~ 0.41 < 0.5 (single
+# image). 200 K and a thin 0.4 A skin make the displacement trigger fire within
+# a few tens of 2 fs steps.
+CUTOFF, SKIN, NUM_STEPS = 6.0, 0.4, 25
+
+_LJ_PARAMS = LennardJonesParameters.from_dict(
+    cutoff=CUTOFF, parameters={"Ar": (3.4, 0.0103)}, mixing_rule="lorentz_berthelot"
+)
+
+
+def _cutoff_table(systems) -> Table[SystemId, Array]:
+    return Table(systems.keys, jnp.full((len(systems.keys),), CUTOFF))
+
+
+def _make_state(
+    skin: float,
+    integrator: str,
+    skin_params: UniversalNeighborlistParameters | None = None,
+) -> MdState:
+    atoms = ase.build.bulk("Ar", "fcc", a=5.26, cubic=True) * (3, 3, 3)
+    md = MdParameters(
+        temperature=200.0,
+        time_step=2.0,
+        friction_coefficient=0.01,
+        thermostat_time_constant=100.0,
+        target_pressure=1e5,
+        pressure_coupling_time=1000.0,
+        compressibility=5e-10,
+        minimum_scale_factor=0.9,
+        integrator=cast(Any, integrator),
+        initialize_momenta=True,
+        verlet_skin=skin,
+    )
+    particles, systems = md_state_from_ase(atoms, md, key=jax.random.key(0))
+    cutoffs = _cutoff_table(systems)
+    state = MdState(
+        particles=particles,
+        systems=systems,
+        neighborlist_params=UniversalNeighborlistParameters.estimate(
+            particles.data.system.counts, systems, cutoffs
+        ),
+        step=jnp.array([0]),
+    )
+    if skin > 0:
+        group = VerletSkinState.seed(
+            particles, systems, cutoffs, skin, params=skin_params
+        )
+        state = dataclasses.replace(state, verlet_skin=group)
+    return state
+
+
+def _make_propagators(integrator: str, cutoffs: Table[SystemId, Array]):
+    """(dense, verlet) propagators sharing the LJ parameters."""
+    state_lens = identity_lens(MdState)
+    dense_potential = make_lennard_jones_from_state(
+        state_lens, parameters=_LJ_PARAMS, gradient=POSITIONS_AND_CELL
+    )
+    verlet_potential = make_lennard_jones_from_state(
+        state_lens,
+        parameters=_LJ_PARAMS,
+        gradient=POSITIONS_AND_CELL,
+        neighborlist_factory=skin_neighborlist,
+    )
+    dense = make_md_propagator(state_lens, cast(Any, integrator), dense_potential)
+    verlet = make_md_propagator(
+        state_lens,
+        cast(Any, integrator),
+        verlet_potential,
+        verlet_skin=SKIN,
+        cutoffs=cutoffs,
+    )
+    return dense, verlet
+
+
+def _positions_close(a: MdState, b: MdState, what: str) -> None:
+    max_diff = float(
+        jnp.max(jnp.abs(a.particles.data.positions - b.particles.data.positions))
+    )
+    assert max_diff < 1e-8, f"Verlet diverged from dense ({what}): {max_diff:.2e}"
+
+
+@pytest.mark.parametrize("integrator", ["csvr", "csvr_npt"])
+def test_verlet_trajectory_matches_dense(integrator: str) -> None:
+    """The on-device trigger reproduces the every-step dense trajectory (same
+    keys), and it actually fires at least once."""
+    dense_state = _make_state(0.0, integrator)
+    verlet_state = _make_state(SKIN, integrator)
+    dense_prop, verlet_prop = _make_propagators(
+        integrator, _cutoff_table(dense_state.systems)
+    )
+
+    dense = make_cycle_function(dense_prop)
+    verlet = make_cycle_function(verlet_prop)
+    dense_chain = key_chain(jax.random.key(1))
+    verlet_chain = key_chain(jax.random.key(1))
+    flags = []
+    for _ in range(NUM_STEPS):
+        dense_state = propagate_and_fix(dense, next(dense_chain), dense_state)
+        verlet_state = propagate_and_fix(verlet, next(verlet_chain), verlet_state)
+        assert verlet_state.verlet_skin is not None
+        flags.append(bool(jax.device_get(verlet_state.verlet_skin.should_rebuild)))
+
+    assert any(flags), "the rebuild trigger never fired; weaken the skin"
+    _positions_close(dense_state, verlet_state, integrator)
+
+
+def test_verlet_fused_blocks_match_dense() -> None:
+    """The skin path composes with blocked stepping: rebuilds happen on device
+    inside the fused loop and the trajectory still matches the dense one."""
+    block_size = 5
+    dense_state = _make_state(0.0, "csvr")
+    verlet_state = _make_state(SKIN, "csvr")
+    dense_prop, verlet_prop = _make_propagators(
+        "csvr", _cutoff_table(dense_state.systems)
+    )
+
+    dense = make_cycle_function(LoopPropagator(dense_prop, block_size))
+    verlet = make_cycle_function(LoopPropagator(verlet_prop, block_size))
+    dense_chain = key_chain(jax.random.key(1))
+    verlet_chain = key_chain(jax.random.key(1))
+    for _ in range(NUM_STEPS // block_size):
+        dense_state = propagate_and_fix(dense, next(dense_chain), dense_state)
+        verlet_state = propagate_and_fix(verlet, next(verlet_chain), verlet_state)
+
+    # No backstop replay happened (the extrapolating trigger kept ahead), so the
+    # two trajectories are at the same step and directly comparable.
+    assert int(verlet_state.step[0]) == NUM_STEPS
+    assert int(dense_state.step[0]) == NUM_STEPS
+    _positions_close(dense_state, verlet_state, "fused blocks")
+
+
+@pytest.mark.parametrize(
+    "sabotage",
+    [
+        # avg_edges only: the eager seed build OVERGROWS its local capacity (its
+        # assertions cannot surface), which desynchronizes the stored edges from
+        # the static params unless the seed refits them.
+        pytest.param({"avg_edges": 1}, id="avg_edges"),
+        pytest.param(
+            {"avg_edges": 1, "avg_candidates": 1, "avg_image_candidates": 1},
+            id="all",
+        ),
+    ],
+)
+def test_undersized_seed_capacities_are_repaired(sabotage: dict) -> None:
+    """The eager seed build cannot surface capacity assertions, so the first
+    traced step rebuilds under assertion coverage: deliberately undersized skin
+    capacities must be grown by the fix loop, not silently truncate the list or
+    crash the first trace with mismatched cond branch shapes."""
+    healthy = _make_state(SKIN, "csvr")
+    _, verlet_prop = _make_propagators("csvr", _cutoff_table(healthy.systems))
+    assert healthy.verlet_skin is not None
+    sabotaged = dataclasses.replace(healthy.verlet_skin.neighborlist_params, **sabotage)
+    state = _make_state(SKIN, "csvr", skin_params=sabotaged)
+
+    verlet = make_cycle_function(verlet_prop)
+    chain = key_chain(jax.random.key(1))
+    for _ in range(3):
+        state = propagate_and_fix(verlet, next(chain), state)
+
+    assert state.verlet_skin is not None
+    assert state.verlet_skin.neighborlist_params.avg_edges > 1
+    assert int(state.step[0]) == 3
+
+
+def test_unabsorbable_skin_escalates_with_config_hint() -> None:
+    """A skin far below one step's motion cannot be repaired by any rebuild
+    schedule; the backstop must fail with the configuration hint instead of
+    silently missing pairs."""
+    state_lens = identity_lens(MdState)
+    potential = make_lennard_jones_from_state(
+        state_lens,
+        parameters=_LJ_PARAMS,
+        gradient=POSITIONS_AND_CELL,
+        neighborlist_factory=skin_neighborlist,
+    )
+    tiny = 1e-4
+    state = _make_state(tiny, "csvr")
+    prop = make_md_propagator(
+        state_lens,
+        cast(Any, "csvr"),
+        potential,
+        verlet_skin=tiny,
+        cutoffs=_cutoff_table(state.systems),
+    )
+    cycle = make_cycle_function(prop)
+    with pytest.raises(ValueError, match="cannot absorb"):
+        propagate_and_fix(cycle, jax.random.key(1), state)
+
+
+@pytest.mark.parametrize("block_size", [1, 3])
+def test_run_entry_point_with_verlet_skin(block_size: int) -> None:
+    """The unified MD entry point wires the skin path end to end (seeding,
+    factory injection, fused blocks, HDF5 output readable by the analyzer)."""
+    from kups.application.md.analysis import analyze_md_file
+    from kups.application.simulations.md import Config, run
+    from kups.application.simulations.potentials import LjPotentialConfig
+
+    # The cubic 10.6 A cell (32 atoms) keeps (cutoff + skin) / box = 5.0 / 10.6
+    # inside the single-image limit.
+    inp_file = ar_cif(cubic=True)
+    out_file = tmp_h5()
+    config = Config(
+        run=MdRunConfig(
+            out_file=out_file,
+            num_steps=6,
+            num_warmup_steps=2,
+            block_size=block_size,
+            seed=42,
+        ),
+        md=MdParameters(
+            temperature=100.0,
+            time_step=2.0,
+            friction_coefficient=1.0,
+            thermostat_time_constant=100.0,
+            target_pressure=1.0,
+            pressure_coupling_time=1.0e10,
+            compressibility=4.5e-5,
+            minimum_scale_factor=1.0,
+            integrator="baoab_langevin",
+            initialize_momenta=True,
+            verlet_skin=1.0,
+        ),
+        potential=LjPotentialConfig(
+            cutoff=4.0,
+            parameters={"Ar": (3.405, 0.010326)},
+            mixing_rule="lorentz_berthelot",
+        ),
+        inp_files=(inp_file,),
+    )
+    run(config)
+    results = analyze_md_file(out_file, n_blocks=2)
+    result = next(iter(results.values()))
+    assert jnp.isfinite(result.total_energy.mean).all().item()
+    assert jnp.isfinite(result.temperature.mean).all().item()

--- a/test/application/test_md_lj.py
+++ b/test/application/test_md_lj.py
@@ -3,9 +3,6 @@
 
 """End-to-end smoke test for the Lennard-Jones MD entry point."""
 
-import tempfile
-
-import ase.build
 import jax.numpy as jnp
 import pytest
 
@@ -14,47 +11,7 @@ from kups.application.md.data import MdParameters, MdRunConfig
 from kups.application.simulations.md import Config, run
 from kups.application.simulations.potentials import LjPotentialConfig
 
-
-def _ar_cif(rattle: float = 0.0) -> str:
-    """Write a small fcc-argon supercell (32 atoms, ~10.6 Å cube) as a P1 CIF.
-
-    Labels are kept uniform (``Ar``) so they match the LJ parameter table;
-    ASE's CIF writer would otherwise uniquify them to ``Ar1``, ``Ar2``, ...
-    """
-    atoms = ase.build.bulk("Ar", "fcc", a=5.3) * (2, 2, 2)
-    if rattle:
-        atoms.rattle(rattle, seed=1)
-    a, b, c, al, be, ga = atoms.cell.cellpar()
-    rows = "\n".join(
-        f"Ar Ar {x:.6f} {y:.6f} {z:.6f}" for x, y, z in atoms.get_scaled_positions()
-    )
-    cif = f"""data_ar
-_cell_length_a {a:.6f}
-_cell_length_b {b:.6f}
-_cell_length_c {c:.6f}
-_cell_angle_alpha {al:.6f}
-_cell_angle_beta {be:.6f}
-_cell_angle_gamma {ga:.6f}
-_symmetry_space_group_name_H-M 'P 1'
-_symmetry_Int_Tables_number 1
-loop_
-_atom_site_label
-_atom_site_type_symbol
-_atom_site_fract_x
-_atom_site_fract_y
-_atom_site_fract_z
-{rows}
-"""
-    f = tempfile.NamedTemporaryFile(suffix=".cif", delete=False, mode="w")
-    f.write(cif)
-    f.close()
-    return f.name
-
-
-def _tmp_h5() -> str:
-    f = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
-    f.close()
-    return f.name
+from ._builders import ar_cif, tmp_h5
 
 
 def _config(out_file: str, inp_file: str) -> Config:
@@ -86,8 +43,8 @@ class TestRun:
 
     @pytest.fixture(scope="class")
     def out_file(self) -> str:
-        out = _tmp_h5()
-        run(_config(out, _ar_cif()))
+        out = tmp_h5()
+        run(_config(out, ar_cif()))
         return out
 
     def test_analyzer_reads_back_physical_outputs(self, out_file: str) -> None:

--- a/test/application/test_relax_lj.py
+++ b/test/application/test_relax_lj.py
@@ -4,9 +4,7 @@
 """End-to-end smoke test for the Lennard-Jones relaxation entry point."""
 
 import dataclasses
-import tempfile
 
-import ase.build
 import jax
 import jax.numpy as jnp
 import numpy.testing as npt
@@ -31,46 +29,7 @@ from kups.observables.stress import stress_via_virial_theorem, total_lattice_gra
 from kups.potential.classical.lennard_jones import LennardJonesParameters
 from kups.relaxation.config import make_optimizer
 
-
-def _ar_cif(rattle: float) -> str:
-    """Write a rattled fcc-argon supercell as a P1 CIF with uniform ``Ar`` labels.
-
-    The rattle gives the optimizer nonzero forces to act on; uniform labels
-    keep them matching the LJ parameter table (ASE's writer would uniquify).
-    """
-    atoms = ase.build.bulk("Ar", "fcc", a=5.3) * (2, 2, 2)
-    atoms.rattle(rattle, seed=1)
-    a, b, c, al, be, ga = atoms.cell.cellpar()
-    rows = "\n".join(
-        f"Ar Ar {x:.6f} {y:.6f} {z:.6f}" for x, y, z in atoms.get_scaled_positions()
-    )
-    cif = f"""data_ar
-_cell_length_a {a:.6f}
-_cell_length_b {b:.6f}
-_cell_length_c {c:.6f}
-_cell_angle_alpha {al:.6f}
-_cell_angle_beta {be:.6f}
-_cell_angle_gamma {ga:.6f}
-_symmetry_space_group_name_H-M 'P 1'
-_symmetry_Int_Tables_number 1
-loop_
-_atom_site_label
-_atom_site_type_symbol
-_atom_site_fract_x
-_atom_site_fract_y
-_atom_site_fract_z
-{rows}
-"""
-    f = tempfile.NamedTemporaryFile(suffix=".cif", delete=False, mode="w")
-    f.write(cif)
-    f.close()
-    return f.name
-
-
-def _tmp_h5() -> str:
-    f = tempfile.NamedTemporaryFile(suffix=".h5", delete=False)
-    f.close()
-    return f.name
+from ._builders import LBFGS_OPTIMIZER, ar_cif, tmp_h5
 
 
 def _config(out_file: str, inp_file: str, *, optimize_cell: bool = False) -> Config:
@@ -80,11 +39,7 @@ def _config(out_file: str, inp_file: str, *, optimize_cell: bool = False) -> Con
             max_steps=5,
             seed=42,
             force_tolerance=0.5,
-            optimizer=[
-                {"transform": "scale_by_ase_lbfgs", "memory_size": 10, "alpha": 70},
-                {"transform": "max_step_size", "max_step_size": 0.2},
-                {"transform": "scale", "step_size": -1},
-            ],
+            optimizer=LBFGS_OPTIMIZER,
             optimize_cell=optimize_cell,
         ),
         potential=LjPotentialConfig(
@@ -101,8 +56,8 @@ class TestRun:
 
     @pytest.fixture(scope="class")
     def out_file(self) -> str:
-        out = _tmp_h5()
-        run(_config(out, _ar_cif(rattle=0.1)))
+        out = tmp_h5()
+        run(_config(out, ar_cif(rattle=0.1)))
         return out
 
     def test_analyzer_reads_back_physical_outputs(self, out_file: str):
@@ -116,7 +71,7 @@ class TestRun:
 
 def _build_propagator(optimize_cell: bool):
     """Build an LJ relaxation propagator and its initial state."""
-    config = _config(_tmp_h5(), _ar_cif(rattle=0.1), optimize_cell=optimize_cell)
+    config = _config(tmp_h5(), ar_cif(rattle=0.1), optimize_cell=optimize_cell)
     assert isinstance(config.potential, LjPotentialConfig)
     lj = LennardJonesParameters.from_dict(
         cutoff=config.potential.cutoff,

--- a/test/application/test_relax_verlet.py
+++ b/test/application/test_relax_verlet.py
@@ -1,0 +1,186 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Relaxation integration tests for the Verlet-skin neighbor list.
+
+Mirrors ``test/application/md/test_verlet.py`` for the relaxation driver: the
+rebuild schedule is driven by the real on-device trigger and the resulting
+optimisation trajectory is compared against the every-step dense path. Pure
+trigger/refine unit tests live in ``test/core/neighborlist/test_verlet.py``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from kups.application.potential.classical.lennard_jones import (
+    make_lennard_jones_from_state,
+)
+from kups.application.potential.filter import POSITIONS_ONLY
+from kups.application.relaxation.data import (
+    RelaxRunConfig,
+    RelaxState,
+    relax_state_from_ase,
+)
+from kups.application.relaxation.simulation import make_relax_propagator
+from kups.application.utils.propagate import make_cycle_function
+from kups.core.lens import identity_lens
+from kups.core.neighborlist import (
+    AdaptiveNeighborList,
+    UniversalNeighborlistParameters,
+    VerletSkinState,
+    skin_neighborlist,
+)
+from kups.core.propagator import propagate_and_fix
+from kups.potential.classical.lennard_jones import LennardJonesParameters
+from kups.relaxation.config import make_optimizer
+
+from ._builders import LBFGS_OPTIMIZER, ar_cif, tmp_h5
+
+# Ar fcc 2x2x2 -> 32 atoms, 10.6 A box; (cutoff + skin) / box < 0.5 (single
+# image). The 0.2 A max step size keeps one step's margin consumption (at most
+# 0.4 A) inside the 0.6 A budget, while the rattle is large enough that the
+# displacement trigger fires within a few optimisation steps.
+CUTOFF, SKIN, NUM_STEPS = 4.0, 0.6, 8
+
+_LJ_PARAMS = LennardJonesParameters.from_dict(
+    cutoff=CUTOFF, parameters={"Ar": (3.405, 0.010326)}, mixing_rule="lorentz_berthelot"
+)
+
+
+def _build(skin: float, rattle: float = 0.15):
+    """A relaxation propagator and its initial state, with or without a skin."""
+    state_lens = identity_lens(RelaxState)
+    optimizer = make_optimizer(LBFGS_OPTIMIZER)
+    potential = make_lennard_jones_from_state(
+        state_lens,
+        parameters=_LJ_PARAMS,
+        gradient=POSITIONS_ONLY,
+        neighborlist_factory=skin_neighborlist
+        if skin > 0
+        else AdaptiveNeighborList.from_state,
+    )
+    particles, systems = relax_state_from_ase(ar_cif(rattle, cubic=True))
+    cutoffs = _LJ_PARAMS.cutoff
+    propagator, opt_init = make_relax_propagator(
+        state_lens,
+        potential,
+        optimizer,
+        POSITIONS_ONLY,
+        verlet_skin=skin,
+        cutoffs=cutoffs,
+    )
+    state = RelaxState(
+        particles=particles,
+        systems=systems,
+        neighborlist_params=UniversalNeighborlistParameters.estimate(
+            particles.data.system.counts, systems, cutoffs
+        ),
+        opt_state=opt_init(particles, systems),
+        step=jnp.array([0]),
+        verlet_skin=VerletSkinState.seed(particles, systems, cutoffs, skin)
+        if skin > 0
+        else None,
+    )
+    return propagator, state
+
+
+def test_verlet_relaxation_matches_dense() -> None:
+    """The on-device trigger reproduces the every-step dense optimisation
+    trajectory, and it actually fires at least once."""
+    dense_prop, dense_state = _build(0.0)
+    verlet_prop, verlet_state = _build(SKIN)
+
+    dense = make_cycle_function(dense_prop)
+    verlet = make_cycle_function(verlet_prop)
+    flags = []
+    for i in range(NUM_STEPS):
+        key = jax.random.key(i)  # relaxation consumes no randomness
+        dense_state = propagate_and_fix(dense, key, dense_state)
+        verlet_state = propagate_and_fix(verlet, key, verlet_state)
+        assert verlet_state.verlet_skin is not None
+        flags.append(bool(jax.device_get(verlet_state.verlet_skin.should_rebuild)))
+
+    assert any(flags), "the rebuild trigger never fired; weaken the skin"
+    max_diff = float(
+        jnp.max(
+            jnp.abs(
+                dense_state.particles.data.positions
+                - verlet_state.particles.data.positions
+            )
+        )
+    )
+    assert max_diff < 1e-8, f"Verlet diverged from dense: {max_diff:.2e}"
+    assert int(verlet_state.step[0]) == NUM_STEPS
+
+
+def test_unabsorbable_skin_escalates_with_config_hint() -> None:
+    """A skin far below one optimisation step's motion cannot be repaired by
+    any rebuild schedule; the backstop must fail with the configuration hint
+    instead of silently missing pairs."""
+    tiny = 1e-4
+    prop, state = _build(tiny)
+    cycle = make_cycle_function(prop)
+    with pytest.raises(ValueError, match="cannot absorb"):
+        propagate_and_fix(cycle, jax.random.key(0), state)
+
+
+def test_run_entry_point_with_verlet_skin() -> None:
+    """The unified relaxation entry point wires the skin path end to end
+    (seeding, factory injection, HDF5 output readable by the analyzer)."""
+    from kups.application.relaxation.analysis import analyze_relax_file
+    from kups.application.simulations.potentials import LjPotentialConfig
+    from kups.application.simulations.relax import Config, run
+
+    out_file = tmp_h5()
+    config = Config(
+        run=RelaxRunConfig(
+            out_file=out_file,
+            max_steps=NUM_STEPS,
+            seed=42,
+            force_tolerance=1e-6,
+            optimizer=LBFGS_OPTIMIZER,
+            optimize_cell=False,
+            verlet_skin=SKIN,
+        ),
+        potential=LjPotentialConfig(
+            cutoff=CUTOFF,
+            parameters={"Ar": (3.405, 0.010326)},
+            mixing_rule="lorentz_berthelot",
+        ),
+        inp_files=(ar_cif(rattle=0.15, cubic=True),),
+    )
+    run(config)
+    results = analyze_relax_file(out_file)
+    result = next(iter(results.values()))
+    assert jnp.isfinite(jnp.asarray(result.final_energy)).item()
+    assert jnp.isfinite(jnp.asarray(result.final_max_force)).item()
+    assert result.n_steps >= 1
+
+
+def test_verlet_group_is_seedable_with_undersized_params() -> None:
+    """Deliberately undersized skin capacities are grown by the fix loop on the
+    first traced steps instead of truncating the list (mirrors the MD test)."""
+    prop, state = _build(SKIN)
+    assert state.verlet_skin is not None
+    sabotaged = dataclasses.replace(state.verlet_skin.neighborlist_params, avg_edges=1)
+    group = VerletSkinState.seed(
+        state.particles,
+        state.systems,
+        _LJ_PARAMS.cutoff,
+        SKIN,
+        params=sabotaged,
+    )
+    state = dataclasses.replace(state, verlet_skin=group)
+
+    cycle = make_cycle_function(prop)
+    for i in range(3):
+        state = propagate_and_fix(cycle, jax.random.key(i), state)
+
+    assert state.verlet_skin is not None
+    assert state.verlet_skin.neighborlist_params.avg_edges > 1
+    assert int(state.step[0]) == 3


### PR DESCRIPTION
**Stack (bottom → top):** #261 → #262 → #263 → #264 → #194

Top of the **Verlet-skin stack** (assert-repair tests → neighborlist_factory → margin bound → skin machinery → **this PR**).

## What

`md.verlet_skin > 0` builds the potential with `neighborlist_factory=skin_neighborlist`, seeds the Verlet fields on `MdState` via `seed_verlet_state`, and runs one ordinary propagator (`make_verlet_md_propagator`: rebuild-if-flagged → MD step → trigger/backstop) through the plain `run_md` driver at **any `block_size`** — no host-side dispatch, no per-step device→host sync, no special run loop. The rebuild/trigger steps don't consume the PRNG chain, so the noise matches a `verlet_skin = 0` run key for key.

## Tests

- Trajectory equivalence vs the every-step dense path with identical keys, per-step **and** fused (`block_size=5`), for `csvr` and `csvr_npt`.
- Mid-run capacity repair from an undersized seed (both sabotage variants: `avg_edges`-only, which makes the eager seed overgrow, and all-three).
- The escalation path (`verlet_skin` too small to absorb one step → `ValueError` with a configuration hint).
- Entry point end to end at `block_size` 1 and 3 (seeding, factory injection, HDF5 readable by the analyzer).

## Notes for the stack

The design rationale, the completeness bound, and the review history (an adversarial multi-agent review confirmed and led to fixes for cross-system margin coupling, an eager-seed shape desync, and corrected revert-semantics documentation; a fuzzer compared the refined list against brute-force image enumeration over 300+ boundary-adversarial trials with zero soundness violations) live in the lower PRs of this stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
