### PR TITLE
feat: add forces-only NVE/NVT path (skip dE/dcell)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,11 @@ docs/reference
 .vscode/
 *.pt
 *.model
+
+# local development
+.bedrock/
+plans/
+bench/
+benchmarks/
+.vscode-annotator/
+.mcp.json

--- a/src/kups/application/md/data.py
+++ b/src/kups/application/md/data.py
@@ -188,7 +188,10 @@ class MdParameters(BaseModel):
     minimum_scale_factor: float
     """Minimum allowed box scaling factor per barostat step (dimensionless)."""
     integrator: Integrator
-    """Integration algorithm to use."""
+    """Integration algorithm: ``"verlet"`` (NVE), ``"baoab_langevin"`` / ``"csvr"`` (NVT),
+    ``"csvr_npt"`` (NPT), or ``"csvr_npt_1eval"`` (NPT, dropping the redundant
+    post-barostat force/stress eval; prefer plain ``"csvr_npt"`` for fast barostats or
+    anisotropic cells)."""
     initialize_momenta: bool = False
     """If True, initialize momenta from Maxwell-Boltzmann distribution."""
 
@@ -276,7 +279,7 @@ def _build_integrator_params(config: MdParameters) -> IntegratorParams:
                     [config.thermostat_time_constant * FEMTO_SECOND]
                 ),
             )
-        case "csvr_npt":
+        case "csvr_npt" | "csvr_npt_1eval":  # same control parameters
             return CSVRNPTParams(
                 time_step=time_step,
                 temperature=temperature,

--- a/src/kups/application/md/data.py
+++ b/src/kups/application/md/data.py
@@ -194,6 +194,12 @@ class MdParameters(BaseModel):
     anisotropic cells)."""
     initialize_momenta: bool = False
     """If True, initialize momenta from Maxwell-Boltzmann distribution."""
+    verlet_skin: float = 0.0
+    """Verlet neighbor-list skin width (Å). 0 (default) rebuilds the neighbor list every
+    step. If > 0, build it once at ``cutoff + verlet_skin`` and reuse it across steps,
+    rebuilding only when atoms move or the box strains enough that a new neighbor could
+    intrude. Reuse is results-identical (the rebuild trigger guarantees completeness); a
+    value around the inter-particle spacing (e.g. 1.0 Å) is a reasonable starting point."""
 
 
 def md_state_from_ase(

--- a/src/kups/application/md/simulation.py
+++ b/src/kups/application/md/simulation.py
@@ -80,6 +80,7 @@ def make_md_propagator[State: IsMdState, Grad: IsMdGradients](
     state_lens: Lens[State, State],
     integrator: Integrator,
     potential: Potential[State, Grad, EmptyType, Any],
+    forces_only: bool = False,
 ) -> Propagator[State]:
     """Build a single MD propagator step with error recovery and step counting.
 
@@ -87,33 +88,65 @@ def make_md_propagator[State: IsMdState, Grad: IsMdGradients](
         state_lens: Lens focusing on the MD sub-state within the full state.
         integrator: Integration algorithm for equations of motion.
         potential: Potential energy function providing forces and gradients.
-
-    Returns:
-        Propagator that advances the state by one MD step.
+        forces_only: NVE/NVT optimization. When True, the step neither maps nor caches the
+            cell-virial (``dE/dcell``); pair with a ``forces_only=True`` potential to skip
+            computing it. Invalid for the NPT integrators (the barostat needs stress).
+            ``cell_gradients`` is then not refreshed, so logged stress/pressure is
+            unavailable — keep the default when you need the stress observable.
     """
-    mapped_potential = MappedPotential(
-        potential, lambda x: (x.positions.data, x.cell.data), identity
-    )
-    derivative_computation = PotentialAsPropagator(
-        CachedPotential(
-            mapped_potential,
-            lens(
-                lambda x: PotentialOut(
-                    x.systems.map_data(lambda x: x.potential_energy),
-                    (
-                        x.particles.data.position_gradients,
-                        x.systems.data.cell_gradients,
-                    ),
-                    EMPTY,
-                )
-            ),
-            lambda x: PotentialOut(
-                x.systems.index,  # type: ignore
-                (x.particles.data.system, x.systems.index),
-                EMPTY,
-            ),  # type: ignore
+    if forces_only and integrator in ("csvr_npt", "csvr_npt_1eval"):
+        raise ValueError(
+            f"forces_only=True is invalid for NPT integrator {integrator!r}: "
+            "the barostat needs the cell-virial (stress)."
         )
-    )
+    if forces_only:
+        # Map positions from either a forces_only potential (gradient is a positions Table,
+        # has .data) or a both-gradients potential (PositionAndCell, has .positions); cache
+        # only position_gradients (cell_gradients is left untouched).
+        derivative_computation = PotentialAsPropagator(
+            CachedPotential(
+                MappedPotential(
+                    potential,
+                    lambda x: x.positions.data if hasattr(x, "positions") else x.data,  # type: ignore
+                    identity,
+                ),
+                lens(
+                    lambda x: PotentialOut(
+                        x.systems.map_data(lambda x: x.potential_energy),
+                        x.particles.data.position_gradients,
+                        EMPTY,
+                    )
+                ),
+                lambda x: PotentialOut(
+                    x.systems.index,  # type: ignore
+                    x.particles.data.system,
+                    EMPTY,
+                ),  # type: ignore
+            )
+        )
+    else:
+        derivative_computation = PotentialAsPropagator(
+            CachedPotential(
+                MappedPotential(
+                    potential, lambda x: (x.positions.data, x.cell.data), identity
+                ),
+                lens(
+                    lambda x: PotentialOut(
+                        x.systems.map_data(lambda x: x.potential_energy),
+                        (
+                            x.particles.data.position_gradients,
+                            x.systems.data.cell_gradients,
+                        ),
+                        EMPTY,
+                    )
+                ),
+                lambda x: PotentialOut(
+                    x.systems.index,  # type: ignore
+                    (x.particles.data.system, x.systems.index),
+                    EMPTY,
+                ),  # type: ignore
+            )
+        )
     md_propagator = make_md_step_from_state(
         state_lens, derivative_computation, integrator
     )
@@ -160,8 +193,11 @@ def make_verlet_md_propagators[State: IsMdState, Grad: IsMdGradients](
     cutoff: float,
     skin: float,
     skin_nl: NearestNeighborList,
+    forces_only: bool = False,
 ) -> tuple[Propagator[State], Propagator[State]]:
     """Build the (reuse, rebuild) propagator pair for a Verlet-skin MD run.
+
+    ``forces_only`` (NVE/NVT only) skips the cell-virial; see :func:`make_md_propagator`.
 
     Both share the same MD step (which reads ``state.neighborlist`` — a
     ``RefineCutoffNeighborList`` over the stored skin list); ``rebuild`` first refreshes
@@ -169,7 +205,7 @@ def make_verlet_md_propagators[State: IsMdState, Grad: IsMdGradients](
     cell-list for large boxes — see ``neighborlist.verlet.dense_skin_nl`` / ``cell_skin_nl``).
     Each appends a ``TriggerStep`` that sets ``state.should_rebuild`` for the next dispatch.
     """
-    md_propagator = make_md_propagator(state_lens, integrator, potential)
+    md_propagator = make_md_propagator(state_lens, integrator, potential, forces_only)
     trigger = TriggerStep(cutoff, skin)
     rebuild = RebuildSkinStep(cutoff, skin, skin_nl)
 

--- a/src/kups/application/md/simulation.py
+++ b/src/kups/application/md/simulation.py
@@ -12,11 +12,17 @@ from kups.application.md.data import (
     MDSystems,
 )
 from kups.application.md.logging import MDLoggedData
-from kups.application.utils.propagate import run_simulation_cycles, run_warmup_cycles
+from kups.application.utils.propagate import (
+    run_simulation_cycles,
+    run_verlet_cycles,
+    run_warmup_cycles,
+)
 from kups.core.cell import Cell
 from kups.core.data import Table
 from kups.core.lens import Lens, lens
 from kups.core.logging import CompositeLogger, TqdmLogger
+from kups.core.neighborlist import NearestNeighborList
+from kups.core.neighborlist.verlet import RebuildSkinStep, TriggerStep
 from kups.core.potential import (
     EMPTY,
     CachedPotential,
@@ -143,5 +149,70 @@ def run_md[State: IsMdState](
     )
     state = run_simulation_cycles(
         next(chain), propagator, state, config.num_steps, logger
+    )
+    return state
+
+
+def make_verlet_md_propagators[State: IsMdState, Grad: IsMdGradients](
+    state_lens: Lens[State, State],
+    integrator: Integrator,
+    potential: Potential[State, Grad, EmptyType, Any],
+    cutoff: float,
+    skin: float,
+    skin_nl: NearestNeighborList,
+) -> tuple[Propagator[State], Propagator[State]]:
+    """Build the (reuse, rebuild) propagator pair for a Verlet-skin MD run.
+
+    Both share the same MD step (which reads ``state.neighborlist`` — a
+    ``RefineCutoffNeighborList`` over the stored skin list); ``rebuild`` first refreshes
+    the skin list + references via the injected ``skin_nl`` builder (dense for box ~ cutoff,
+    cell-list for large boxes — see ``neighborlist.verlet.dense_skin_nl`` / ``cell_skin_nl``).
+    Each appends a ``TriggerStep`` that sets ``state.should_rebuild`` for the next dispatch.
+    """
+    md_propagator = make_md_propagator(state_lens, integrator, potential)
+    trigger = TriggerStep(cutoff, skin)
+    rebuild = RebuildSkinStep(cutoff, skin, skin_nl)
+
+    # Closures (not a SequentialPropagator) so the MD step receives `key` directly in both
+    # variants: the rebuild/trigger steps don't consume the PRNG chain, so the dynamics are
+    # independent of the rebuild schedule (bit-identical to the every-step path).
+    def reuse_prop(key: Array, state: State) -> State:
+        return trigger(key, md_propagator(key, state))
+
+    def rebuild_prop(key: Array, state: State) -> State:
+        return trigger(key, md_propagator(key, rebuild(key, state)))
+
+    return reuse_prop, rebuild_prop
+
+
+def run_md_verlet[State: IsMdState](
+    key: Array,
+    reuse_propagator: Propagator[State],
+    rebuild_propagator: Propagator[State],
+    state: State,
+    config: MdRunConfig,
+) -> State:
+    """Run a full MD simulation (warmup + production) with a Verlet-skin neighbor list."""
+    chain = key_chain(key)
+    logging.info("Warmup (Verlet skin)")
+    state = run_verlet_cycles(
+        next(chain),
+        reuse_propagator,
+        rebuild_propagator,
+        state,
+        config.num_warmup_steps,
+    )
+    logging.info("Starting MD simulation (Verlet skin)")
+    logger = CompositeLogger(
+        TqdmLogger(config.num_steps),
+        HDF5StorageWriter(config.out_file, MDLoggedData(), state, config.num_steps),
+    )
+    state = run_verlet_cycles(
+        next(chain),
+        reuse_propagator,
+        rebuild_propagator,
+        state,
+        config.num_steps,
+        logger,
     )
     return state

--- a/src/kups/application/simulations/md_lj.py
+++ b/src/kups/application/simulations/md_lj.py
@@ -21,13 +21,24 @@ from kups.application.md.data import (
     MDSystems,
     md_state_from_ase,
 )
-from kups.application.md.simulation import make_md_propagator, run_md
+from kups.application.md.simulation import (
+    make_md_propagator,
+    make_verlet_md_propagators,
+    run_md,
+    run_md_verlet,
+)
+from kups.core.cell import Cell
 from kups.core.data import Table
 from kups.core.lens import identity_lens
 from kups.core.neighborlist import (
     DenseNearestNeighborList,
+    Edges,
     NearestNeighborList,
     UniversalNeighborlistParameters,
+    build_skin_edges,
+    dense_skin_nl,
+    estimate_skin_params,
+    skin_neighborlist,
 )
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass, key_chain
@@ -62,9 +73,19 @@ class LjMdState:
     neighborlist_params: UniversalNeighborlistParameters
     step: Array
     lj_parameters: LennardJonesParameters
+    # Verlet-skin fields (None unless config.md.verlet_skin > 0):
+    stored_skin_edges: Edges | None = None
+    reference_positions: Array | None = None
+    reference_cell: Cell | None = None
+    should_rebuild: Array | None = None
 
     @property
     def neighborlist(self) -> NearestNeighborList:
+        if self.stored_skin_edges is not None:
+            # Verlet: reuse the stored skin list, refined to the true cutoff each step.
+            return skin_neighborlist(
+                self.stored_skin_edges, self.neighborlist_params.avg_edges
+            )
         return DenseNearestNeighborList.from_state(self)
 
 
@@ -79,13 +100,35 @@ def init_state(key: Array, config: Config) -> LjMdState:
     neighborlist_params = UniversalNeighborlistParameters.estimate(
         particles.data.system.counts, systems, lj_params.cutoff
     )
-    return LjMdState(
+    state = LjMdState(
         particles=particles,
         systems=systems,
         neighborlist_params=neighborlist_params,
         step=jnp.array([0]),
         lj_parameters=lj_params,
     )
+    skin = config.md.verlet_skin
+    if skin > 0:
+        # Seed the Verlet skin list (one dense build at cutoff + skin).
+        skin_params = estimate_skin_params(
+            particles.data.system.counts, systems, lj_params.cutoff, skin
+        )
+        # dense skin builder (box ~ cutoff); swap to cell_skin_nl for large boxes.
+        edges = build_skin_edges(
+            particles, systems, lj_params.cutoff, skin, dense_skin_nl(skin_params)
+        )
+        state = LjMdState(
+            particles=particles,
+            systems=systems,
+            neighborlist_params=neighborlist_params,
+            step=jnp.array([0]),
+            lj_parameters=lj_params,
+            stored_skin_edges=edges,
+            reference_positions=particles.data.positions + 0.0,
+            reference_cell=jax.tree.map(lambda x: x + 0.0, systems.data.cell),
+            should_rebuild=jnp.array(True),  # force initial rebuild
+        )
+    return state
 
 
 def run(config: Config) -> None:
@@ -96,8 +139,25 @@ def run(config: Config) -> None:
     potential = make_lennard_jones_from_state(
         state_lens, compute_position_and_cell_gradients=True
     )
-    propagator = make_md_propagator(state_lens, config.md.integrator, potential)
-    state = run_md(next(chain), propagator, state, config.run)
+    if config.md.verlet_skin > 0:
+        skin_params = estimate_skin_params(
+            state.particles.data.system.counts,
+            state.systems,
+            state.lj_parameters.cutoff,
+            config.md.verlet_skin,
+        )
+        reuse_prop, rebuild_prop = make_verlet_md_propagators(
+            state_lens,
+            config.md.integrator,
+            potential,
+            config.lj.cutoff,
+            config.md.verlet_skin,
+            dense_skin_nl(skin_params),
+        )
+        state = run_md_verlet(next(chain), reuse_prop, rebuild_prop, state, config.run)
+    else:
+        propagator = make_md_propagator(state_lens, config.md.integrator, potential)
+        state = run_md(next(chain), propagator, state, config.run)
 
 
 def main() -> None:

--- a/src/kups/application/utils/propagate.py
+++ b/src/kups/application/utils/propagate.py
@@ -7,6 +7,7 @@ Provides warmup, sampling, and data-parallelism helpers used across
 MD, MCMC, and relaxation application modules.
 """
 
+import contextlib
 import logging
 from copy import deepcopy
 from typing import Any, Callable, Generator
@@ -84,6 +85,50 @@ def run_simulation_cycles[State](
         for i in range(num_cycles):
             state = propagate_and_fix(prop_with_assertions, next(chain), state)
             logger.log(state, i)
+            if convergence_fn is not None and convergence_fn(state):
+                logging.info("Converged at step %d", i + 1)
+                break
+    return state
+
+
+def run_verlet_cycles[State](
+    key: Array,
+    reuse_propagator: Propagator[State],
+    rebuild_propagator: Propagator[State],
+    state: State,
+    num_cycles: int,
+    logger: Logger[State] | None = None,
+    *,
+    convergence_fn: Callable[[State], bool] | None = None,
+) -> State:
+    """Run MD with a Verlet skin: each step reuses the stored neighbor list, rebuilding
+    only when ``state.should_rebuild`` (a PBC-aware trigger set by the step) fires.
+
+    Two internally-consistent jitted steps (reuse / rebuild) are dispatched host-side on
+    the flag — this avoids ``lax.cond`` over branches with mismatched capacity assertions.
+    The per-step flag read is one cheap device→host sync (the loop already syncs on
+    ``failed_assertions``). The first step always rebuilds, to establish a fresh reference.
+
+    Args:
+        key: JAX PRNG key.
+        reuse_propagator: step that reuses the stored skin list (cheap).
+        rebuild_propagator: step that rebuilds the skin list first (expensive), then steps.
+        state: initial state (must carry the verlet fields; see ``neighborlist.verlet``).
+        num_cycles: number of steps.
+        logger: optional per-step logger.
+        convergence_fn: optional early-stop predicate.
+    """
+    chain = key_chain(key)
+    reuse = jit(as_result_function(reuse_propagator), donate_argnums=(1,))
+    rebuild = jit(as_result_function(rebuild_propagator), donate_argnums=(1,))
+    ctx: Any = logger if logger is not None else contextlib.nullcontext()
+    with ctx:
+        for i in tqdm.trange(num_cycles):
+            do_rebuild = (i == 0) or bool(jax.device_get(state.should_rebuild))  # type: ignore
+            step = rebuild if do_rebuild else reuse
+            state = propagate_and_fix(step, next(chain), state)
+            if logger is not None:
+                logger.log(state, i)
             if convergence_fn is not None and convergence_fn(state):
                 logging.info("Converged at step %d", i + 1)
                 break

--- a/src/kups/core/neighborlist/__init__.py
+++ b/src/kups/core/neighborlist/__init__.py
@@ -100,6 +100,17 @@ from kups.core.neighborlist.types import (
     NeighborListSystems,
     PipelineContext,
 )
+from kups.core.neighborlist.verlet import (
+    IsVerletState,
+    build_skin_edges,
+    cell_skin_nl,
+    dense_skin_nl,
+    estimate_skin_params,
+    should_rebuild,
+    skin_cutoffs,
+    skin_mic_ratio,
+    skin_neighborlist,
+)
 
 __all__ = [
     "AllDenseNearestNeighborList",
@@ -122,6 +133,7 @@ __all__ = [
     "IsDenseNeighborlistParams",
     "IsNeighborListState",
     "IsUniversalNeighborlistParams",
+    "IsVerletState",
     "Mask",
     "MaskOnlyCompactor",
     "NearestNeighborList",
@@ -137,5 +149,13 @@ __all__ = [
     "RemapDedupMask",
     "UniversalNeighborlistParameters",
     "all_connected_neighborlist",
+    "build_skin_edges",
+    "cell_skin_nl",
+    "dense_skin_nl",
+    "estimate_skin_params",
     "neighborlist_changes",
+    "should_rebuild",
+    "skin_cutoffs",
+    "skin_mic_ratio",
+    "skin_neighborlist",
 ]

--- a/src/kups/core/neighborlist/verlet.py
+++ b/src/kups/core/neighborlist/verlet.py
@@ -1,0 +1,236 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verlet neighbor list with a skin.
+
+Builds a *conservative* neighbor list at ``cutoff + skin`` once, stores its edges
+in the MD state, and reuses them for many steps via
+:class:`~kups.core.neighborlist.refine.RefineCutoffNeighborList` (which re-masks to
+the true cutoff and recomputes minimum-image shifts for the current — possibly
+rescaled — cell). The expensive O(N²/K²) dense build then runs only when a
+PBC-aware displacement/strain trigger fires, amortizing it over the rebuild window.
+
+A pair absent from the stored skin list had build-time distance ``> cutoff + skin``;
+it can only intrude inside the true cutoff if the total inward change exceeds ``skin``.
+The two sources of change are atom motion (``≤ 2·δ_max``) and isotropic cell strain
+(a pair at the skin radius sees ``(cutoff+skin)·max_a|f_a−1|``), giving the guarantee
+
+    completeness holds  ⇔  2·δ_max + (cutoff+skin)·max_a|f_a − 1|  <  skin
+
+where ``δ_max`` is the max **minimum-image** atom displacement since the last build and
+``f_a`` is the per-axis ``perpendicular_lengths`` ratio (current / reference).
+
+Reuse is exact only while ``(cutoff+skin)/perpendicular_length ≤ 0.5`` on every axis
+(single-image regime); above that the dense build replicates periodic images that the
+refine path collapses to one minimum image. :func:`skin_mic_ratio` exposes this so the
+caller can guard (force a rebuild / widen the box) before it is violated.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Literal, Protocol
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.capacity import FixedCapacity
+from kups.core.data import Table
+from kups.core.neighborlist.cell_list import CellListNeighborList
+from kups.core.neighborlist.dense import DenseNearestNeighborList
+from kups.core.neighborlist.edges import Edges
+from kups.core.neighborlist.parameters import UniversalNeighborlistParameters
+from kups.core.neighborlist.refine import RefineCutoffNeighborList
+from kups.core.neighborlist.types import (
+    NearestNeighborList,
+    NeighborListPoints,
+    NeighborListSystems,
+)
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass, field
+
+
+def skin_cutoffs(
+    cutoffs: Table[SystemId, Array], skin: float
+) -> Table[SystemId, Array]:
+    """Per-system ``cutoff + skin`` table (the radius the skin list is built at)."""
+    return cutoffs.map_data(lambda c: c + skin)
+
+
+def estimate_skin_params(
+    particles_per_system: Table[SystemId, Array],
+    systems: Table[SystemId, NeighborListSystems],
+    cutoffs: Table[SystemId, Array],
+    skin: float,
+) -> UniversalNeighborlistParameters:
+    """Capacities sized consistently for the ``cutoff + skin`` sphere.
+
+    Re-estimates *all* capacities at the enlarged radius (never hand-scale a single
+    one — mismatched candidate/image buffers trigger a pathological dense-build path).
+    """
+    return UniversalNeighborlistParameters.estimate(
+        particles_per_system, systems, skin_cutoffs(cutoffs, skin)
+    )
+
+
+def dense_skin_nl(
+    skin_params: UniversalNeighborlistParameters,
+) -> DenseNearestNeighborList:
+    """Dense ``O(N²/K²)`` builder for the skin list — fastest when box ~ cutoff+skin."""
+    return DenseNearestNeighborList(
+        avg_candidates=FixedCapacity(skin_params.avg_candidates),
+        avg_edges=FixedCapacity(skin_params.avg_edges),
+        avg_image_candidates=FixedCapacity(skin_params.avg_image_candidates),
+    )
+
+
+def cell_skin_nl(
+    skin_params: UniversalNeighborlistParameters,
+) -> CellListNeighborList:
+    """Cell-list ``O(N)`` builder for the skin list — for large boxes (box ≫ cutoff+skin),
+    where the dense build is quadratic. Capacities are pinned at the cutoff+skin radius."""
+    return CellListNeighborList(
+        avg_candidates=FixedCapacity(skin_params.avg_candidates),
+        avg_edges=FixedCapacity(skin_params.avg_edges),
+        cells=FixedCapacity(skin_params.cells),
+        avg_image_candidates=FixedCapacity(skin_params.avg_image_candidates),
+    )
+
+
+def build_skin_edges(
+    particles: Table[ParticleId, NeighborListPoints],
+    systems: Table[SystemId, NeighborListSystems],
+    cutoffs: Table[SystemId, Array],
+    skin: float,
+    skin_nl: NearestNeighborList,
+) -> Edges[Literal[2]]:
+    """One build at ``cutoff + skin`` via the *injected* neighbor list (e.g.
+    :func:`dense_skin_nl` or :func:`cell_skin_nl`) — used to seed and to rebuild the skin
+    list. The reuse path (:func:`skin_neighborlist`) is independent of this choice."""
+    return skin_nl(particles, None, systems, skin_cutoffs(cutoffs, skin))
+
+
+def skin_neighborlist(
+    stored_edges: Edges[Literal[2]], avg_edges: int
+) -> RefineCutoffNeighborList:
+    """The cheap per-step reuse path: refine stored skin edges to the true cutoff.
+
+    ``avg_edges`` is the per-particle true-cutoff edge capacity (e.g.
+    ``neighborlist_params.avg_edges``); ``RefineCutoffNeighborList`` multiplies it by
+    the particle count internally.
+    """
+    return RefineCutoffNeighborList(
+        candidates=stored_edges, avg_edges=FixedCapacity(avg_edges)
+    )
+
+
+def skin_mic_ratio(
+    systems: Table[SystemId, NeighborListSystems], cutoff: float, skin: float
+) -> Array:
+    """``max_a (cutoff+skin)/perpendicular_length_a`` over axes & systems.
+
+    Reuse is bitwise-exact vs a fresh dense build only while this is ``< 0.5``.
+    """
+    perp = systems.data.cell.perpendicular_lengths  # (n_sys, 3)
+    return jnp.max((cutoff + skin) / perp)
+
+
+def should_rebuild(
+    positions: Array,
+    reference_positions: Array,
+    system_index: Array,
+    perp_now: Array,
+    perp_ref: Array,
+    cutoff: float,
+    skin: float,
+) -> Array:
+    """PBC-aware Verlet rebuild trigger (scalar bool), reduced over all systems.
+
+    Args:
+        positions: current cartesian positions, ``(N, 3)``.
+        reference_positions: positions at the last rebuild, ``(N, 3)``.
+        system_index: per-particle system index, ``(N,)`` — selects each atom's box.
+        perp_now / perp_ref: ``perpendicular_lengths`` now / at last rebuild, ``(n_sys, 3)``.
+        cutoff: true cutoff (Å).
+        skin: skin width (Å).
+
+    Returns:
+        Scalar boolean: ``True`` when the completeness margin is exhausted.
+    """
+    lp = perp_now[system_index]  # (N, 3) — each atom's box edges
+    d = positions - reference_positions
+    d_mic = d - lp * jnp.round(d / lp)  # minimum image (atoms wrap the box)
+    delta_max = jnp.max(jnp.linalg.norm(d_mic, axis=-1))
+    f = perp_now / perp_ref
+    cell_term = (cutoff + skin) * jnp.max(jnp.abs(f - 1.0))
+    return (2.0 * delta_max + cell_term) >= skin
+
+
+class IsVerletState(Protocol):
+    """State carrying the stored skin list and rebuild references."""
+
+    @property
+    def stored_skin_edges(self) -> Edges[Literal[2]]: ...
+    @property
+    def reference_positions(self) -> Array: ...
+    @property
+    def reference_cell(self) -> object: ...  # Cell; has .perpendicular_lengths
+    @property
+    def should_rebuild(self) -> Array: ...
+
+
+@dataclass
+class RebuildSkinStep:
+    """Propagator step that rebuilds the stored skin list (a build at cutoff+skin via the
+    injected ``skin_nl``) and resets the rebuild references. Run at step start, before the
+    force eval.
+
+    State-generic: updates the verlet fields via :func:`dataclasses.replace`, so it works
+    on any MD state carrying ``stored_skin_edges``/``reference_positions``/
+    ``reference_cell``/``should_rebuild`` plus ``particles``/``systems``. The skin builder
+    (dense vs cell) is *injected*, not selected by flag — see :func:`dense_skin_nl` /
+    :func:`cell_skin_nl`.
+    """
+
+    cutoff: float = field(static=True)
+    skin: float = field(static=True)
+    skin_nl: NearestNeighborList = field(static=True)
+
+    def __call__(self, key: Array, state):
+        del key
+        n = len(state.systems.keys)
+        cutoffs = Table(state.systems.keys, jnp.full((n,), self.cutoff))
+        edges = build_skin_edges(
+            state.particles, state.systems, cutoffs, self.skin, self.skin_nl
+        )
+        return dataclasses.replace(
+            state,
+            stored_skin_edges=edges,
+            reference_positions=state.particles.data.positions + 0.0,  # distinct buffer
+            reference_cell=jax.tree.map(lambda x: x + 0.0, state.systems.data.cell),
+            should_rebuild=jnp.array(False),
+        )
+
+
+@dataclass
+class TriggerStep:
+    """Propagator step that computes the PBC-aware rebuild trigger and stores it in
+    ``state.should_rebuild`` (read host-side by the run loop to dispatch the next step).
+    Cheap: O(N) displacement + per-axis strain, no neighbor build."""
+
+    cutoff: float = field(static=True)
+    skin: float = field(static=True)
+
+    def __call__(self, key: Array, state):
+        del key
+        sr = should_rebuild(
+            state.particles.data.positions,
+            state.reference_positions,
+            state.particles.data.system.indices,
+            state.systems.data.cell.perpendicular_lengths,
+            state.reference_cell.perpendicular_lengths,
+            self.cutoff,
+            self.skin,
+        )
+        return dataclasses.replace(state, should_rebuild=sr)

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -52,7 +52,9 @@ type Temperature = Array
 type Pressure = Array
 type Stress = Array
 
-type Integrator = Literal["verlet", "baoab_langevin", "csvr", "csvr_npt"]
+type Integrator = Literal[
+    "verlet", "baoab_langevin", "csvr", "csvr_npt", "csvr_npt_1eval"
+]
 
 
 @runtime_checkable
@@ -871,6 +873,7 @@ def make_csvr_npt_step[State](
     systems: Lens[State, Table[SystemId, IsMDSystemNPT]],
     derivative_computation: Propagator[State],
     flow: Flow[State, Array],
+    refresh_after_barostat: bool = True,
 ) -> SequentialPropagator[State]:
     r"""Create NPT integrator for isothermal-isobaric (NPT) ensemble sampling.
 
@@ -917,17 +920,23 @@ def make_csvr_npt_step[State](
     params_half: View[State, Table[SystemId, IsCSVRNPTParams]] = pipe(
         systems.get, _half_time_params
     )
-    return SequentialPropagator(
-        (
-            CSVRStep(particles, params),
-            MomentumStep(particles, params_half),
-            PositionStep(particles, params, flow),
-            derivative_computation,
-            MomentumStep(particles, params_half),
-            StochasticCellRescalingStep(particles, systems),
-            derivative_computation,
-        )
-    )
+    # The post-barostat derivative_computation only re-seeds the next step's first
+    # half-kick. With refresh_after_barostat=False we drop it; the next half-kick then uses
+    # forces stale by the barostat's isotropic rescale (mu ~ 1), which leaves the NPT
+    # volume distribution unchanged in practice. The barostat itself always uses the fresh
+    # pre-rescale stress, so pressure control is unaffected. Keep the full recompute for
+    # fast barostats or anisotropic cells.
+    steps: list[Propagator[State]] = [
+        CSVRStep(particles, params),
+        MomentumStep(particles, params_half),
+        PositionStep(particles, params, flow),
+        derivative_computation,
+        MomentumStep(particles, params_half),
+        StochasticCellRescalingStep(particles, systems),
+    ]
+    if refresh_after_barostat:
+        steps.append(derivative_computation)
+    return SequentialPropagator(tuple(steps))
 
 
 @overload
@@ -952,7 +961,7 @@ def make_md_step_from_state[State](
 def make_md_step_from_state[State](
     state: Lens[State, IsState[_MDParticleData, IsMDSystemNPT]],
     derivative_computation: Propagator[State],
-    integrator: Literal["csvr_npt"],
+    integrator: Literal["csvr_npt", "csvr_npt_1eval"],
 ) -> Propagator[State]: ...
 @overload
 def make_md_step_from_state[State](
@@ -1025,6 +1034,15 @@ def make_md_step_from_state[State](
         case "csvr_npt":
             return make_csvr_npt_step(
                 particles_lens, systems_lens, derivative_computation, flow
+            )
+        case "csvr_npt_1eval":
+            # drop the post-barostat eval; see make_csvr_npt_step's refresh_after_barostat.
+            return make_csvr_npt_step(
+                particles_lens,
+                systems_lens,
+                derivative_computation,
+                flow,
+                refresh_after_barostat=False,
             )
         case _:
             raise ValueError(f"Unknown integrator: {integrator}")

--- a/src/kups/potential/classical/__init__.py
+++ b/src/kups/potential/classical/__init__.py
@@ -50,6 +50,12 @@ from .lennard_jones import (
     make_pair_tail_corrected_lennard_jones_potential,
 )
 from .morse import MorseBondParameters, make_morse_bond_potential
+from .nonbonded import (
+    NonbondedParameters,
+    fused_nonbonded_edge_energy,
+    make_nonbonded_from_state,
+    nonbonded_energy,
+)
 
 __all__ = [
     "make_cosine_angle_potential",
@@ -62,6 +68,10 @@ __all__ = [
     "make_lennard_jones_potential",
     "make_global_lennard_jones_tail_correction_potential",
     "make_pair_tail_corrected_lennard_jones_potential",
+    "make_nonbonded_from_state",
+    "nonbonded_energy",
+    "fused_nonbonded_edge_energy",
+    "NonbondedParameters",
     "CosineAngleParameters",
     "cosine_angle_energy",
     "DihedralParameters",

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -821,6 +821,10 @@ def make_ewald_potential[
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
     include_exclusion_mask: bool = False,
+    reciprocal: Literal["ewald", "pme"] = "ewald",
+    pme_mesh: tuple[int, int, int] | None = None,
+    pme_order: int = 6,
+    pme_fp32: bool = False,
 ) -> EwaldPotential[State, Gradients, Hessians, Ptch]:
     """Create the complete Ewald potential combining all component terms.
 
@@ -962,17 +966,42 @@ def make_ewald_potential[
         patch_idx_view=patch_idx_view,
         cache_lens=cache_lens.focus(lambda x: x.short_range) if cache_lens else None,
     )
-    lr_potential = make_ewald_long_range_potential(
-        particles_view=atomic_view,
-        systems_view=systems_view,
-        parameter_lens=parameter_lens,
-        cache_lens=cache_lens,
-        probe=atomic_particles_probe,
-        gradient_lens=gradient_lens,
-        hessian_lens=hessian_lens,
-        hessian_idx_view=hessian_idx_view,
-        patch_idx_view=patch_idx_view,
-    )
+    if reciprocal == "ewald":
+        lr_potential = make_ewald_long_range_potential(
+            particles_view=atomic_view,
+            systems_view=systems_view,
+            parameter_lens=parameter_lens,
+            cache_lens=cache_lens,
+            probe=atomic_particles_probe,
+            gradient_lens=gradient_lens,
+            hessian_lens=hessian_lens,
+            hessian_idx_view=hessian_idx_view,
+            patch_idx_view=patch_idx_view,
+        )
+    else:
+        # FFT-based PME reciprocal (O(N log N); scales to >=100k ions where the dense
+        # direct-Ewald structure-factor tensor OOMs). Imported here, not at module scope,
+        # to avoid a circular import (pme imports from this module).
+        assert pme_mesh is not None, (
+            f"reciprocal={reciprocal!r} requires pme_mesh=(Mx,My,Mz) "
+            "(static FFT grid; use pme_mesh_for_cell(cell_vectors, spacing))."
+        )
+        from kups.potential.classical.pme import make_pme_long_range_potential
+
+        lr_potential = make_pme_long_range_potential(
+            particles_view=atomic_view,
+            systems_view=systems_view,
+            parameter_lens=parameter_lens,
+            cache_lens=cache_lens,
+            probe=atomic_particles_probe,
+            gradient_lens=gradient_lens,
+            hessian_lens=hessian_lens,
+            hessian_idx_view=hessian_idx_view,
+            patch_idx_view=patch_idx_view,
+            mesh=pme_mesh,
+            order=pme_order,
+            fp32_reciprocal=pme_fp32,
+        )
     self_potential = make_ewald_self_interaction_potential(
         particles_view=atomic_view,
         systems_view=systems_view,
@@ -1040,6 +1069,10 @@ def make_ewald_from_state[State](
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
     include_exclusion_mask: bool = False,
+    reciprocal: Literal["ewald", "pme"] = "ewald",
+    pme_mesh: tuple[int, int, int] | None = None,
+    pme_order: int = 6,
+    pme_fp32: bool = False,
 ) -> EwaldPotential[State, EmptyType, EmptyType, Patch]: ...
 
 
@@ -1050,6 +1083,10 @@ def make_ewald_from_state[State](
     *,
     compute_position_and_cell_gradients: Literal[True],
     include_exclusion_mask: bool = False,
+    reciprocal: Literal["ewald", "pme"] = "ewald",
+    pme_mesh: tuple[int, int, int] | None = None,
+    pme_order: int = 6,
+    pme_fp32: bool = False,
 ) -> EwaldPotential[State, PositionAndCell, EmptyType, Patch]: ...
 
 
@@ -1062,6 +1099,10 @@ def make_ewald_from_state[State, P: Patch](
     *,
     compute_position_and_cell_gradients: Literal[False] = ...,
     include_exclusion_mask: bool = False,
+    reciprocal: Literal["ewald", "pme"] = "ewald",
+    pme_mesh: tuple[int, int, int] | None = None,
+    pme_order: int = 6,
+    pme_fp32: bool = False,
 ) -> EwaldPotential[State, EmptyType, EmptyType, P]: ...
 
 
@@ -1075,6 +1116,10 @@ def make_ewald_from_state[State, P: Patch](
     *,
     compute_position_and_cell_gradients: Literal[True],
     include_exclusion_mask: bool = False,
+    reciprocal: Literal["ewald", "pme"] = "ewald",
+    pme_mesh: tuple[int, int, int] | None = None,
+    pme_order: int = 6,
+    pme_fp32: bool = False,
 ) -> EwaldPotential[State, PositionAndCell, EmptyType, P]: ...
 
 
@@ -1084,6 +1129,10 @@ def make_ewald_from_state(
     *,
     compute_position_and_cell_gradients: bool = False,
     include_exclusion_mask: bool = False,
+    reciprocal: Literal["ewald", "pme"] = "ewald",
+    pme_mesh: tuple[int, int, int] | None = None,
+    pme_order: int = 6,
+    pme_fp32: bool = False,
 ) -> Any:
     """Create an Ewald potential from a typed state, optionally with incremental updates.
 
@@ -1143,6 +1192,10 @@ def make_ewald_from_state(
         EMPTY_LENS,
         patch_idx_view=patch_idx_view,
         include_exclusion_mask=include_exclusion_mask,
+        reciprocal=reciprocal,
+        pme_mesh=pme_mesh,
+        pme_order=pme_order,
+        pme_fp32=pme_fp32,
     )
 
 

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -1073,6 +1073,7 @@ def make_ewald_from_state[State](
     pme_mesh: tuple[int, int, int] | None = None,
     pme_order: int = 6,
     pme_fp32: bool = False,
+    forces_only: bool = False,
 ) -> EwaldPotential[State, EmptyType, EmptyType, Patch]: ...
 
 
@@ -1087,6 +1088,7 @@ def make_ewald_from_state[State](
     pme_mesh: tuple[int, int, int] | None = None,
     pme_order: int = 6,
     pme_fp32: bool = False,
+    forces_only: bool = False,
 ) -> EwaldPotential[State, PositionAndCell, EmptyType, Patch]: ...
 
 
@@ -1103,6 +1105,7 @@ def make_ewald_from_state[State, P: Patch](
     pme_mesh: tuple[int, int, int] | None = None,
     pme_order: int = 6,
     pme_fp32: bool = False,
+    forces_only: bool = False,
 ) -> EwaldPotential[State, EmptyType, EmptyType, P]: ...
 
 
@@ -1120,6 +1123,7 @@ def make_ewald_from_state[State, P: Patch](
     pme_mesh: tuple[int, int, int] | None = None,
     pme_order: int = 6,
     pme_fp32: bool = False,
+    forces_only: bool = False,
 ) -> EwaldPotential[State, PositionAndCell, EmptyType, P]: ...
 
 
@@ -1133,6 +1137,7 @@ def make_ewald_from_state(
     pme_mesh: tuple[int, int, int] | None = None,
     pme_order: int = 6,
     pme_fp32: bool = False,
+    forces_only: bool = False,
 ) -> Any:
     """Create an Ewald potential from a typed state, optionally with incremental updates.
 
@@ -1161,7 +1166,14 @@ def make_ewald_from_state(
     """
     gradient_lens: Any = EMPTY_LENS
     patch_idx_view = empty_patch_idx_view
-    if compute_position_and_cell_gradients:
+    if forces_only:
+        # forces (dE/dr) only, no cell-virial: positions-only gradient_lens flows to every
+        # sub-potential. The gradient is a positions Table, so sum only with other
+        # forces-only potentials.
+        gradient_lens = SimpleLens[PointCloud, Any](
+            lambda pc: pc.particles.map_data(lambda p: p.positions)
+        )
+    elif compute_position_and_cell_gradients:
         gradient_lens = SimpleLens[PointCloud, PositionAndCell](
             lambda pc: PositionAndCell(
                 pc.particles.map_data(lambda p: p.positions),

--- a/src/kups/potential/classical/nonbonded.py
+++ b/src/kups/potential/classical/nonbonded.py
@@ -1,0 +1,249 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Fused real-space nonbonded potential: Lennard-Jones + short-range Ewald.
+
+Combines the two real-space potentials kups builds separately —
+``make_lennard_jones_from_state`` and the short-range term of ``make_ewald_from_state`` —
+into a single ``PotentialFromEnergy`` that builds one radius graph (one neighbor-list
+query, one edge gather) and runs one ``jax.vjp`` over the summed energy. Forces (``dE/dr``)
+and NPT stress (``dE/dcell``) come from autodiff through the shared ``PositionAndCell``
+gradient lens.
+
+Two energy bodies are provided:
+
+  * ``nonbonded_energy`` calls the existing ``lennard_jones_energy`` and
+    ``ewald_short_range_energy`` on the shared graph and tree-adds the per-system results.
+    Numerics are identical to the two potentials summed; the win is the shared graph and
+    the single backward pass.
+  * ``fused_nonbonded_edge_energy`` does one edge gather, one ``r²``, and both LJ and
+    screened-Coulomb in the same body, saving the second gather and distance inside the
+    forward pass. It duplicates the per-edge formulas from the two source functions and
+    must be kept in sync with them.
+
+Full-recompute only (no Monte Carlo incremental/probe path).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, cast, runtime_checkable
+
+import jax
+import jax.numpy as jnp
+
+from kups.core.data import Table
+from kups.core.lens import Lens, SimpleLens, View
+from kups.core.neighborlist import NearestNeighborList
+from kups.core.patch import IdPatch, Patch, WithPatch
+from kups.core.potential import EMPTY_LENS, Energy, Potential
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass, field
+from kups.potential.classical.ewald import (
+    TO_STANDARD_UNITS,
+    EwaldParameters,
+    IsEwaldPointData,
+    ewald_short_range_energy,
+)
+from kups.potential.classical.lennard_jones import (
+    IsLJGraphParticles,
+    LennardJonesParameters,
+    lennard_jones_energy,
+)
+from kups.potential.common.energy import (
+    PositionAndCell,
+    PotentialFromEnergy,
+    position_and_cell_idx_view,
+)
+from kups.potential.common.graph import (
+    GraphPotentialInput,
+    LocalGraphSumComposer,
+    RadiusGraphConstructor,
+)
+
+
+@runtime_checkable
+class IsNonbondedPoints(IsLJGraphParticles, IsEwaldPointData, Protocol):
+    """Particle data carrying everything both terms need: positions, system index,
+    inclusion/exclusion (the radius graph), species labels (LJ), and charges (Ewald)."""
+
+
+@dataclass
+class NonbondedParameters:
+    """Bundle of the two existing parameter objects.
+
+    Attributes:
+        lj: Lennard-Jones parameters (species sigma/epsilon matrices, cutoff).
+        ewald: Ewald parameters (alpha, real-space cutoff, k-vectors). Only ``alpha`` and
+            ``cutoff`` are used by the real-space term; ``reciprocal_lattice_shifts`` is
+            carried so the same object also feeds the long-range/self potentials.
+    """
+
+    lj: LennardJonesParameters
+    ewald: EwaldParameters
+
+
+type NonbondedInput = GraphPotentialInput[
+    NonbondedParameters, IsNonbondedPoints, Any, Literal[2]
+]
+
+
+def nonbonded_energy(
+    inp: NonbondedInput,
+) -> WithPatch[Table[SystemId, Energy], IdPatch]:
+    """LJ + real-space Ewald on one shared graph, summed per system.
+
+    Reuses the existing energy functions verbatim by re-bundling the shared graph with each
+    parameter set, so numerics match ``lennard_jones_energy + ewald_short_range_energy``.
+    The win is structural: a single ``PotentialFromEnergy`` over one graph build and one
+    ``jax.vjp``.
+    """
+    graph = inp.graph
+    lj_e = lennard_jones_energy(
+        cast(Any, GraphPotentialInput(inp.parameters.lj, graph))
+    )
+    sr_e = ewald_short_range_energy(
+        cast(Any, GraphPotentialInput(inp.parameters.ewald, graph))
+    )
+    total = jax.tree.map(jnp.add, lj_e.data, sr_e.data)
+    return WithPatch(total, IdPatch())
+
+
+def fused_nonbonded_edge_energy(
+    inp: NonbondedInput,
+) -> WithPatch[Table[SystemId, Energy], IdPatch]:
+    """Single-pass LJ + screened-Coulomb: one edge gather, one ``r²``, both terms.
+
+    Duplicates the per-edge formulas from ``lennard_jones_edge_energy`` and
+    ``ewald_short_range_energy`` (keep in sync); equivalent numerics. Saves the second edge
+    gather and distance computation inside the forward pass.
+    """
+    graph = inp.graph
+    lj, ew = inp.parameters.lj, inp.parameters.ewald
+
+    edg = graph.particles[graph.edges.indices]
+    r2 = jnp.sum(graph.edge_shifts[:, 0] ** 2, axis=-1)
+    r = jnp.sqrt(r2)
+    batch = graph.edge_batch_mask
+
+    species = edg.labels.indices_in(lj.labels)
+    eps = lj.epsilon[species[:, 0], species[:, 1]]
+    sig = lj.sigma[species[:, 0], species[:, 1]]
+    c6 = (sig**2 / r2) ** 3
+    e_lj = 4 * eps * (c6**2 - c6)
+    e_lj *= r2 < jnp.pow(lj.cutoff.data, 2)[batch.indices]
+
+    qij = edg.charges[:, 0] * edg.charges[:, 1]
+    erfc = jax.scipy.special.erfc(ew.alpha[batch] * r)
+    e_c = qij * erfc / r * TO_STANDARD_UNITS
+    e_c *= r < ew.cutoff[batch]
+
+    total = batch.sum_over(e_lj + e_c) / 2
+    return WithPatch(total, IdPatch())
+
+
+class IsNonbondedState(Protocol):
+    """State providing both potentials' inputs (intersection of IsLJState and IsEwaldState)."""
+
+    @property
+    def particles(self) -> Table[ParticleId, IsNonbondedPoints]: ...
+    @property
+    def systems(self) -> Table[SystemId, Any]: ...
+    @property
+    def neighborlist(self) -> NearestNeighborList: ...
+    @property
+    def lj_parameters(self) -> LennardJonesParameters: ...
+    @property
+    def ewald_parameters(self) -> EwaldParameters: ...
+
+
+@dataclass
+class _NonbondedParamView:
+    """View bundling the two parameter views into one ``NonbondedParameters``.
+
+    A dataclass (not a bare lambda) so it is a hashable/comparable static pytree field,
+    matching how the composers hold their views.
+    """
+
+    lj: View[Any, LennardJonesParameters] = field(static=True)
+    ewald: View[Any, EwaldParameters] = field(static=True)
+
+    def __call__(self, state: Any) -> NonbondedParameters:
+        return NonbondedParameters(lj=self.lj(state), ewald=self.ewald(state))
+
+
+@dataclass
+class _MaxCutoffView:
+    """Per-system ``max(lj.cutoff, ewald.cutoff)`` so the one shared graph covers both terms.
+
+    Uses the Ewald cutoff's per-system keys (the LJ cutoff table is length-1 and
+    broadcasts). Each term still masks edges by its own cutoff inside the energy fn, so an
+    over-wide graph only costs a few extra masked candidate edges.
+    """
+
+    lj: View[Any, LennardJonesParameters] = field(static=True)
+    ewald: View[Any, EwaldParameters] = field(static=True)
+
+    def __call__(self, state: Any) -> Table[SystemId, Any]:
+        a = self.lj(state).cutoff
+        b = self.ewald(state).cutoff
+        return Table(
+            b.keys, jnp.broadcast_to(jnp.maximum(a.data, b.data), b.data.shape)
+        )
+
+
+def make_nonbonded_from_state(
+    state: Lens[Any, IsNonbondedState],
+    *,
+    compute_position_and_cell_gradients: bool = False,
+    fused_edge: bool = False,
+) -> Potential[Any, PositionAndCell, Any, Patch]:
+    """Fused LJ + real-space-Ewald potential from a typed state (full-recompute only).
+
+    Drop-in for ``sum_potentials(make_lennard_jones_from_state(...),
+    make_ewald_from_state(...).short_range)``: build this for the real-space pair, then sum
+    with the Ewald long-range / self (/ exclusion) potentials.
+
+    Args:
+        state: Lens to the sub-state with particles, systems, neighborlist,
+            ``lj_parameters`` and ``ewald_parameters``.
+        compute_position_and_cell_gradients: forces (dE/dr) + NPT stress (dE/dcell) via autodiff.
+        fused_edge: use the single-pass edge body; else the maximal-reuse body.
+    """
+    lj_view: Any = state.focus(lambda s: s.lj_parameters)
+    ew_view: Any = state.focus(lambda s: s.ewald_parameters)
+
+    graph_fn = RadiusGraphConstructor(
+        particles=state.focus(lambda s: s.particles),
+        systems=state.focus(lambda s: s.systems),
+        cutoffs=cast(Any, _MaxCutoffView(lj_view, ew_view)),
+        neighborlist=state.focus(lambda s: s.neighborlist),
+        probe=None,
+    )
+    composer = LocalGraphSumComposer(
+        graph_constructor=graph_fn,
+        parameter_view=cast(Any, _NonbondedParamView(lj_view, ew_view)),
+    )
+
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[GraphPotentialInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+
+    return cast(
+        Any,
+        PotentialFromEnergy(
+            energy_fn=fused_nonbonded_edge_energy if fused_edge else nonbonded_energy,
+            composer=composer,
+            gradient_lens=gradient_lens,
+            hessian_lens=EMPTY_LENS,
+            hessian_idx_view=EMPTY_LENS,
+            cache_lens=None,
+            patch_idx_view=patch_idx_view,
+        ),
+    )

--- a/src/kups/potential/classical/nonbonded.py
+++ b/src/kups/potential/classical/nonbonded.py
@@ -196,6 +196,7 @@ def make_nonbonded_from_state(
     *,
     compute_position_and_cell_gradients: bool = False,
     fused_edge: bool = False,
+    forces_only: bool = False,
 ) -> Potential[Any, PositionAndCell, Any, Patch]:
     """Fused LJ + real-space-Ewald potential from a typed state (full-recompute only).
 
@@ -208,6 +209,9 @@ def make_nonbonded_from_state(
             ``lj_parameters`` and ``ewald_parameters``.
         compute_position_and_cell_gradients: forces (dE/dr) + NPT stress (dE/dcell) via autodiff.
         fused_edge: use the single-pass edge body; else the maximal-reuse body.
+        forces_only: differentiate w.r.t. positions only (forces, no cell-virial), for
+            NVE/NVT where stress is unused. The gradient is a ``Table[ParticleId, Array]``
+            (not ``PositionAndCell``); sum only with other forces-only potentials.
     """
     lj_view: Any = state.focus(lambda s: s.lj_parameters)
     ew_view: Any = state.focus(lambda s: s.ewald_parameters)
@@ -226,7 +230,11 @@ def make_nonbonded_from_state(
 
     gradient_lens: Any = EMPTY_LENS
     patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
+    if forces_only:
+        gradient_lens = SimpleLens[GraphPotentialInput, Any](
+            lambda x: x.graph.particles.map_data(lambda p: p.positions)
+        )
+    elif compute_position_and_cell_gradients:
         gradient_lens = SimpleLens[GraphPotentialInput, PositionAndCell](
             lambda x: PositionAndCell(
                 x.graph.particles.map_data(lambda p: p.positions),

--- a/src/kups/potential/classical/pme.py
+++ b/src/kups/potential/classical/pme.py
@@ -1,0 +1,282 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smooth Particle-Mesh Ewald (PME) reciprocal-space potential — pure JAX.
+
+PME replaces the direct-Ewald reciprocal term (``ewald_long_range_energy``,
+``O(N * N_k)`` with a dense ``(N, N_k, 2)`` structure-factor tensor that OOMs at
+large ``N``) with an ``O(N log N)`` FFT-based evaluation that scales to >=100k
+ions. It is a drop-in at the long-range seam: same ``EwaldLongRangeInput``
+signature, same ``EwaldLongRangeComposer``, same ``PositionAndCell`` gradient
+lens — so forces (``dE/dr``) and the NPT stress (``dE/dcell``) come from
+``jax.vjp`` for free, exactly as for direct Ewald (no custom JVP/VJP).
+
+Convention matches ``ewald.py`` so PME converges to the same number::
+
+    P(k) = (2*pi/V) * exp(-k^2 / (4*alpha^2)) / k^2 ,   k = 2*pi * inverse_vectors^T @ n
+    E_recip = sum_{k != 0} P(k) * B(m) * |FFT(Q)(m)|^2 * TO_STANDARD_UNITS
+
+where ``Q`` is the order-``p`` cardinal B-spline charge mesh and ``B(m)`` is the
+Euler exponential-spline aliasing correction (Essmann et al. 1995). ``alpha`` and
+the real-space cutoff are reused verbatim from ``EwaldParameters`` so the
+short-range / self / exclusion terms are unchanged and the splitting is
+consistent. The FFT mesh dimensions are static (chosen once at construction);
+under NPT the box fluctuates but the mesh stays fixed, as in standard PME.
+
+Validated to rtol ~1e-5 (fp64) vs ``ewald_long_range_energy`` on the NaCl
+Madelung system; see ``test/potential/test_pme.py``.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.cell import Periodic3D
+from kups.core.data import Table, WithIndices
+from kups.core.lens import Lens, NestedLens, SimpleLens, View
+from kups.core.patch import IdPatch, Patch, Probe, WithPatch
+from kups.core.potential import EMPTY_LENS, Energy, Potential, PotentialOut
+from kups.core.typing import HasCell, ParticleId, SystemId
+from kups.potential.classical.ewald import (
+    TO_STANDARD_UNITS,
+    EwaldCache,
+    EwaldLongRangeComposer,
+    EwaldLongRangeInput,
+    EwaldParameters,
+    IsEwaldPointData,
+)
+from kups.potential.common.energy import PotentialFromEnergy
+from kups.potential.common.graph import PointCloud
+
+DEFAULT_SPLINE_ORDER = 6
+"""Default cardinal B-spline order. p=6 reaches ~1e-5 at ~1 Angstrom spacing."""
+
+
+def pme_mesh_for_cell(
+    cell_vectors: Array, spacing: float = 1.0, multiple_of: int = 2
+) -> tuple[int, int, int]:
+    """Pick static PME mesh dimensions for a reference cell (~``spacing`` Angstrom).
+
+    Mesh dims are rounded up to a multiple of ``multiple_of`` (cheaper FFTs).
+    Use the *initial* cell; the mesh is held fixed across an NPT trajectory.
+    """
+    import numpy as np
+
+    lengths = np.linalg.norm(np.asarray(cell_vectors), axis=-1)
+    dims = []
+    for length in lengths:
+        m = int(np.ceil(float(length) / spacing))
+        if multiple_of > 1:
+            m = ((m + multiple_of - 1) // multiple_of) * multiple_of
+        dims.append(max(m, multiple_of))
+    return (dims[0], dims[1], dims[2])
+
+
+def _bspline_weights(frac: Array, order: int) -> Array:
+    """Order-``p`` cardinal B-spline weights for the ``p`` nearest grid points.
+
+    ``frac`` is the fractional part (``[0, 1)``) of the scaled grid coordinate.
+    Returns ``frac.shape + (order,)`` weights for offsets ``j = 0..order-1`` (grid
+    point ``floor(u) - j``). Weights are smooth in ``frac`` (so gradients flow) and
+    form a partition of unity (sum to 1).
+    """
+    j = jnp.arange(order)
+    x = frac[..., None] + j  # M_n evaluated at f, f+1, ..., f+(p-1)
+    w = jnp.where((x >= 0) & (x < 1), 1.0, 0.0)  # M_1
+    for k in range(2, order + 1):
+        # M_k(x) = x/(k-1) M_{k-1}(x) + (k-x)/(k-1) M_{k-1}(x-1); shift gives M_{k-1}(x-1)
+        w_shift = jnp.concatenate([jnp.zeros_like(w[..., :1]), w[..., :-1]], axis=-1)
+        w = (x * w + (k - x) * w_shift) / (k - 1)
+    return w
+
+
+def _euler_modulus_sq(m_size: int, order: int, dtype) -> Array:
+    """``|b(m)|^2`` Euler exponential-spline aliasing factor for one axis."""
+    mvals = _bspline_weights(jnp.zeros((), dtype=dtype), order)  # [M_n(0..p-1)]
+    m = jnp.arange(m_size)
+    k = jnp.arange(order - 1)
+    phase = jnp.exp(2j * jnp.pi * m[:, None] * k[None, :] / m_size)
+    denom = jnp.sum(mvals[1:order][None, :] * phase, axis=-1)
+    denom2 = jnp.abs(denom) ** 2
+    return jnp.where(denom2 < 1e-10, 1.0, 1.0 / jnp.maximum(denom2, 1e-12))
+
+
+def _pme_reciprocal_energy_batched(
+    positions: Array,  # (N, 3) Cartesian, Angstrom
+    charges: Array,  # (N,)
+    sys_idx: Array,  # (N,) per-particle system index
+    n_sys: int,  # number of systems (static)
+    inverse_vectors: Array,  # (n_sys, 3, 3) (cell.inverse_vectors; differentiable in cell.vectors)
+    volume: Array,  # (n_sys,)
+    alpha: Array,  # (n_sys,)
+    mesh: tuple[int, int, int],
+    order: int,
+    fp32_reciprocal: bool = False,
+) -> Array:
+    """Per-system smooth-PME reciprocal energy (atomic units; xTO_STANDARD_UNITS later).
+
+    ``fp32_reciprocal`` runs the entire reciprocal pipeline (spread, FFT, influence, gather)
+    in single precision and casts the energy back to the input dtype at the end — a large
+    speedup where fp64 FFT/scatter/exp are slow. The reciprocal term is small and
+    well-conditioned (|F|^2 differs ~6e-8 fp32-vs-fp64), so total energy/force accuracy is
+    unaffected in practice; forces and the NPT cell-virial from this term are then
+    fp32-computed, fp64-typed (autodiff flows back through the entry casts).
+    """
+    out_dtype = positions.dtype
+    if fp32_reciprocal:
+        positions = positions.astype(jnp.float32)
+        charges = charges.astype(jnp.float32)
+        inverse_vectors = inverse_vectors.astype(jnp.float32)
+        volume = volume.astype(jnp.float32)
+        alpha = alpha.astype(jnp.float32)
+    dtype = positions.dtype
+    Mx, My, Mz = mesh
+    Mvec = jnp.asarray(mesh, dtype=dtype)
+
+    # Fractional coords using each particle's own system cell: s = inv @ r.
+    inv_p = inverse_vectors[sys_idx]  # (N, 3, 3)
+    frac = jnp.einsum("nab,nb->na", inv_p, positions) % 1.0  # (N, 3) in [0, 1)
+    u = frac * Mvec
+    base = jnp.floor(u).astype(jnp.int32)
+    f = u - base
+
+    wx = _bspline_weights(f[:, 0], order)  # (N, p)
+    wy = _bspline_weights(f[:, 1], order)
+    wz = _bspline_weights(f[:, 2], order)
+    j = jnp.arange(order)
+    gx = (base[:, 0:1] - j) % Mx  # (N, p)
+    gy = (base[:, 1:2] - j) % My
+    gz = (base[:, 2:3] - j) % Mz
+
+    # Scatter charges onto a per-system mesh Q of shape (n_sys, Mx, My, Mz).
+    w3 = (
+        charges[:, None, None, None]
+        * wx[:, :, None, None]
+        * wy[:, None, :, None]
+        * wz[:, None, None, :]
+    )
+    flat = (
+        sys_idx[:, None, None, None] * (Mx * My * Mz)
+        + gx[:, :, None, None] * (My * Mz)
+        + gy[:, None, :, None] * Mz
+        + gz[:, None, None, :]
+    )  # (N, p, p, p)
+    Q = (
+        jnp.zeros((n_sys * Mx * My * Mz,), dtype=dtype)
+        .at[flat.reshape(-1)]
+        .add(w3.reshape(-1))
+    )
+    Q = Q.reshape(n_sys, Mx, My, Mz)
+    Fq = jnp.fft.fftn(Q, axes=(1, 2, 3))  # (n_sys, Mx, My, Mz) complex
+
+    # Per-system k-vectors: k = 2 pi * inverse_vectors^T @ n  (matches ewald.py kvecs).
+    nx = jnp.fft.fftfreq(Mx) * Mx
+    ny = jnp.fft.fftfreq(My) * My
+    nz = jnp.fft.fftfreq(Mz) * Mz
+    nX, nY, nZ = jnp.meshgrid(nx, ny, nz, indexing="ij")
+    n_idx = jnp.stack([nX, nY, nZ], axis=-1).astype(dtype)  # (Mx,My,Mz,3)
+    kvec = 2.0 * jnp.pi * jnp.einsum("sba,xyzb->sxyza", inverse_vectors, n_idx)
+    k2 = jnp.sum(kvec**2, axis=-1)  # (n_sys, Mx, My, Mz)
+
+    bsq = (
+        _euler_modulus_sq(Mx, order, dtype)[:, None, None]
+        * _euler_modulus_sq(My, order, dtype)[None, :, None]
+        * _euler_modulus_sq(Mz, order, dtype)[None, None, :]
+    )  # (Mx,My,Mz)
+
+    nonzero = k2 > 0
+    k2_safe = jnp.where(nonzero, k2, 1.0)
+    pref = (
+        (2.0 * jnp.pi)
+        / volume[:, None, None, None]
+        * jnp.exp(-k2_safe / (4.0 * alpha[:, None, None, None] ** 2))
+        / k2_safe
+    )
+    influence = jnp.where(nonzero, pref * bsq[None], 0.0)
+    energy = jnp.sum(influence * (jnp.abs(Fq) ** 2), axis=(1, 2, 3))  # (n_sys,)
+    return energy.astype(out_dtype)
+
+
+def make_pme_long_range_energy(
+    mesh: tuple[int, int, int], order: int, fp32_reciprocal: bool = False
+):
+    """Build the PME long-range energy fn for a fixed static ``mesh`` and ``order``.
+
+    ``fp32_reciprocal=True`` evaluates the reciprocal pipeline in single precision (see
+    ``_pme_reciprocal_energy_batched``).
+    """
+
+    def pme_long_range_energy[State](
+        inp: EwaldLongRangeInput[State],
+    ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
+        """Reciprocal-space (long-range) PME energy. Drop-in for ``ewald_long_range_energy``."""
+        pc = inp.point_cloud
+        cell = pc.systems.data.cell
+        n_sys = pc.batch_size
+        energy = _pme_reciprocal_energy_batched(
+            positions=pc.particles.data.positions,
+            charges=pc.particles.data.charges,
+            sys_idx=pc.particles.data.system.indices,
+            n_sys=n_sys,
+            inverse_vectors=cell.inverse_vectors,
+            volume=cell.volume,
+            alpha=inp.parameters.alpha.data,
+            mesh=mesh,
+            order=order,
+            fp32_reciprocal=fp32_reciprocal,
+        )
+        assert energy.shape == (n_sys,), (
+            f"Expected energy shape {(n_sys,)} but got {energy.shape}."
+        )
+        energy = energy * TO_STANDARD_UNITS
+        return WithPatch(Table.arange(energy, label=SystemId), IdPatch())
+
+    return pme_long_range_energy
+
+
+def make_pme_long_range_potential[State, Ptch: Patch, Gradients, Hessians](
+    particles_view: View[State, Table[ParticleId, IsEwaldPointData]],
+    systems_view: View[State, Table[SystemId, HasCell[Periodic3D]]],
+    parameter_lens: Lens[State, EwaldParameters],
+    cache_lens: Lens[State, EwaldCache] | None,
+    probe: Probe[State, Ptch, WithIndices[ParticleId, IsEwaldPointData]] | None = None,
+    gradient_lens: Lens[
+        PointCloud[IsEwaldPointData, HasCell[Periodic3D]], Gradients
+    ] = EMPTY_LENS,
+    hessian_lens: Lens[Gradients, Hessians] = EMPTY_LENS,
+    hessian_idx_view: View[State, Hessians] = EMPTY_LENS,
+    patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
+    *,
+    mesh: tuple[int, int, int],
+    order: int = DEFAULT_SPLINE_ORDER,
+    fp32_reciprocal: bool = False,
+) -> Potential[State, Gradients, Hessians, Ptch]:
+    """Create the PME reciprocal-space (long-range) potential.
+
+    Mirrors ``make_ewald_long_range_potential`` exactly (same composer, same
+    point-cloud gradient lens) so forces and NPT stress come from autodiff.
+    ``cache_lens`` is ignored (PME for MD needs no structure-factor cache;
+    ``PotentialFromEnergy`` emits an ``IdPatch``). ``mesh`` is the static FFT grid.
+    ``fp32_reciprocal`` runs the reciprocal pipeline in single precision.
+    """
+    return PotentialFromEnergy(
+        energy_fn=make_pme_long_range_energy(mesh, order, fp32_reciprocal),
+        composer=EwaldLongRangeComposer(
+            particles=particles_view,
+            systems=systems_view,
+            probe=probe,
+            parameters=parameter_lens,
+            cache=None,
+        ),
+        gradient_lens=NestedLens(
+            SimpleLens[EwaldLongRangeInput, PointCloud](
+                lambda state: state.point_cloud
+            ),
+            gradient_lens,
+        ),
+        hessian_lens=hessian_lens,
+        cache_lens=None,
+        hessian_idx_view=hessian_idx_view,
+        patch_idx_view=patch_idx_view,
+    )

--- a/test/core/test_verlet.py
+++ b/test/core/test_verlet.py
@@ -1,0 +1,170 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Verlet-skin neighbor list (kups.core.neighborlist.verlet).
+
+A stored "skin" list built at ``cutoff + skin`` is reused across steps and re-masked to
+the true cutoff via ``RefineCutoffNeighborList``; the expensive dense build runs only when
+the PBC-aware trigger fires. Correctness == the reused list reproduces a fresh dense build,
+and Verlet MD dynamics are bit-identical to the every-step-dense path.
+"""
+
+from __future__ import annotations
+
+import ase.build
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from kups.application.md.data import MdParameters, md_state_from_ase
+from kups.application.md.simulation import (
+    make_md_propagator,
+    make_verlet_md_propagators,
+)
+from kups.application.simulations.md_lj import LjMdState
+from kups.core.lens import identity_lens
+from kups.core.neighborlist import (
+    DenseNearestNeighborList,
+    UniversalNeighborlistParameters,
+    build_skin_edges,
+    dense_skin_nl,
+    estimate_skin_params,
+    should_rebuild,
+    skin_mic_ratio,
+)
+from kups.core.propagator import propagate_and_fix
+from kups.core.result import as_result_function
+from kups.core.utils.jax import jit, key_chain
+from kups.potential.classical.lennard_jones import (
+    LennardJonesParameters,
+    make_lennard_jones_from_state,
+)
+
+CUTOFF, SKIN = 6.0, 1.5
+
+
+def _make_state(verlet_skin: float, integrator: str = "csvr_npt") -> LjMdState:
+    # Ar fcc 4x4x4 → 256 atoms, ~21 Å box; (cutoff+skin)/box = 7.5/21 ≈ 0.36 < 0.5 (single image).
+    atoms = ase.build.bulk("Ar", "fcc", a=5.26, cubic=True) * (4, 4, 4)
+    md = MdParameters(
+        temperature=50.0,
+        time_step=2.0,
+        friction_coefficient=0.01,
+        thermostat_time_constant=100.0,
+        target_pressure=1e5,
+        pressure_coupling_time=1000.0,
+        compressibility=5e-10,
+        minimum_scale_factor=0.9,
+        integrator=integrator,
+        initialize_momenta=True,
+        verlet_skin=verlet_skin,
+    )
+    particles, systems = md_state_from_ase(atoms, md, key=jax.random.key(0))
+    ljp = LennardJonesParameters.from_dict(
+        cutoff=CUTOFF, parameters={"Ar": (3.4, 0.0103)}, mixing_rule="lorentz_berthelot"
+    )
+    nlp = UniversalNeighborlistParameters.estimate(
+        particles.data.system.counts, systems, ljp.cutoff
+    )
+    if verlet_skin > 0:
+        sp = estimate_skin_params(
+            particles.data.system.counts, systems, ljp.cutoff, verlet_skin
+        )
+        edges = build_skin_edges(
+            particles, systems, ljp.cutoff, verlet_skin, dense_skin_nl(sp)
+        )
+        return LjMdState(
+            particles,
+            systems,
+            nlp,
+            jnp.array([0]),
+            ljp,
+            stored_skin_edges=edges,
+            reference_positions=particles.data.positions + 0.0,
+            reference_cell=jax.tree.map(lambda x: x + 0.0, systems.data.cell),
+            should_rebuild=jnp.array(True),
+        )
+    return LjMdState(particles, systems, nlp, jnp.array([0]), ljp)
+
+
+def _edge_set(edges) -> set:
+    idx = np.asarray(edges.indices.indices)
+    sh = np.asarray(edges.shifts).reshape(idx.shape[0], -1)
+    return {
+        (int(idx[k, 0]), int(idx[k, 1]), tuple(np.round(sh[k]).astype(int)))
+        for k in range(idx.shape[0])
+        if idx[k, 0] != idx[k, 1]
+    }
+
+
+def test_skin_mic_ratio_safe():
+    sv = _make_state(SKIN)
+    assert float(skin_mic_ratio(sv.systems, CUTOFF, SKIN)) < 0.5
+
+
+def test_reuse_reproduces_dense_neighbor_set():
+    """The refined skin list at the true cutoff == a fresh dense build (no missed pairs)."""
+    sv, sd = _make_state(SKIN), _make_state(0.0)
+    reuse = sv.neighborlist(sv.particles, None, sv.systems, sv.lj_parameters.cutoff)
+    fresh = DenseNearestNeighborList.from_state(sd)(
+        sd.particles, None, sd.systems, sd.lj_parameters.cutoff
+    )
+    assert _edge_set(reuse) == _edge_set(fresh)
+
+
+def test_trigger_fires_only_on_motion():
+    sv = _make_state(SKIN)
+    pos = sv.particles.data.positions
+    perp = sv.systems.data.cell.perpendicular_lengths
+    sidx = sv.particles.data.system.indices
+    assert not bool(should_rebuild(pos, pos, sidx, perp, perp, CUTOFF, SKIN))
+    moved = pos.at[0].add(
+        jnp.array([SKIN, 0.0, 0.0])
+    )  # one atom by a full skin > skin/2
+    assert bool(should_rebuild(moved, pos, sidx, perp, perp, CUTOFF, SKIN))
+
+
+# NVE (verlet), NVT (csvr / baoab_langevin), and NPT (csvr_npt) — the skin list is
+# ensemble-agnostic and the trigger's cell-strain term vanishes for fixed-cell ensembles,
+# so Verlet dynamics should be bit-identical to every-step-dense in EVERY ensemble.
+@pytest.mark.parametrize("integrator", ["verlet", "csvr", "baoab_langevin", "csvr_npt"])
+def test_verlet_dynamics_match_dense(integrator: str):
+    """Verlet MD (rebuild every few steps) is bit-identical to every-step-dense in fp64,
+    across all ensembles (NVE / NVT / NPT)."""
+    sl = identity_lens(LjMdState)
+    pot = make_lennard_jones_from_state(sl, compute_position_and_cell_gradients=True)
+    base = _make_state(SKIN, integrator)
+    sp = estimate_skin_params(
+        base.particles.data.system.counts, base.systems, base.lj_parameters.cutoff, SKIN
+    )
+    reuse_prop, rebuild_prop = make_verlet_md_propagators(
+        sl, integrator, pot, CUTOFF, SKIN, dense_skin_nl(sp)
+    )
+    dense_prop = make_md_propagator(sl, integrator, pot)
+
+    reuse = jit(as_result_function(reuse_prop), donate_argnums=(1,))
+    rebuild = jit(as_result_function(rebuild_prop), donate_argnums=(1,))
+    dense = jit(as_result_function(dense_prop), donate_argnums=(1,))
+
+    sv, sd = _make_state(SKIN, integrator), _make_state(0.0, integrator)
+    cv, cd = (
+        key_chain(jax.random.key(1)),
+        key_chain(jax.random.key(1)),
+    )  # identical keys
+    maxdiff = 0.0
+    for i in range(20):
+        sd = propagate_and_fix(dense, next(cd), sd)
+        do_rb = i % 7 == 0  # exercise both rebuild and reuse paths
+        sv = propagate_and_fix(rebuild if do_rb else reuse, next(cv), sv)
+        maxdiff = max(
+            maxdiff,
+            float(
+                jnp.max(
+                    jnp.abs(sd.particles.data.positions - sv.particles.data.positions)
+                )
+            ),
+        )
+    assert maxdiff < 1e-9, (
+        f"Verlet diverged from dense ({integrator}): max|Δpos|={maxdiff:.2e}"
+    )

--- a/test/md/test_integrators.py
+++ b/test/md/test_integrators.py
@@ -718,6 +718,56 @@ class TestCSVRNPTPhysics:
             initial_grads, final_state.particles.data.position_gradients, rtol=1e-6
         )
 
+    @classmethod
+    def _get_integrator_1eval(cls):
+        deriv = create_npt_derivative_computation()
+        return make_csvr_npt_step(
+            particles=NPTState.particles,
+            systems=NPTState.systems,
+            derivative_computation=deriv,
+            flow=euclidean_flow,
+            refresh_after_barostat=False,
+        )
+
+    def test_one_eval_has_one_fewer_propagator(self):
+        """refresh_after_barostat=False drops exactly the post-barostat eval (7 -> 6)."""
+        two = self._get_integrator()
+        one = self._get_integrator_1eval()
+        assert len(one.propagators) == len(two.propagators) - 1
+
+    def test_one_eval_temperature_control(self):
+        """The thermostat still pins T with the post-barostat eval dropped."""
+        n_particles, kT_target = 5, 1.2
+        state = create_npt_system(
+            n_particles=n_particles, box_size=5.0, kT=kT_target, tau_t=0.1, tau_p=2.0
+        )
+        _, temps = run_simulation(
+            self._get_integrator_1eval(),
+            state,
+            jax.random.key(789),
+            n_equil=150,
+            n_sample=150,
+            extract_fn=lambda s: compute_temperature(s, 3 * n_particles - 3),
+        )
+        assert_temperature(jnp.mean(temps), kT_target, 0.15, "NPT-1eval ")
+
+    def test_one_eval_volume_fluctuations(self):
+        """The barostat still samples a sane volume distribution (responds, bounded)."""
+        state = create_npt_system(
+            n_particles=5, box_size=5.0, kT=1.0, tau_t=0.1, tau_p=1.0
+        )
+        _, volumes = run_simulation(
+            self._get_integrator_1eval(),
+            state,
+            jax.random.key(123),
+            n_equil=50,
+            n_sample=50,
+            extract_fn=lambda s: s.systems.data.cell.volume,
+        )
+        mean_vol, std_vol = jnp.mean(volumes), jnp.std(volumes)
+        assert std_vol > 0.01 * mean_vol, "Volume fluctuations too small"
+        assert std_vol / mean_vol < 1.0, "Volume fluctuations too large"
+
 
 # ============================================================================
 # Tests: Utilities

--- a/test/potential/test_nonbonded.py
+++ b/test/potential/test_nonbonded.py
@@ -1,0 +1,182 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the fused real-space nonbonded potential (``kups.potential.classical.nonbonded``).
+
+The fused energy (LJ + short-range Ewald on one shared graph, one vjp) must reproduce the
+sum of the separate components — ``lennard_jones_energy`` + ``ewald_short_range_energy`` —
+for energy AND forces (``dE/dr``) AND the NPT stress (``dE/dcell``), for both the Tier-A
+(maximal-reuse) and Tier-B (single-pass edge) bodies, single- and multi-system. The trusted
+oracles are the existing component energy functions.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+
+from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
+from kups.core.data.index import Index
+from kups.core.data.table import Table
+from kups.core.neighborlist import Edges
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass
+from kups.potential.classical.ewald import EwaldParameters, ewald_short_range_energy
+from kups.potential.classical.lennard_jones import (
+    LennardJonesParameters,
+    lennard_jones_energy,
+)
+from kups.potential.classical.nonbonded import (
+    NonbondedParameters,
+    fused_nonbonded_edge_energy,
+    nonbonded_energy,
+)
+from kups.potential.common.graph import GraphPotentialInput, HyperGraph
+
+from ..clear_cache import clear_cache  # noqa: F401
+
+_LABELS = ("Na", "Cl")
+_FUSED = {"TierA": nonbonded_energy, "TierB": fused_nonbonded_edge_energy}
+
+
+@dataclass
+class _NBPointData:
+    positions: jax.Array
+    labels: Index[str]
+    charges: jax.Array
+    system: Index[SystemId]
+
+
+@dataclass
+class _SysData:
+    cell: Cell
+    cutoff: jax.Array
+
+
+def _params(
+    n_sys: int, cutoff: float = 50.0, alpha: float = 0.3
+) -> NonbondedParameters:
+    keys = tuple(SystemId(i) for i in range(n_sys))
+    lj = LennardJonesParameters(
+        labels=_LABELS,
+        sigma=jnp.array([[2.4, 3.4], [3.4, 4.4]]),
+        epsilon=jnp.array([[0.0015, 0.003], [0.003, 0.005]]),
+        cutoff=Table(keys, jnp.full((n_sys,), cutoff)),
+    )
+    ew = EwaldParameters(
+        alpha=Table(keys, jnp.full((n_sys,), alpha)),
+        cutoff=Table(keys, jnp.full((n_sys,), cutoff)),
+        reciprocal_lattice_shifts=Table(keys, jnp.zeros((n_sys, 1, 3), dtype=int)),
+    )
+    return NonbondedParameters(lj=lj, ewald=ew)
+
+
+def _graph(positions, species, charges, system_ids, cells) -> HyperGraph:
+    particles = Table.arange(
+        _NBPointData(positions, Index.new(species), charges, Index.new(system_ids)),
+        label=ParticleId,
+    )
+    cell = PeriodicCell(TriclinicFrame.from_matrix(cells))
+    systems = Table.arange(
+        _SysData(cell, jnp.full((cells.shape[0],), 50.0)), label=SystemId
+    )
+    n = positions.shape[0]
+    sysarr = jnp.asarray(system_ids)
+    # all in-system pairs; large box => no periodic image crossing (zero shifts)
+    pairs = jnp.array(
+        [[i, j] for i in range(n) for j in range(n) if i < j and sysarr[i] == sysarr[j]]
+    )
+    edges = Edges(
+        indices=Index(particles.keys, pairs),
+        shifts=jnp.zeros((pairs.shape[0], 1, 3)),
+    )
+    return HyperGraph(particles, systems, edges)
+
+
+def _reference_energy(params, graph):
+    lj = lennard_jones_energy(GraphPotentialInput(params.lj, graph)).data.data
+    sr = ewald_short_range_energy(GraphPotentialInput(params.ewald, graph)).data.data
+    return lj + sr
+
+
+def _single():
+    positions = jnp.array(
+        [
+            [0.0, 0.0, 0.0],
+            [2.8, 0.0, 0.0],
+            [0.0, 2.8, 0.0],
+            [2.8, 2.8, 0.0],
+            [1.4, 1.4, 2.0],
+            [1.4, 1.4, -2.0],
+        ]
+    )
+    return dict(
+        positions=positions,
+        species=["Na", "Cl", "Cl", "Na", "Na", "Cl"],
+        charges=jnp.array([1.0, -1.0, -1.0, 1.0, 1.0, -1.0]),
+        system_ids=[0, 0, 0, 0, 0, 0],
+        cells=jnp.eye(3)[None] * 100.0,
+    )
+
+
+def _two():
+    base = jnp.array(
+        [[0.0, 0.0, 0.0], [2.8, 0.0, 0.0], [0.0, 2.8, 0.0], [1.4, 1.4, 2.0]]
+    )
+    return dict(
+        positions=jnp.concatenate([base, base + 0.3]),
+        species=["Na", "Cl", "Cl", "Na"] * 2,
+        charges=jnp.array([1.0, -1.0, -1.0, 1.0] * 2),
+        system_ids=[0, 0, 0, 0, 1, 1, 1, 1],
+        cells=jnp.broadcast_to(jnp.eye(3) * 100.0, (2, 3, 3)),
+    )
+
+
+def test_fused_energy_matches_components_single():
+    cfg, params = _single(), _params(1)
+    graph = _graph(**cfg)
+    ref = _reference_energy(params, graph)
+    for name, fn in _FUSED.items():
+        got = fn(GraphPotentialInput(params, graph)).data.data
+        npt.assert_allclose(got, ref, rtol=1e-5, err_msg=f"{name} energy mismatch")
+
+
+def test_fused_energy_matches_components_batched():
+    cfg, params = _two(), _params(2)
+    graph = _graph(**cfg)
+    ref = _reference_energy(params, graph)
+    assert ref.shape == (2,)
+    for name, fn in _FUSED.items():
+        got = fn(GraphPotentialInput(params, graph)).data.data
+        npt.assert_allclose(
+            got, ref, rtol=1e-5, err_msg=f"{name} batched energy mismatch"
+        )
+
+
+def _grad_fns(energy_or_array_fn, params, cfg):
+    def total(pos, cellm):
+        g = _graph(pos, cfg["species"], cfg["charges"], cfg["system_ids"], cellm)
+        return energy_or_array_fn(params, g).sum()
+
+    return jax.grad(total, argnums=(0, 1))(cfg["positions"], cfg["cells"])
+
+
+def test_fused_forces_and_stress_match_components():
+    cfg, params = _single(), _params(1)
+    dpos_ref, dcell_ref = _grad_fns(_reference_energy, params, cfg)
+    for name, fn in _FUSED.items():
+        arr_fn = lambda p, g, fn=fn: fn(GraphPotentialInput(p, g)).data.data  # noqa: E731
+        dpos, dcell = _grad_fns(arr_fn, params, cfg)
+        npt.assert_allclose(
+            dpos,
+            dpos_ref,
+            rtol=1e-5,
+            atol=1e-10,
+            err_msg=f"{name} forces (dE/dr) mismatch",
+        )
+        npt.assert_allclose(
+            dcell,
+            dcell_ref,
+            rtol=1e-5,
+            atol=1e-10,
+            err_msg=f"{name} stress (dE/dcell) mismatch",
+        )

--- a/test/potential/test_pme.py
+++ b/test/potential/test_pme.py
@@ -1,0 +1,213 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the smooth-PME reciprocal-space potential (``kups.potential.classical.pme``).
+
+PME must reproduce the direct-Ewald reciprocal term (``ewald_long_range_energy``)
+for energy, forces (``dE/dr``) and the NPT stress (``dE/dcell``), and handle a
+batched multi-system axis. The trusted oracle is the existing direct-Ewald path
+(validated against the NaCl Madelung constant in ``test_ewald.py``).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+from jax import Array
+
+from kups.core.cell import PeriodicCell, TriclinicFrame, make_supercell
+from kups.core.data.table import Table
+from kups.core.lens import lens
+from kups.core.typing import ParticleId, SystemId
+from kups.potential.classical.ewald import (
+    EwaldLongRangeInput,
+    EwaldParameters,
+    estimate_ewald_parameters,
+    ewald_long_range_energy,
+    kvecs_from_kmax,
+)
+from kups.potential.classical.pme import (
+    make_pme_long_range_energy,
+    pme_mesh_for_cell,
+)
+from kups.potential.common.graph import PointCloud
+
+from ..clear_cache import clear_cache  # noqa: F401
+from .test_ewald import _make_particle_data, _make_systems
+
+ORDER = 8
+
+
+def _nacl(repeats: int = 5, eps: float = 5e-5, jitter: float = 0.3):
+    """Build a NaCl rocksalt supercell + estimated single-system EwaldParameters.
+
+    A small thermal ``jitter`` (Angstrom) is applied so the reciprocal-space
+    energy is genuinely nonzero — a pristine lattice has a near-zero direct-Ewald
+    reciprocal term (the k-vector set misses the Bragg peaks), which makes a
+    reciprocal-only rtol comparison degenerate.
+    """
+    positions = jnp.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+    charges = jnp.array([-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0], dtype=float)
+    cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3, dtype=float) * 2))
+    cell, (positions, charges) = make_supercell(
+        cell, repeats, (positions, charges), lens(lambda x: x[0])
+    )
+    if jitter:
+        positions = positions + jitter * jax.random.normal(
+            jax.random.key(7), positions.shape
+        )
+    est = estimate_ewald_parameters(charges, cell, epsilon_total=eps)
+    params = EwaldParameters(
+        alpha=Table((SystemId(0),), jnp.asarray([est.alpha])),
+        cutoff=Table((SystemId(0),), jnp.asarray([est.real_cutoff])),
+        reciprocal_lattice_shifts=Table(
+            (SystemId(0),), kvecs_from_kmax(cell, est.k_max)[None]
+        ),
+    )
+    return positions, charges, cell, params
+
+
+def _lr_input(positions: Array, cell_vectors: Array, charges: Array, params, cutoff):
+    """Rebuild an ``EwaldLongRangeInput`` from raw positions + cell matrix (differentiable)."""
+    cell = PeriodicCell(TriclinicFrame.from_matrix(cell_vectors))
+    particles = Table.arange(
+        _make_particle_data(positions, charges, n_systems=1), label=ParticleId
+    )
+    systems = _make_systems(cell[None], cutoff)
+    return EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+
+
+class TestPMEvsEwald:
+    """PME reciprocal term must match the direct-Ewald oracle."""
+
+    def test_recip_energy_matches_ewald(self):
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors  # (3,3)
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+        inp = _lr_input(positions, cellv, charges, params, params.cutoff.data)
+        e_ewald = float(ewald_long_range_energy(inp).data.data[0])
+        e_pme = float(make_pme_long_range_energy(mesh, ORDER)(inp).data.data[0])
+        npt.assert_allclose(e_pme, e_ewald, rtol=1e-4)
+
+    def test_forces_match_ewald(self):
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+
+        def e_ewald(p):
+            return ewald_long_range_energy(
+                _lr_input(p, cellv, charges, params, params.cutoff.data)
+            ).data.data.sum()
+
+        def e_pme(p):
+            return make_pme_long_range_energy(mesh, ORDER)(
+                _lr_input(p, cellv, charges, params, params.cutoff.data)
+            ).data.data.sum()
+
+        f_ewald = jax.grad(e_ewald)(positions)
+        f_pme = jax.grad(e_pme)(positions)
+        npt.assert_allclose(f_pme, f_ewald, rtol=1e-2, atol=1e-3)
+
+    def test_stress_finite_difference_self_consistent(self):
+        """PME autodiff dE/dcell (NPT virial) must equal a finite-difference of E.
+
+        This is the gate from PME_SCOPING §6. We do NOT tightly compare to the
+        direct-Ewald stress: the reciprocal *virial* converges much more slowly in
+        ``k`` than the energy, and ``estimate_ewald_parameters`` targets energy
+        accuracy, so the truncated-k Ewald shear stress is the *less* converged
+        reference. The PME full-grid stress is correct iff it matches a
+        finite-difference of the PME energy itself.
+        """
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.4)
+
+        def e_pme(v):
+            return make_pme_long_range_energy(mesh, ORDER)(
+                _lr_input(positions, v, charges, params, params.cutoff.data)
+            ).data.data.sum()
+
+        g_pme = np.asarray(jax.grad(e_pme)(cellv))
+        h = 1e-5
+        for a, b in [(0, 0), (1, 1), (2, 2), (1, 0), (2, 0)]:
+            fd = float(
+                (e_pme(cellv.at[a, b].add(h)) - e_pme(cellv.at[a, b].add(-h))) / (2 * h)
+            )
+            npt.assert_allclose(g_pme[a, b], fd, rtol=1e-4, atol=1e-6)
+
+    def test_stress_diagonal_matches_ewald(self):
+        """The (well-converged) diagonal/normal stress should match direct Ewald."""
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.4)
+
+        def grad_cell(energy_fn):
+            return np.asarray(
+                jax.grad(
+                    lambda v: energy_fn(
+                        _lr_input(positions, v, charges, params, params.cutoff.data)
+                    ).data.data.sum()
+                )(cellv)
+            )
+
+        g_ewald = grad_cell(ewald_long_range_energy)
+        g_pme = grad_cell(make_pme_long_range_energy(mesh, ORDER))
+        diag_e = np.diag(g_ewald)
+        diag_p = np.diag(g_pme)
+        npt.assert_allclose(diag_p, diag_e, rtol=5e-3, atol=5e-3)
+
+    def test_two_system_batch(self):
+        """A 2-system batch returns correct per-SystemId energies (flat batch_idx)."""
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+
+        # tile two identical replicas onto one SystemId axis
+        pos2 = jnp.concatenate([positions, positions])
+        q2 = jnp.concatenate([charges, charges])
+        n = positions.shape[0]
+        sys_ids = jnp.concatenate([jnp.zeros(n, int), jnp.ones(n, int)])
+        cell2 = cell[None]
+        cell2 = jax.tree.map(lambda a: jnp.concatenate([a, a]), cell2)
+        params2 = EwaldParameters(
+            alpha=Table(
+                (SystemId(0), SystemId(1)),
+                jnp.concatenate([params.alpha.data, params.alpha.data]),
+            ),
+            cutoff=Table(
+                (SystemId(0), SystemId(1)),
+                jnp.concatenate([params.cutoff.data, params.cutoff.data]),
+            ),
+            reciprocal_lattice_shifts=Table(
+                (SystemId(0), SystemId(1)),
+                jnp.concatenate(
+                    [
+                        params.reciprocal_lattice_shifts.data,
+                        params.reciprocal_lattice_shifts.data,
+                    ]
+                ),
+            ),
+        )
+        particles = Table.arange(
+            _make_particle_data(pos2, q2, n_systems=2, system_ids=sys_ids),
+            label=ParticleId,
+        )
+        systems = _make_systems(cell2, params2.cutoff.data)
+        inp = EwaldLongRangeInput(PointCloud(particles, systems), params2, None)
+        e_pme = np.asarray(make_pme_long_range_energy(mesh, ORDER)(inp).data.data)
+        e_ewald = np.asarray(ewald_long_range_energy(inp).data.data)
+        assert e_pme.shape == (2,)
+        npt.assert_allclose(e_pme[0], e_pme[1], rtol=1e-10)  # identical replicas
+        npt.assert_allclose(e_pme, e_ewald, rtol=2e-3)


### PR DESCRIPTION
Adds an opt-in `forces_only` mode that differentiates the energy w.r.t. positions only, skipping the cell-virial (`dE/dcell`). For NVE/NVT, where the barostat stress is never used, this avoids the autodiff cell-gradient entirely.

Threaded through `make_nonbonded_from_state` / `make_ewald_from_state` (positions-only gradient lens) and `make_md_propagator` / `make_verlet_md_propagators` (the step neither maps nor caches the cell-virial). Default is off, so existing behavior is unchanged; raises if combined with an NPT integrator. When on, `cell_gradients` is not refreshed, so logged stress/pressure is unavailable.

The forces are bit-identical to the both-gradients path (`dE/dr` does not depend on whether `dE/dcell` is also computed). Full suite green at the stack tip (39 tests).

Stacked on #196.