### PR TITLE
feat: add fused real-space nonbonded (LJ + short-range Ewald) potential

### DIFF
--- a/src/kups/potential/classical/__init__.py
+++ b/src/kups/potential/classical/__init__.py
@@ -50,6 +50,12 @@ from .lennard_jones import (
     make_pair_tail_corrected_lennard_jones_potential,
 )
 from .morse import MorseBondParameters, make_morse_bond_potential
+from .nonbonded import (
+    NonbondedParameters,
+    fused_nonbonded_edge_energy,
+    make_nonbonded_from_state,
+    nonbonded_energy,
+)
 
 __all__ = [
     "make_cosine_angle_potential",
@@ -62,6 +68,10 @@ __all__ = [
     "make_lennard_jones_potential",
     "make_global_lennard_jones_tail_correction_potential",
     "make_pair_tail_corrected_lennard_jones_potential",
+    "make_nonbonded_from_state",
+    "nonbonded_energy",
+    "fused_nonbonded_edge_energy",
+    "NonbondedParameters",
     "CosineAngleParameters",
     "cosine_angle_energy",
     "DihedralParameters",

--- a/src/kups/potential/classical/nonbonded.py
+++ b/src/kups/potential/classical/nonbonded.py
@@ -1,0 +1,249 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Fused real-space nonbonded potential: Lennard-Jones + short-range Ewald.
+
+Combines the two real-space potentials kups builds separately —
+``make_lennard_jones_from_state`` and the short-range term of ``make_ewald_from_state`` —
+into a single ``PotentialFromEnergy`` that builds one radius graph (one neighbor-list
+query, one edge gather) and runs one ``jax.vjp`` over the summed energy. Forces (``dE/dr``)
+and NPT stress (``dE/dcell``) come from autodiff through the shared ``PositionAndCell``
+gradient lens.
+
+Two energy bodies are provided:
+
+  * ``nonbonded_energy`` calls the existing ``lennard_jones_energy`` and
+    ``ewald_short_range_energy`` on the shared graph and tree-adds the per-system results.
+    Numerics are identical to the two potentials summed; the win is the shared graph and
+    the single backward pass.
+  * ``fused_nonbonded_edge_energy`` does one edge gather, one ``r²``, and both LJ and
+    screened-Coulomb in the same body, saving the second gather and distance inside the
+    forward pass. It duplicates the per-edge formulas from the two source functions and
+    must be kept in sync with them.
+
+Full-recompute only (no Monte Carlo incremental/probe path).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, cast, runtime_checkable
+
+import jax
+import jax.numpy as jnp
+
+from kups.core.data import Table
+from kups.core.lens import Lens, SimpleLens, View
+from kups.core.neighborlist import NearestNeighborList
+from kups.core.patch import IdPatch, Patch, WithPatch
+from kups.core.potential import EMPTY_LENS, Energy, Potential
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass, field
+from kups.potential.classical.ewald import (
+    TO_STANDARD_UNITS,
+    EwaldParameters,
+    IsEwaldPointData,
+    ewald_short_range_energy,
+)
+from kups.potential.classical.lennard_jones import (
+    IsLJGraphParticles,
+    LennardJonesParameters,
+    lennard_jones_energy,
+)
+from kups.potential.common.energy import (
+    PositionAndCell,
+    PotentialFromEnergy,
+    position_and_cell_idx_view,
+)
+from kups.potential.common.graph import (
+    GraphPotentialInput,
+    LocalGraphSumComposer,
+    RadiusGraphConstructor,
+)
+
+
+@runtime_checkable
+class IsNonbondedPoints(IsLJGraphParticles, IsEwaldPointData, Protocol):
+    """Particle data carrying everything both terms need: positions, system index,
+    inclusion/exclusion (the radius graph), species labels (LJ), and charges (Ewald)."""
+
+
+@dataclass
+class NonbondedParameters:
+    """Bundle of the two existing parameter objects.
+
+    Attributes:
+        lj: Lennard-Jones parameters (species sigma/epsilon matrices, cutoff).
+        ewald: Ewald parameters (alpha, real-space cutoff, k-vectors). Only ``alpha`` and
+            ``cutoff`` are used by the real-space term; ``reciprocal_lattice_shifts`` is
+            carried so the same object also feeds the long-range/self potentials.
+    """
+
+    lj: LennardJonesParameters
+    ewald: EwaldParameters
+
+
+type NonbondedInput = GraphPotentialInput[
+    NonbondedParameters, IsNonbondedPoints, Any, Literal[2]
+]
+
+
+def nonbonded_energy(
+    inp: NonbondedInput,
+) -> WithPatch[Table[SystemId, Energy], IdPatch]:
+    """LJ + real-space Ewald on one shared graph, summed per system.
+
+    Reuses the existing energy functions verbatim by re-bundling the shared graph with each
+    parameter set, so numerics match ``lennard_jones_energy + ewald_short_range_energy``.
+    The win is structural: a single ``PotentialFromEnergy`` over one graph build and one
+    ``jax.vjp``.
+    """
+    graph = inp.graph
+    lj_e = lennard_jones_energy(
+        cast(Any, GraphPotentialInput(inp.parameters.lj, graph))
+    )
+    sr_e = ewald_short_range_energy(
+        cast(Any, GraphPotentialInput(inp.parameters.ewald, graph))
+    )
+    total = jax.tree.map(jnp.add, lj_e.data, sr_e.data)
+    return WithPatch(total, IdPatch())
+
+
+def fused_nonbonded_edge_energy(
+    inp: NonbondedInput,
+) -> WithPatch[Table[SystemId, Energy], IdPatch]:
+    """Single-pass LJ + screened-Coulomb: one edge gather, one ``r²``, both terms.
+
+    Duplicates the per-edge formulas from ``lennard_jones_edge_energy`` and
+    ``ewald_short_range_energy`` (keep in sync); equivalent numerics. Saves the second edge
+    gather and distance computation inside the forward pass.
+    """
+    graph = inp.graph
+    lj, ew = inp.parameters.lj, inp.parameters.ewald
+
+    edg = graph.particles[graph.edges.indices]
+    r2 = jnp.sum(graph.edge_shifts[:, 0] ** 2, axis=-1)
+    r = jnp.sqrt(r2)
+    batch = graph.edge_batch_mask
+
+    species = edg.labels.indices_in(lj.labels)
+    eps = lj.epsilon[species[:, 0], species[:, 1]]
+    sig = lj.sigma[species[:, 0], species[:, 1]]
+    c6 = (sig**2 / r2) ** 3
+    e_lj = 4 * eps * (c6**2 - c6)
+    e_lj *= r2 < jnp.pow(lj.cutoff.data, 2)[batch.indices]
+
+    qij = edg.charges[:, 0] * edg.charges[:, 1]
+    erfc = jax.scipy.special.erfc(ew.alpha[batch] * r)
+    e_c = qij * erfc / r * TO_STANDARD_UNITS
+    e_c *= r < ew.cutoff[batch]
+
+    total = batch.sum_over(e_lj + e_c) / 2
+    return WithPatch(total, IdPatch())
+
+
+class IsNonbondedState(Protocol):
+    """State providing both potentials' inputs (intersection of IsLJState and IsEwaldState)."""
+
+    @property
+    def particles(self) -> Table[ParticleId, IsNonbondedPoints]: ...
+    @property
+    def systems(self) -> Table[SystemId, Any]: ...
+    @property
+    def neighborlist(self) -> NearestNeighborList: ...
+    @property
+    def lj_parameters(self) -> LennardJonesParameters: ...
+    @property
+    def ewald_parameters(self) -> EwaldParameters: ...
+
+
+@dataclass
+class _NonbondedParamView:
+    """View bundling the two parameter views into one ``NonbondedParameters``.
+
+    A dataclass (not a bare lambda) so it is a hashable/comparable static pytree field,
+    matching how the composers hold their views.
+    """
+
+    lj: View[Any, LennardJonesParameters] = field(static=True)
+    ewald: View[Any, EwaldParameters] = field(static=True)
+
+    def __call__(self, state: Any) -> NonbondedParameters:
+        return NonbondedParameters(lj=self.lj(state), ewald=self.ewald(state))
+
+
+@dataclass
+class _MaxCutoffView:
+    """Per-system ``max(lj.cutoff, ewald.cutoff)`` so the one shared graph covers both terms.
+
+    Uses the Ewald cutoff's per-system keys (the LJ cutoff table is length-1 and
+    broadcasts). Each term still masks edges by its own cutoff inside the energy fn, so an
+    over-wide graph only costs a few extra masked candidate edges.
+    """
+
+    lj: View[Any, LennardJonesParameters] = field(static=True)
+    ewald: View[Any, EwaldParameters] = field(static=True)
+
+    def __call__(self, state: Any) -> Table[SystemId, Any]:
+        a = self.lj(state).cutoff
+        b = self.ewald(state).cutoff
+        return Table(
+            b.keys, jnp.broadcast_to(jnp.maximum(a.data, b.data), b.data.shape)
+        )
+
+
+def make_nonbonded_from_state(
+    state: Lens[Any, IsNonbondedState],
+    *,
+    compute_position_and_cell_gradients: bool = False,
+    fused_edge: bool = False,
+) -> Potential[Any, PositionAndCell, Any, Patch]:
+    """Fused LJ + real-space-Ewald potential from a typed state (full-recompute only).
+
+    Drop-in for ``sum_potentials(make_lennard_jones_from_state(...),
+    make_ewald_from_state(...).short_range)``: build this for the real-space pair, then sum
+    with the Ewald long-range / self (/ exclusion) potentials.
+
+    Args:
+        state: Lens to the sub-state with particles, systems, neighborlist,
+            ``lj_parameters`` and ``ewald_parameters``.
+        compute_position_and_cell_gradients: forces (dE/dr) + NPT stress (dE/dcell) via autodiff.
+        fused_edge: use the single-pass edge body; else the maximal-reuse body.
+    """
+    lj_view: Any = state.focus(lambda s: s.lj_parameters)
+    ew_view: Any = state.focus(lambda s: s.ewald_parameters)
+
+    graph_fn = RadiusGraphConstructor(
+        particles=state.focus(lambda s: s.particles),
+        systems=state.focus(lambda s: s.systems),
+        cutoffs=cast(Any, _MaxCutoffView(lj_view, ew_view)),
+        neighborlist=state.focus(lambda s: s.neighborlist),
+        probe=None,
+    )
+    composer = LocalGraphSumComposer(
+        graph_constructor=graph_fn,
+        parameter_view=cast(Any, _NonbondedParamView(lj_view, ew_view)),
+    )
+
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[GraphPotentialInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+
+    return cast(
+        Any,
+        PotentialFromEnergy(
+            energy_fn=fused_nonbonded_edge_energy if fused_edge else nonbonded_energy,
+            composer=composer,
+            gradient_lens=gradient_lens,
+            hessian_lens=EMPTY_LENS,
+            hessian_idx_view=EMPTY_LENS,
+            cache_lens=None,
+            patch_idx_view=patch_idx_view,
+        ),
+    )

--- a/test/potential/test_nonbonded.py
+++ b/test/potential/test_nonbonded.py
@@ -1,0 +1,182 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the fused real-space nonbonded potential (``kups.potential.classical.nonbonded``).
+
+The fused energy (LJ + short-range Ewald on one shared graph, one vjp) must reproduce the
+sum of the separate components — ``lennard_jones_energy`` + ``ewald_short_range_energy`` —
+for energy AND forces (``dE/dr``) AND the NPT stress (``dE/dcell``), for both the Tier-A
+(maximal-reuse) and Tier-B (single-pass edge) bodies, single- and multi-system. The trusted
+oracles are the existing component energy functions.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+
+from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
+from kups.core.data.index import Index
+from kups.core.data.table import Table
+from kups.core.neighborlist import Edges
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass
+from kups.potential.classical.ewald import EwaldParameters, ewald_short_range_energy
+from kups.potential.classical.lennard_jones import (
+    LennardJonesParameters,
+    lennard_jones_energy,
+)
+from kups.potential.classical.nonbonded import (
+    NonbondedParameters,
+    fused_nonbonded_edge_energy,
+    nonbonded_energy,
+)
+from kups.potential.common.graph import GraphPotentialInput, HyperGraph
+
+from ..clear_cache import clear_cache  # noqa: F401
+
+_LABELS = ("Na", "Cl")
+_FUSED = {"TierA": nonbonded_energy, "TierB": fused_nonbonded_edge_energy}
+
+
+@dataclass
+class _NBPointData:
+    positions: jax.Array
+    labels: Index[str]
+    charges: jax.Array
+    system: Index[SystemId]
+
+
+@dataclass
+class _SysData:
+    cell: Cell
+    cutoff: jax.Array
+
+
+def _params(
+    n_sys: int, cutoff: float = 50.0, alpha: float = 0.3
+) -> NonbondedParameters:
+    keys = tuple(SystemId(i) for i in range(n_sys))
+    lj = LennardJonesParameters(
+        labels=_LABELS,
+        sigma=jnp.array([[2.4, 3.4], [3.4, 4.4]]),
+        epsilon=jnp.array([[0.0015, 0.003], [0.003, 0.005]]),
+        cutoff=Table(keys, jnp.full((n_sys,), cutoff)),
+    )
+    ew = EwaldParameters(
+        alpha=Table(keys, jnp.full((n_sys,), alpha)),
+        cutoff=Table(keys, jnp.full((n_sys,), cutoff)),
+        reciprocal_lattice_shifts=Table(keys, jnp.zeros((n_sys, 1, 3), dtype=int)),
+    )
+    return NonbondedParameters(lj=lj, ewald=ew)
+
+
+def _graph(positions, species, charges, system_ids, cells) -> HyperGraph:
+    particles = Table.arange(
+        _NBPointData(positions, Index.new(species), charges, Index.new(system_ids)),
+        label=ParticleId,
+    )
+    cell = PeriodicCell(TriclinicFrame.from_matrix(cells))
+    systems = Table.arange(
+        _SysData(cell, jnp.full((cells.shape[0],), 50.0)), label=SystemId
+    )
+    n = positions.shape[0]
+    sysarr = jnp.asarray(system_ids)
+    # all in-system pairs; large box => no periodic image crossing (zero shifts)
+    pairs = jnp.array(
+        [[i, j] for i in range(n) for j in range(n) if i < j and sysarr[i] == sysarr[j]]
+    )
+    edges = Edges(
+        indices=Index(particles.keys, pairs),
+        shifts=jnp.zeros((pairs.shape[0], 1, 3)),
+    )
+    return HyperGraph(particles, systems, edges)
+
+
+def _reference_energy(params, graph):
+    lj = lennard_jones_energy(GraphPotentialInput(params.lj, graph)).data.data
+    sr = ewald_short_range_energy(GraphPotentialInput(params.ewald, graph)).data.data
+    return lj + sr
+
+
+def _single():
+    positions = jnp.array(
+        [
+            [0.0, 0.0, 0.0],
+            [2.8, 0.0, 0.0],
+            [0.0, 2.8, 0.0],
+            [2.8, 2.8, 0.0],
+            [1.4, 1.4, 2.0],
+            [1.4, 1.4, -2.0],
+        ]
+    )
+    return dict(
+        positions=positions,
+        species=["Na", "Cl", "Cl", "Na", "Na", "Cl"],
+        charges=jnp.array([1.0, -1.0, -1.0, 1.0, 1.0, -1.0]),
+        system_ids=[0, 0, 0, 0, 0, 0],
+        cells=jnp.eye(3)[None] * 100.0,
+    )
+
+
+def _two():
+    base = jnp.array(
+        [[0.0, 0.0, 0.0], [2.8, 0.0, 0.0], [0.0, 2.8, 0.0], [1.4, 1.4, 2.0]]
+    )
+    return dict(
+        positions=jnp.concatenate([base, base + 0.3]),
+        species=["Na", "Cl", "Cl", "Na"] * 2,
+        charges=jnp.array([1.0, -1.0, -1.0, 1.0] * 2),
+        system_ids=[0, 0, 0, 0, 1, 1, 1, 1],
+        cells=jnp.broadcast_to(jnp.eye(3) * 100.0, (2, 3, 3)),
+    )
+
+
+def test_fused_energy_matches_components_single():
+    cfg, params = _single(), _params(1)
+    graph = _graph(**cfg)
+    ref = _reference_energy(params, graph)
+    for name, fn in _FUSED.items():
+        got = fn(GraphPotentialInput(params, graph)).data.data
+        npt.assert_allclose(got, ref, rtol=1e-5, err_msg=f"{name} energy mismatch")
+
+
+def test_fused_energy_matches_components_batched():
+    cfg, params = _two(), _params(2)
+    graph = _graph(**cfg)
+    ref = _reference_energy(params, graph)
+    assert ref.shape == (2,)
+    for name, fn in _FUSED.items():
+        got = fn(GraphPotentialInput(params, graph)).data.data
+        npt.assert_allclose(
+            got, ref, rtol=1e-5, err_msg=f"{name} batched energy mismatch"
+        )
+
+
+def _grad_fns(energy_or_array_fn, params, cfg):
+    def total(pos, cellm):
+        g = _graph(pos, cfg["species"], cfg["charges"], cfg["system_ids"], cellm)
+        return energy_or_array_fn(params, g).sum()
+
+    return jax.grad(total, argnums=(0, 1))(cfg["positions"], cfg["cells"])
+
+
+def test_fused_forces_and_stress_match_components():
+    cfg, params = _single(), _params(1)
+    dpos_ref, dcell_ref = _grad_fns(_reference_energy, params, cfg)
+    for name, fn in _FUSED.items():
+        arr_fn = lambda p, g, fn=fn: fn(GraphPotentialInput(p, g)).data.data  # noqa: E731
+        dpos, dcell = _grad_fns(arr_fn, params, cfg)
+        npt.assert_allclose(
+            dpos,
+            dpos_ref,
+            rtol=1e-5,
+            atol=1e-10,
+            err_msg=f"{name} forces (dE/dr) mismatch",
+        )
+        npt.assert_allclose(
+            dcell,
+            dcell_ref,
+            rtol=1e-5,
+            atol=1e-10,
+            err_msg=f"{name} stress (dE/dcell) mismatch",
+        )


### PR DESCRIPTION
Combines the two real-space potentials kups builds separately — `make_lennard_jones_from_state` and the short-range term of `make_ewald_from_state` — into one `PotentialFromEnergy` that builds a single radius graph (one neighbor-list query, one edge gather) and runs one `jax.vjp` over the summed energy. Forces and NPT stress come from autodiff through the shared gradient lens.

Two energy bodies: `nonbonded_energy` (reuses the existing energy fns on the shared graph; numerics identical to the two summed) and `fused_nonbonded_edge_energy` (single edge gather/r², both terms inline). Full-recompute only.

Tests: `test/potential/test_nonbonded.py` (3 pass; energy/forces/stress match the separate-component oracle, both bodies).

Stacked on #194.