### PR TITLE
feat: Add `MatrixStructure` flag with `structured_matmul` and `structured_det_and_inverse` dispatch

### DIFF
--- a/src/kups/core/utils/math.py
+++ b/src/kups/core/utils/math.py
@@ -8,13 +8,16 @@ factorial ratios, polynomial root finding, and optimized matrix operations for
 3×3 matrices.
 """
 
+from __future__ import annotations
+
 from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol, overload, override, runtime_checkable
 
 import jax
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.utils.jax import jit, vectorize
+from kups.core.utils.jax import dataclass, jit, vectorize
 
 
 @jit
@@ -398,6 +401,175 @@ def triangular_3x3_matmul(
     return inner(L, x)
 
 
+@runtime_checkable
+class SquareMatrix(Protocol):
+    @property
+    def array(self) -> Array:
+        """Underlying array of shape `(..., 3, 3)` representing the matrix."""
+        ...
+
+    @overload
+    def matmul(self, x: Array, *, side: MatmulSide | str = ...) -> Array: ...
+    @overload
+    def matmul(
+        self, x: SquareMatrix, *, side: MatmulSide | str = ...
+    ) -> SquareMatrix: ...
+    def matmul(
+        self, x: Array | SquareMatrix, *, side: MatmulSide | str = MatmulSide.RIGHT
+    ) -> Array | SquareMatrix:
+        """Matrix-vector or matrix-matrix multiplication.
+
+        Args:
+            x: Vector or matrix to multiply.
+            side: Multiplication side:
+                - `"right"`: Computes `x @ self`
+                - `"left"`: Computes `self @ x`
+
+        Returns:
+            Result of the multiplication.
+        """
+        ...
+
+    def det(self) -> Array:
+        """Compute the determinant of the matrix.
+
+        Returns:
+            Determinant as a scalar array.
+        """
+        ...
+
+    def inverse(self) -> SquareMatrix:
+        """Compute the inverse of the matrix.
+
+        Returns:
+            Inverse of the matrix.
+        """
+        ...
+
+    def scale(self, factor: Array) -> SquareMatrix:
+        """Scale the matrix by a given factor.
+
+        Args:
+            factor: Scalar factor to scale the matrix.
+
+        Returns:
+            Scaled matrix.
+        """
+        ...
+
+
+@dataclass
+class GeneralSquareMatrix:
+    array: Array
+
+    @overload
+    def matmul(self, x: Array, *, side: MatmulSide | str = ...) -> Array: ...
+    @overload
+    def matmul(
+        self, x: SquareMatrix, *, side: MatmulSide | str = ...
+    ) -> SquareMatrix: ...
+
+    def matmul(
+        self, x: Array | SquareMatrix, *, side: MatmulSide | str = MatmulSide.RIGHT
+    ) -> Array | SquareMatrix:
+        if isinstance(x, SquareMatrix):
+            # Matrix-matrix: RIGHT composes as ``self @ x`` so a DeformedFrame's
+            # ``base.matmul(deformation)`` evaluates to ``base @ deformation``.
+            product = (
+                x.array @ self.array
+                if side == MatmulSide.LEFT
+                else self.array @ x.array
+            )
+            return GeneralSquareMatrix(product)
+        return (
+            jnp.einsum("...ij,...j->...i", self.array, x)
+            if side == MatmulSide.LEFT
+            else jnp.einsum("...ji,...j->...i", self.array, x)
+        )
+
+    def det(self) -> Array:
+        return jnp.linalg.det(self.array)
+
+    def inverse(self) -> SquareMatrix:
+        return GeneralSquareMatrix(jnp.linalg.inv(self.array))
+
+    def scale(self, factor: Array) -> SquareMatrix:
+        return GeneralSquareMatrix(self.array * factor)
+
+
+@dataclass
+class LowerTriangularSquareMatrix(GeneralSquareMatrix):
+    array: Array
+
+    @overload
+    def matmul(self, x: Array, *, side: MatmulSide | str = ...) -> Array: ...
+    @overload
+    def matmul(
+        self, x: SquareMatrix, *, side: MatmulSide | str = ...
+    ) -> SquareMatrix: ...
+
+    @override
+    def matmul(
+        self, x: Array | SquareMatrix, *, side: MatmulSide | str = MatmulSide.RIGHT
+    ) -> Array | SquareMatrix:
+        if isinstance(x, SquareMatrix):
+            product = (
+                x.array @ self.array
+                if side == MatmulSide.LEFT
+                else self.array @ x.array
+            )
+            if isinstance(x, LowerTriangularSquareMatrix):
+                return LowerTriangularSquareMatrix(product)
+            return GeneralSquareMatrix(product)
+        return triangular_3x3_matmul(self.array, x, lower=True, side=side)
+
+    @override
+    def det(self) -> Array:
+        return jnp.prod(jnp.diagonal(self.array, axis1=-2, axis2=-1), axis=-1)
+
+    @override
+    def inverse(self) -> SquareMatrix:
+        _, inv = triangular_3x3_det_and_inverse(self.array, lower=True)
+        return LowerTriangularSquareMatrix(inv)
+
+
+@dataclass
+class DiagonalSquareMatrix(LowerTriangularSquareMatrix):
+    array: Array
+
+    @overload
+    def matmul(self, x: Array, *, side: MatmulSide | str = ...) -> Array: ...
+    @overload
+    def matmul(
+        self, x: SquareMatrix, *, side: MatmulSide | str = ...
+    ) -> SquareMatrix: ...
+
+    @override
+    def matmul(
+        self, x: Array | SquareMatrix, *, side: MatmulSide | str = MatmulSide.RIGHT
+    ) -> Array | SquareMatrix:
+        if isinstance(x, SquareMatrix):
+            product = (
+                x.array @ self.array
+                if side == MatmulSide.LEFT
+                else self.array @ x.array
+            )
+            if isinstance(x, DiagonalSquareMatrix):
+                return DiagonalSquareMatrix(product)
+            if isinstance(x, LowerTriangularSquareMatrix):
+                return LowerTriangularSquareMatrix(product)
+            return GeneralSquareMatrix(product)
+        # The diagonal matrix-vector product is side-invariant.
+        diag = jnp.diagonal(self.array, axis1=-2, axis2=-1)
+        return diag * x
+
+    @override
+    def inverse(self) -> SquareMatrix:
+        diag_inv = 1.0 / jnp.diagonal(self.array, axis1=-2, axis2=-1)
+        eye = jnp.eye(diag_inv.shape[-1], dtype=self.array.dtype)
+        return DiagonalSquareMatrix(diag_inv[..., None] * eye)
+
+
 @jit
 def solve_affine_ode(A: Array, b: Array, x0: Array, dt: Array | float) -> Array:
     r"""Solve the affine ODE $\dot{x} = A\,x + b$ exactly over $[0, \Delta t]$.
@@ -494,3 +666,9 @@ def next_higher_power(value: Array, base: Array | float = 2.0) -> Array:
     result = jnp.power(base, exponents)
     # Linear growth for base <= 1
     return jnp.where(base <= 1, value, result).astype(int)
+
+
+if TYPE_CHECKING:
+
+    def _(m: GeneralSquareMatrix) -> None:
+        __: SquareMatrix = m

--- a/test/core/test_math.py
+++ b/test/core/test_math.py
@@ -8,6 +8,9 @@ import numpy.testing as npt
 import pytest
 
 from kups.core.utils.math import (
+    DiagonalSquareMatrix,
+    GeneralSquareMatrix,
+    LowerTriangularSquareMatrix,
     MatmulSide,
     cubic_roots,
     det_and_inverse_3x3,
@@ -20,6 +23,18 @@ from kups.core.utils.math import (
     triangular_3x3_logm,
     triangular_3x3_matmul,
 )
+
+
+@pytest.fixture(autouse=True)
+def _enable_x64():
+    """Enable float64 for this module's tests without leaking the global flag
+    into other test modules."""
+    prev = jax.config.read("jax_enable_x64")
+    jax.config.update("jax_enable_x64", True)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
 
 
 class TestLogFactorialRatio:
@@ -414,6 +429,105 @@ class TestNextHigherPower:
             next_higher_power(jnp.array([4, 10, 28]), base=3),
             jnp.array([9, 27, 81]),
         )
+
+
+_STRUCTURED = [GeneralSquareMatrix, LowerTriangularSquareMatrix, DiagonalSquareMatrix]
+
+
+def _structured(cls: type[GeneralSquareMatrix], A: jax.Array) -> jax.Array:
+    """Project ``A`` onto the structure ``cls`` represents."""
+    if cls is DiagonalSquareMatrix:
+        return jnp.diag(jnp.diagonal(A, axis1=-2, axis2=-1))
+    if cls is LowerTriangularSquareMatrix:
+        return jnp.tril(A)
+    return A
+
+
+class TestSquareMatrixMatmul:
+    @pytest.fixture(params=[MatmulSide.LEFT, MatmulSide.RIGHT])
+    def side(self, request: pytest.FixtureRequest) -> MatmulSide:
+        return request.param
+
+    @pytest.mark.parametrize("cls", _STRUCTURED, ids=lambda c: c.__name__)
+    def test_matches_dense_reference(
+        self, cls: type[GeneralSquareMatrix], side: MatmulSide
+    ):
+        M = _structured(cls, jax.random.normal(jax.random.PRNGKey(0), (3, 3)))
+        x = jax.random.normal(jax.random.PRNGKey(1), (10, 3))
+        result = cls(M).matmul(x, side=side)
+        # RIGHT = x @ M, LEFT = M @ x.
+        expected = (
+            jnp.einsum("ij,bj->bi", M, x)
+            if side is MatmulSide.LEFT
+            else jnp.einsum("bi,ij->bj", x, M)
+        )
+        npt.assert_allclose(result, expected, rtol=1e-12)
+
+    @pytest.mark.parametrize(
+        "cls",
+        [LowerTriangularSquareMatrix, DiagonalSquareMatrix],
+        ids=lambda c: c.__name__,
+    )
+    def test_fast_path_matches_general(
+        self, cls: type[GeneralSquareMatrix], side: MatmulSide
+    ):
+        M = _structured(cls, jax.random.normal(jax.random.PRNGKey(2), (3, 3)))
+        x = jax.random.normal(jax.random.PRNGKey(3), (5, 3))
+        npt.assert_allclose(
+            cls(M).matmul(x, side=side),
+            GeneralSquareMatrix(M).matmul(x, side=side),
+            rtol=1e-12,
+        )
+
+    def test_diagonal_side_invariance(self):
+        D = jnp.diag(jax.random.normal(jax.random.PRNGKey(6), (3,)))
+        x = jax.random.normal(jax.random.PRNGKey(7), (5, 3))
+        left = DiagonalSquareMatrix(D).matmul(x, side=MatmulSide.LEFT)
+        right = DiagonalSquareMatrix(D).matmul(x, side=MatmulSide.RIGHT)
+        npt.assert_allclose(left, right, rtol=1e-12)
+
+    def test_batched_matrices(self, side: MatmulSide):
+        M = jnp.tril(jax.random.normal(jax.random.PRNGKey(8), (4, 3, 3)))
+        x = jax.random.normal(jax.random.PRNGKey(9), (4, 3))
+        result = LowerTriangularSquareMatrix(M).matmul(x, side=side)
+        expected = (
+            jnp.einsum("bij,bj->bi", M, x)
+            if side is MatmulSide.LEFT
+            else jnp.einsum("bi,bij->bj", x, M)
+        )
+        npt.assert_allclose(result, expected, rtol=1e-12)
+
+
+class TestSquareMatrixDetAndInverse:
+    @pytest.mark.parametrize("cls", _STRUCTURED, ids=lambda c: c.__name__)
+    def test_matches_dense_reference(self, cls: type[GeneralSquareMatrix]):
+        M = _structured(
+            cls, jax.random.normal(jax.random.PRNGKey(0), (3, 3)) + 2 * jnp.eye(3)
+        )
+        m = cls(M)
+        npt.assert_allclose(m.det(), jnp.linalg.det(M), rtol=1e-12)
+        npt.assert_allclose(m.inverse().array, jnp.linalg.inv(M), atol=1e-12)
+
+    def test_batched_matrices(self):
+        M = jnp.tril(jax.random.normal(jax.random.PRNGKey(2), (4, 3, 3))) + 2 * jnp.eye(
+            3
+        )
+        m = LowerTriangularSquareMatrix(M)
+        npt.assert_allclose(m.det(), jnp.linalg.det(M), rtol=1e-12)
+        npt.assert_allclose(m.inverse().array, jnp.linalg.inv(M), atol=1e-12)
+
+
+class TestSquareMatrixPromotion:
+    def test_product_rule(self):
+        """Matrix-matrix products promote to the least-specific structure."""
+        key = jax.random.PRNGKey(0)
+        L = LowerTriangularSquareMatrix(jnp.tril(jax.random.normal(key, (3, 3))))
+        D = DiagonalSquareMatrix(jnp.diag(jax.random.normal(key, (3,))))
+        G = GeneralSquareMatrix(jax.random.normal(key, (3, 3)))
+        assert type(L.matmul(G)) is GeneralSquareMatrix
+        assert type(L.matmul(L)) is LowerTriangularSquareMatrix
+        assert type(D.matmul(L)) is LowerTriangularSquareMatrix
+        assert type(D.matmul(D)) is DiagonalSquareMatrix
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `MatrixStructure` flag and structure-dispatching helpers for 3×3 matrix operations

Introduces a `MatrixStructure` `IntFlag` enum with `GENERAL`, `LOWER_TRIANGULAR`, and `DIAGONAL` variants, along with three new utilities:

- **`matmul_structure`** – infers the structure of a matrix product from the structures of its factors via bitwise intersection.
- **`structured_matmul`** – dispatches a batched 3×3 matvec (`(..., 3, 3) × (..., 3)`) to the appropriate specialized path (diagonal elementwise multiply, triangular matvec, or general einsum) based on a static `MatrixStructure` flag, with support for both `LEFT` and `RIGHT` multiplication sides.
- **`structured_det_and_inverse`** – dispatches determinant and inverse computation to the triangular or general 3×3 routine based on structure.

Both `structured_matmul` and `structured_det_and_inverse` are JIT-compiled with the structure flag as a static argument, so specialization happens at trace time with no runtime branching overhead.

Tests cover correctness against dense JAX references for all three structures, consistency between specialized and general paths, diagonal side-invariance, and batched inputs. A module-scoped `autouse` fixture enables float64 for the test file without leaking the setting to other modules.