### PR TITLE
refactor: Replace `FrechetFrame` with `DeformedFrame`/`MatrixLogFrame` and add `Frame.structure` dispatch

### DIFF
--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -17,7 +17,7 @@ from kups.application.utils.particles import (
     default_exclusion,
     particles_from_ase,
 )
-from kups.core.cell import AnyPeriodicity, Cell, FrechetFrame
+from kups.core.cell import AnyPeriodicity, Cell, DeformedFrame, MatrixLogFrame
 from kups.core.data import Table
 from kups.core.data.index import Index
 from kups.core.lens import bind
@@ -34,7 +34,10 @@ class RelaxParticles(Particles):
     (forces, inclusion/exclusion indices) needed by relaxation propagators.
 
     Attributes:
-        position_gradients: Energy gradient w.r.t. positions, shape ``(n_atoms, 3)``.
+        position_gradients: Optimizer position-DOF gradient ``∂E/∂u_pos`` (the
+            relaxation filter's output), shape ``(n_atoms, 3)``: ``∂E/∂q`` under
+            ``cell_filter`` (reference-cartesian) or ``∂E/∂r`` under
+            ``positions_only``. The force source and ASE-fmax convergence quantity.
     """
 
     position_gradients: Array
@@ -57,11 +60,10 @@ class RelaxSystems:
     cell: Cell[AnyPeriodicity]
     """Cell geometry, batched with shape (1,)."""
     cell_gradients: Cell[AnyPeriodicity]
-    """Energy gradient w.r.t. the cell, stored on the same
-    :class:`~kups.core.cell.Frame` as :attr:`cell` (i.e. the 6 lower-triangular
-    entries of ``∂U/∂h`` for a :class:`~kups.core.cell.TriclinicFrame`). Stress
-    is computed from particles + systems via
-    :func:`~kups.observables.stress.stress_via_virial_theorem`."""
+    """Optimizer cell-DOF gradient ``∂E/∂u_cell`` (the relaxation filter's output),
+    stored on :attr:`cell`'s frame (the lower-triangular log-deformation entries
+    under ``cell_filter``). The ASE-fmax convergence quantity for the cell; the
+    atoms-ride-the-cell coupling is already folded in by the filter pullback."""
     potential_energy: Array
     """Potential energy per system, shape (1,)."""
 
@@ -107,18 +109,23 @@ def relax_state_from_ase(
             position_gradients=jnp.zeros_like(p.data.positions),
         ),
     )
-    # cell_factor = atom count (ASE's exp_cell_factor) balances the extensive
-    # cell-virial gradient against the per-atom forces in the joint optimiser.
-    n_atoms = float(p.data.positions.shape[0])
-    cell = bind(cell, lambda x: x.frame).apply(
-        lambda f: FrechetFrame.from_frame(f, cell_factor=n_atoms)
+    # cell_factor = per-system atom count (ASE's exp_cell_factor) balances the
+    # extensive cell-virial gradient against the per-atom forces in the joint
+    # optimiser. bincount over the system index gives one count per system.
+    n_systems = p.data.system.num_labels
+    cell_factor = jnp.bincount(p.data.system.indices, length=n_systems).astype(
+        p.data.positions.dtype
     )
-    cell = cell[None]
+    cell = bind(cell[None], lambda x: x.frame).apply(
+        lambda f: DeformedFrame.from_frame(
+            f, cell_factor=cell_factor, deformation=MatrixLogFrame
+        )
+    )
     systems = Table.arange(
         RelaxSystems(
             cell=cell,
             cell_gradients=tree_zeros_like(cell),
-            potential_energy=jnp.array([0.0]),
+            potential_energy=jnp.zeros(n_systems),
         ),
         label=SystemId,
     )

--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -104,6 +104,7 @@ from enum import Enum
 from functools import partial
 from typing import (
     Any,
+    Callable,
     Generic,
     Literal,
     Protocol,
@@ -122,9 +123,13 @@ from jax.flatten_util import ravel_pytree
 
 from kups.core.data import Sliceable
 from kups.core.lens import Lens, bind
-from kups.core.utils.jax import dataclass, field
+from kups.core.utils.jax import dataclass, field, jit, no_post_init
 from kups.core.utils.math import (
-    triangular_3x3_det_and_inverse,
+    DiagonalSquareMatrix,
+    GeneralSquareMatrix,
+    LowerTriangularSquareMatrix,
+    SquareMatrix,
+    logm,
     triangular_3x3_expm,
     triangular_3x3_from_tril,
     triangular_3x3_logm,
@@ -212,6 +217,23 @@ class Frame(Protocol):
         """Matrix inverse of [`vectors`][kups.core.cell.Frame.vectors],
         used to convert real-space coordinates to fractional, shape
         ``(..., 3, 3)``."""
+        ...
+
+    @property
+    def matrix(self) -> SquareMatrix:
+        """Static structure of [`vectors`][kups.core.cell.Frame.vectors] used to
+        dispatch the geometric primitives (inverse, volume, transforms) onto the
+        matching fast path. ``LOWER_TRIANGULAR`` / ``DIAGONAL`` keep the triangular
+        and diagonal forms; ``GENERAL`` falls back to dense ``3x3`` algebra."""
+        ...
+
+    @property
+    def reference_vectors(self) -> Array:
+        """Fixed reference basis for deformation-relative atom coordinates,
+        shape ``(..., 3, 3)``. The identity for directly-parameterised frames
+        (so atom DOFs are fractional); a frame that parameterises a deformation
+        of a stored reference (e.g. [DeformedFrame][kups.core.cell.DeformedFrame])
+        returns that reference, conditioning the DOFs against it."""
         ...
 
     @property
@@ -338,17 +360,32 @@ class BaseFrame(Frame, abc.ABC):
 
     @property
     @override
+    def matrix(self) -> SquareMatrix:
+        # Conservative default: any frame without an explicit structure is
+        # correct (just not fast) under the general dense paths.
+        return GeneralSquareMatrix(self.vectors)
+
+    @property
+    @override
     def inverse_vectors(self) -> Array:
-        return triangular_3x3_det_and_inverse(self.vectors)[1]
+        return self.matrix.inverse().array
+
+    @property
+    @override
+    def reference_vectors(self) -> Array:
+        # No stored reference: atom DOFs are fractional. DeformedFrame overrides.
+        return jnp.broadcast_to(
+            jnp.eye(3, dtype=self.vectors.dtype), self.vectors.shape
+        )
 
     @property
     @override
     def volume(self) -> Array:
-        diagonal = jnp.diagonal(self.vectors, axis1=-2, axis2=-1)
-        return jnp.abs(diagonal.prod(axis=-1))
+        return jnp.abs(self.matrix.det())
 
     @property
     @override
+    @jit
     def perpendicular_lengths(self) -> Array:
         v = self.vectors
         a, b, c = v[..., 0, :], v[..., 1, :], v[..., 2, :]
@@ -360,24 +397,27 @@ class BaseFrame(Frame, abc.ABC):
 
     @override
     def to_fractional(self, r: Array) -> Array:
-        return triangular_3x3_matmul(self.inverse_vectors, r)
+        return self.matrix.inverse().matmul(r)
 
     @override
     def to_real(self, r_frac: Array) -> Array:
-        return triangular_3x3_matmul(self.vectors, r_frac)
+        return self.matrix.matmul(r_frac)
 
     @override
+    @jit
     def materialize(self) -> MaterializedFrame:
-        vecs = self.vectors
-        det, inv = triangular_3x3_det_and_inverse(vecs)
-        return MaterializedFrame(vectors=vecs, inverse_vectors=inv, volume=jnp.abs(det))
+        matrix = self.matrix
+        det, inv = matrix.det(), matrix.inverse()
+        return MaterializedFrame(self.matrix, inv, jnp.abs(det))
 
     @override
+    @jit
     def parameter_gradient(self, vectors_grad: Array) -> Self:
         (grad,) = jax.vjp(lambda f: f.vectors, self)[1](vectors_grad)
         return grad
 
     @override
+    @jit
     def vectors_gradient(self, parameter_grad: Frame) -> Array:
         def single(frame: Frame, grad: Frame) -> Array:
             theta, unravel = ravel_pytree(frame)
@@ -391,7 +431,8 @@ class BaseFrame(Frame, abc.ABC):
         fn = single
         for _ in range(self.vectors.ndim - 2):
             fn = jax.vmap(fn)
-        return fn(self, parameter_grad)
+        with no_post_init():
+            return fn(self, parameter_grad)
 
 
 class LinearFrame(BaseFrame, abc.ABC):
@@ -501,6 +542,11 @@ class TriclinicFrame(LinearFrame, Sliceable):
 
     @property
     @override
+    def matrix(self) -> SquareMatrix:
+        return LowerTriangularSquareMatrix(self.vectors)
+
+    @property
+    @override
     def vectors(self) -> Array:
         return triangular_3x3_from_tril(self.tril)
 
@@ -543,6 +589,21 @@ class TriclinicFrame(LinearFrame, Sliceable):
         return type(self)(self.tril * jnp.asarray(other)[..., None])
 
 
+def _broadcast_cell_factor(cell_factor: float | Array, like: Array) -> Array:
+    """Align a scalar / per-system ``cell_factor`` with ``like``'s axes.
+
+    Appends trailing singleton axes so a per-system ``(B,)`` value lines up with
+    ``like``'s leading axis (not its last) and broadcasts against the trailing axes
+    in arithmetic. The result is left at this minimal shape rather than materialised
+    to ``like.shape``, so ``cell_factor`` stays a small leaf instead of inflating
+    into ``like``'s trailing dimensions.
+    """
+    cf = jnp.asarray(cell_factor, like.dtype)
+    cf = cf.reshape(cf.shape + (1,) * (like.ndim - cf.ndim))
+    cf = jnp.broadcast_to(cf, (like.shape[0], *cf.shape[1:]))
+    return cf
+
+
 @dataclass
 class LogTriclinicFrame(BaseFrame, Sliceable):
     """Triclinic [Frame][kups.core.cell.Frame] parameterised in the matrix log.
@@ -563,93 +624,221 @@ class LogTriclinicFrame(BaseFrame, Sliceable):
     Attributes:
         tril: Lower-triangular elements ``[A00, A10, A11, A20, A21, A22]`` of
             ``A``, shape ``(..., 6)``.
+        cell_factor: Stiffening factor (ASE's ``exp_cell_factor``) so that
+            ``vectors = expm(A / cell_factor)`` and the gradient w.r.t. ``A``
+            carries a ``1 / cell_factor`` factor. A stop-gradient leaf broadcast
+            to ``tril``'s shape (equal per slot) so every leaf shares ``tril``'s
+            leading dimension inside batched containers; read the per-system value
+            through ``factor``.
     """
 
     tril: Array
+    cell_factor: Array
 
     @classmethod
-    def from_frame(cls, frame: Frame) -> Self:
-        return cls.from_matrix(frame.vectors)
+    def from_frame(cls, frame: Frame, *, cell_factor: float | Array = 1.0) -> Self:
+        return cls.from_matrix(frame.vectors, cell_factor=cell_factor)
 
     @classmethod
     @override
-    def from_matrix(cls, vecs: Array) -> Self:
+    def from_matrix(cls, vecs: Array, *, cell_factor: float | Array = 1.0) -> Self:
         """Construct from a lower-triangular basis matrix ``L`` (positive
-        diagonal), shape ``(..., 3, 3)``, storing ``logm(L)`` so that
-        ``vectors == L``."""
-        return cls(triangular_3x3_logm(jnp.asarray(vecs))[..., *np.tril_indices(3)])
+        diagonal), shape ``(..., 3, 3)``, storing ``A = cell_factor * logm(L)`` so
+        that ``vectors == expm(A / cell_factor) == L``."""
+        vecs = jnp.asarray(vecs)
+        tril = triangular_3x3_logm(vecs)[..., *np.tril_indices(3)]
+        cf = _broadcast_cell_factor(cell_factor, tril)
+        return cls(tril * cf, cf)
+
+    @property
+    @override
+    def matrix(self) -> SquareMatrix:
+        # expm of a lower-triangular A is lower-triangular.
+        return LowerTriangularSquareMatrix(self.vectors)
 
     @property
     @override
     def vectors(self) -> Array:
-        return triangular_3x3_expm(triangular_3x3_from_tril(self.tril))
+        # fixed preconditioner, never optimised.
+        cf = jax.lax.stop_gradient(self.cell_factor)
+        A = triangular_3x3_from_tril(self.tril / cf)
+        return triangular_3x3_expm(A=A)
 
     @property
     @override
     def volume(self) -> Array:
-        # det(expm(A)) = exp(tr A); the diagonal of A is tril[0], tril[2], tril[5].
-        return jnp.exp(self.tril[..., 0] + self.tril[..., 2] + self.tril[..., 5])
+        # det(expm(A / cf)) = exp(tr(A / cf)); A's diagonal is tril[0], tril[2], tril[5].
+        return jnp.exp(
+            (self.tril[..., 0] + self.tril[..., 2] + self.tril[..., 5])
+            / self.cell_factor[..., 0]
+        )
 
     @override
     def tile(self, multiplicities: tuple[int, int, int]) -> Self:
         # Per-axis row scaling has no closed form in A (diag(m) does not commute
         # with A), so scale the basis matrix and re-take the log.
         m = jnp.asarray(multiplicities)
-        log_matrix = triangular_3x3_logm(self.vectors * m[:, None])
-        return type(self)(log_matrix[..., *np.tril_indices(3)])
+        return type(self).from_matrix(
+            self.vectors * m[:, None], cell_factor=self.cell_factor
+        )
 
     @override
     def __mul__(self, other: Array | float | int) -> Self:
-        # Uniform scaling commutes: expm(A + log(s) I) = s * expm(A), so add
-        # log(s) to the diagonal elements A00, A11, A22 (tril indices 0, 2, 5).
-        log_scale = jnp.log(jnp.asarray(other))[..., None]
+        # Uniform scaling commutes: expm(B + log(s) I) = s * expm(B) for B = A / cf,
+        # so add cf * log(s) to A's diagonal elements (tril indices 0, 2, 5).
+        log_scale = self.cell_factor * jnp.log(jnp.asarray(other))
         diagonal = jnp.array([1.0, 0.0, 1.0, 0.0, 0.0, 1.0])
-        return type(self)(self.tril + log_scale * diagonal)
+        return type(self)(self.tril + log_scale * diagonal, self.cell_factor)
 
 
 @dataclass
-class FrechetFrame(BaseFrame, Sliceable):
-    """Triclinic [Frame][kups.core.cell.Frame] parameterised as a
-    matrix-exponential deformation of a fixed reference frame, after ASE's
-    ``FrechetCellFilter``.
+class MatrixLogFrame(BaseFrame, Sliceable):
+    """Full-3×3 matrix-log [Frame][kups.core.cell.Frame]: ``vectors = expm(A / cf)``.
 
-    ``vectors`` is the reference ``base`` right-multiplied by
-    ``expm(A / cell_factor)`` for a lower-triangular ``A`` (its 6 stored
-    elements). Right-multiplication deforms Cartesian space, so ``vectors`` stays
-    lower-triangular and atoms ride the cell at fixed fractional coordinates. The
-    map is unconstrained -- any ``A`` gives a positive-volume basis -- so cell
-    relaxation in ``A`` cannot collapse or invert the cell. ``vectors`` is
-    nonlinear in the parameters, so like
-    [LogTriclinicFrame][kups.core.cell.LogTriclinicFrame] the gradient maps use
-    the general inverse-Jacobian path on [BaseFrame][kups.core.cell.BaseFrame].
+    The ``GENERAL`` sibling of [LogTriclinicFrame][kups.core.cell.LogTriclinicFrame]:
+    stores a full ``(..., 3, 3)`` generator ``A`` and exponentiates the *whole*
+    matrix (not just a lower-triangular block), so ``vectors`` can be a rotated /
+    sheared cell. The matrix exponential is the principal one; its vjp is the
+    ``expm_frechet`` adjoint, so the inherited
+    [`parameter_gradient`][kups.core.cell.Frame.parameter_gradient] /
+    [`vectors_gradient`][kups.core.cell.Frame.vectors_gradient] are exact with no
+    custom rule.
+
+    Used as both the base and the deformation of a
+    [DeformedFrame][kups.core.cell.DeformedFrame] (build with
+    [from_frame][kups.core.cell.DeformedFrame.from_frame] passing
+    ``deformation=MatrixLogFrame``) to express the full-``3x3`` Frechet basis: every
+    leaf is ``(..., 3, 3)``, so a per-system
+    [Batched][kups.core.data.batched.Batched] slice yields all-``(3, 3)`` leaves
+    that share a leading axis (a ``(6,)`` tril base would fail).
 
     Attributes:
-        tril: Lower-triangular elements ``[A00, A10, A11, A20, A21, A22]`` of
-            ``A``, shape ``(..., 6)``.
-        base: Reference frame; ``A = 0`` reproduces it. Held fixed
-            (stop-gradient) so only ``A`` is optimised.
-        cell_factor: Static stiffening factor (ASE's ``exp_cell_factor``,
-            typically the atom count) scaling the cell gradient by
-            ``1 / cell_factor`` to balance it against the per-atom forces.
+        log_matrix: Generator ``A``, shape ``(..., 3, 3)``.
+        cell_factor: Stiffening factor (ASE's ``exp_cell_factor``) so that
+            ``vectors = expm(A / cell_factor)``. A stop-gradient leaf broadcast to
+            ``log_matrix``'s shape (equal per slot) so it shares the leading axis;
+            read the per-system value through
+            [`factor`][kups.core.cell.MatrixLogFrame.factor].
     """
 
-    tril: Array
-    base: Frame
-    cell_factor: float = field(default=1.0, static=True)
+    log_matrix: Array
+    cell_factor: Array
 
     @classmethod
-    def from_frame(cls, frame: Frame, *, cell_factor: float = 1.0) -> Self:
-        return cls(
-            jnp.zeros(frame.vectors.shape[:-2] + (6,), frame.vectors.dtype),
-            frame,
-            cell_factor,
+    @override
+    def from_matrix(cls, vecs: Array, *, cell_factor: float | Array = 1.0) -> Self:
+        """Construct from an arbitrary basis matrix via the general (eig-based)
+        [logm][kups.core.utils.math.logm], shape ``(..., 3, 3)``.
+
+        For an *arbitrary* matrix; inaccurate for repeated eigenvalues (defective
+        matrices). Use [from_lower_triangular][kups.core.cell.MatrixLogFrame.from_lower_triangular]
+        for the reference cell, whose diagonal can repeat.
+        """
+        vecs = jnp.asarray(vecs)
+        log_matrix = logm(vecs).real
+        cf = _broadcast_cell_factor(cell_factor, log_matrix)
+        return cls(log_matrix * cf, cf)
+
+    @classmethod
+    def from_lower_triangular(
+        cls, vecs: Array, *, cell_factor: float | Array = 1.0
+    ) -> Self:
+        """Construct from a lower-triangular basis matrix (positive diagonal) via the
+        exact [triangular_3x3_logm][kups.core.utils.math.triangular_3x3_logm].
+
+        The closed-form triangular log is exact even for repeated diagonal entries
+        (cubic / tetragonal cells), unlike the eig-based
+        [from_matrix][kups.core.cell.MatrixLogFrame.from_matrix].
+        """
+        vecs = jnp.asarray(vecs)
+        log_matrix = triangular_3x3_logm(vecs)
+        cf = _broadcast_cell_factor(cell_factor, log_matrix)
+        return cls(log_matrix * cf, cf)
+
+    @property
+    @override
+    def vectors(self) -> Array:
+        # fixed preconditioner, never optimised
+        cf = jax.lax.stop_gradient(self.cell_factor)
+        fn = jax.scipy.linalg.expm
+        for _ in range(self.log_matrix.ndim - 2):
+            fn = jax.vmap(fn)
+        return fn(self.log_matrix / cf)
+
+    @override
+    def tile(self, multiplicities: tuple[int, int, int]) -> Self:
+        m = jnp.asarray(multiplicities)
+        return type(self).from_matrix(
+            self.vectors * m[:, None], cell_factor=self.cell_factor
         )
+
+    @override
+    def __mul__(self, other: Array | float | int) -> Self:
+        return type(self).from_matrix(
+            self.vectors * jnp.asarray(other), cell_factor=self.cell_factor
+        )
+
+
+@dataclass
+class DeformedFrame(BaseFrame, Sliceable):
+    """[Frame][kups.core.cell.Frame] parameterised as a differentiable deformation
+    of a fixed reference frame: ``vectors = base @ deformation``.
+
+    ``base`` is held fixed (stop-gradient); only ``deformation``'s parameters are
+    optimised. Right-multiplication deforms Cartesian space, so ``vectors`` stays
+    lower-triangular and atoms at fixed fractional coordinates ride the cell. The
+    deformation frame chooses the parameterisation: a
+    [LogTriclinicFrame][kups.core.cell.LogTriclinicFrame] gives the unconstrained
+    matrix-exponential map of ASE's ``FrechetCellFilter`` (build with
+    [from_frame][kups.core.cell.DeformedFrame.from_frame]); a
+    [TriclinicFrame][kups.core.cell.TriclinicFrame] gives the linear deformation
+    gradient of ASE's ``UnitCellFilter``. ``vectors`` is generally nonlinear in the
+    parameters, so the gradient maps use the general inverse-Jacobian path on
+    [BaseFrame][kups.core.cell.BaseFrame].
+
+    Attributes:
+        base: Reference frame, held fixed (stop-gradient); the identity
+            deformation reproduces it.
+        deformation: Differentiable deformation gradient (the optimised frame).
+    """
+
+    base: Frame
+    deformation: Frame
+
+    @classmethod
+    def from_frame(
+        cls,
+        frame: Frame,
+        *,
+        cell_factor: float | Array = 1.0,
+        deformation: type[LogTriclinicFrame | MatrixLogFrame] = LogTriclinicFrame,
+    ) -> Self:
+        """ASE ``FrechetCellFilter``-style: an exponential-map deformation anchored
+        at ``frame`` (identity deformation, so ``vectors == frame.vectors``).
+
+        ``deformation`` selects the deformation parameterisation:
+        [LogTriclinicFrame][kups.core.cell.LogTriclinicFrame] (default) keeps
+        ``base = frame`` with a lower-triangular ``(6,)`` matrix-log deformation;
+        [MatrixLogFrame][kups.core.cell.MatrixLogFrame] gives a full-``3x3``
+        deformation, re-anchoring ``base`` as a ``MatrixLogFrame`` built from
+        ``frame.vectors`` (via the exact triangular log) so every leaf is
+        ``(..., 3, 3)`` and the resulting frame represents rotated / sheared cells.
+        """
+        eye = jnp.broadcast_to(
+            jnp.eye(3, dtype=frame.vectors.dtype), frame.vectors.shape
+        )
+        deform = deformation.from_matrix(eye, cell_factor=cell_factor)
+        return cls(frame, deform)
 
     @classmethod
     @override
     def from_matrix(cls, vecs: Array) -> Self:
-        base = TriclinicFrame.from_matrix(vecs)
-        return cls(jnp.zeros(base.tril.shape, base.tril.dtype), base)
+        return cls.from_frame(TriclinicFrame.from_matrix(vecs))
+
+    @property
+    @override
+    def matrix(self) -> SquareMatrix:
+        return self.base.matrix.matmul(self.deformation.matrix)
 
     @property
     def _base_vectors(self) -> Array:
@@ -657,24 +846,26 @@ class FrechetFrame(BaseFrame, Sliceable):
 
     @property
     @override
+    def reference_vectors(self) -> Array:
+        return self._base_vectors
+
+    @property
+    @override
     def vectors(self) -> Array:
-        A = triangular_3x3_from_tril(self.tril)
-        exp_A = triangular_3x3_expm(A / self.cell_factor)
-        # Right-multiply: deform Cartesian space (v -> v @ expm(A/cell_factor)), so
-        # atoms at fixed fractional coordinates ride the cell by the same factor.
-        return self._base_vectors @ exp_A
+        # Right-multiply: deform Cartesian space (v -> v @ deformation), so atoms at
+        # fixed fractional coordinates ride the cell.
+        return self._base_vectors @ self.deformation.vectors
 
     @override
     def tile(self, multiplicities: tuple[int, int, int]) -> Self:
-        # Per-axis row scaling acts on the left of ``vectors`` and has no closed
-        # form in ``A`` (the right factor), so apply it to the reference base.
-        return type(self)(self.tril, self.base.tile(multiplicities), self.cell_factor)
+        # Per-axis row scaling acts on the left of ``vectors`` with no closed form
+        # in the right deformation factor, so apply it to the reference base.
+        return type(self)(self.base.tile(multiplicities), self.deformation)
 
     @override
     def __mul__(self, other: Array | float | int) -> Self:
-        # Uniform scaling commutes with the right factor: ``s * (base @ expm) ==
-        # (s * base) @ expm``, so scale the base and leave ``A`` untouched.
-        return type(self)(self.tril, self.base * other, self.cell_factor)
+        # Uniform scaling commutes with the right factor: scale the base.
+        return type(self)(self.base * other, self.deformation)
 
 
 @dataclass
@@ -705,6 +896,11 @@ class OrthogonalFrame(LinearFrame, Sliceable):
         """
         vecs = jnp.asarray(vecs)
         return cls(jnp.diagonal(vecs, axis1=-2, axis2=-1))
+
+    @property
+    @override
+    def matrix(self) -> SquareMatrix:
+        return DiagonalSquareMatrix(self.vectors)
 
     @property
     @override
@@ -753,13 +949,13 @@ class MaterializedFrame(Sliceable):
     of the inverse or determinant) or when the arrays need to cross a
     JIT boundary independently of the frame's original parametrisation.
 
-    The stored matrices are assumed to follow the lower-triangular
-    convention shared by every other Frame implementation; coordinate
-    transforms use [triangular_3x3_matmul][kups.core.utils.math.triangular_3x3_matmul]
-    accordingly. Manually constructing this frame with non-triangular
-    vectors violates the convention.
+    Coordinate transforms dispatch on the stored
+    [`structure`][kups.core.cell.MaterializedFrame.structure] (default
+    ``GENERAL``, so manually-constructed frames with arbitrary vectors are
+    correct); [`materialize`][kups.core.cell.Frame.materialize] propagates the
+    source frame's structure so triangular / diagonal sources keep the fast path.
 
-    All three fields are pytree leaves and must share a leading batch
+    The three array fields are pytree leaves and must share a leading batch
     dim ``B`` to satisfy the [Sliceable][kups.core.data.Sliceable]
     contract — unbatched single-frame inputs must be wrapped with an
     explicit ``[None]`` axis before being passed in.
@@ -768,17 +964,37 @@ class MaterializedFrame(Sliceable):
         vectors: Basis matrix, shape ``(B, 3, 3)``.
         inverse_vectors: Matrix inverse of ``vectors``, shape ``(B, 3, 3)``.
         volume: Absolute determinant of ``vectors``, shape ``(B,)``.
+        structure: Static structure flag dispatching the coordinate transforms.
     """
 
-    vectors: Array
-    inverse_vectors: Array
+    matrix: SquareMatrix
+    inverse_matrix: SquareMatrix
     volume: Array
 
+    @property
+    def vectors(self) -> Array:
+        return self.matrix.array
+
+    @property
+    def inverse_vectors(self) -> Array:
+        return self.inverse_matrix.array
+
     @classmethod
-    def from_matrix(cls, vecs: Array) -> Self:
-        vecs = jnp.asarray(vecs)
-        det, inv = triangular_3x3_det_and_inverse(vecs)
-        return cls(vectors=vecs, inverse_vectors=inv, volume=jnp.abs(det))
+    def from_matrix(
+        cls,
+        vecs: Array,
+        *,
+        structure: Callable[[Array], SquareMatrix] = GeneralSquareMatrix,
+    ) -> Self:
+        matrix = structure(jnp.asarray(vecs))
+        det, inv = matrix.det(), matrix.inverse()
+        return cls(matrix, inv, jnp.abs(det))
+
+    @property
+    def reference_vectors(self) -> Array:
+        return jnp.broadcast_to(
+            jnp.eye(3, dtype=self.vectors.dtype), self.vectors.shape
+        )
 
     @property
     def perpendicular_lengths(self) -> Array:
@@ -790,24 +1006,25 @@ class MaterializedFrame(Sliceable):
         return jnp.stack([Lx, Ly, Lz], axis=-1)
 
     def to_fractional(self, r: Array) -> Array:
-        return triangular_3x3_matmul(self.inverse_vectors, r)
+        return self.inverse_matrix.matmul(r)
 
     def to_real(self, r_frac: Array) -> Array:
-        return triangular_3x3_matmul(self.vectors, r_frac)
+        return self.matrix.matmul(r_frac)
 
     def tile(self, multiplicities: tuple[int, int, int]) -> Self:
         m = jnp.asarray(multiplicities)
         return type(self)(
-            vectors=self.vectors * m[:, None],
-            inverse_vectors=self.inverse_vectors / m[None, :],
+            matrix=self.matrix.scale(m[:, None]),
+            inverse_matrix=self.inverse_matrix.scale(1 / m[None, :]),
             volume=self.volume * jnp.prod(m),
         )
 
     def __mul__(self, other: Array | float | int) -> Self:
         scale = jnp.asarray(other)
+        factor = scale[..., None, None]
         return type(self)(
-            vectors=self.vectors * scale[..., None, None],
-            inverse_vectors=self.inverse_vectors / scale[..., None, None],
+            matrix=self.matrix.scale(factor),
+            inverse_matrix=self.inverse_matrix.scale(1 / factor),
             volume=self.volume * scale**3,
         )
 

--- a/src/kups/core/data/batched.py
+++ b/src/kups/core/data/batched.py
@@ -7,11 +7,13 @@ import jax
 import numpy as np
 
 from kups.core.lens import BoundLens, bind
+from kups.core.utils.jax import skip_post_init_if_disabled
 
 
 class Batched:
     """Mixin that validates consistent leading batch dimension across pytree leaves."""
 
+    @skip_post_init_if_disabled
     def __post_init__(self) -> None:
         """Validate that all array leaves share the same leading dimension.
 

--- a/src/kups/core/neighborlist/edges.py
+++ b/src/kups/core/neighborlist/edges.py
@@ -25,7 +25,6 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass
-from kups.core.utils.math import triangular_3x3_matmul
 
 
 @dataclass
@@ -115,9 +114,9 @@ class Edges[Degree: int](Sliceable):
         Returns:
             Array of shape `(n_edges, Degree-1, 3)` containing absolute shift vectors.
         """
-        lattice = systems.map_data(lambda x: x.cell.vectors)
-        vecs = lattice[particles[self.indices[:, 0]].system]
-        return triangular_3x3_matmul(vecs[:, None], self.shifts)
+        lattice = systems.map_data(lambda x: x.cell.materialize())
+        cells = lattice[particles[self.indices[:, 0]].system][:, None]
+        return cells.frame.to_real(self.shifts)
 
     @property
     def degree(self) -> int:

--- a/src/kups/core/neighborlist/parameters.py
+++ b/src/kups/core/neighborlist/parameters.py
@@ -20,7 +20,7 @@ from kups.core.data import Table
 from kups.core.neighborlist.common import candidate_image_counts, num_cells
 from kups.core.neighborlist.types import NeighborListSystems
 from kups.core.typing import SystemId
-from kups.core.utils.jax import dataclass, field, no_jax_tracing
+from kups.core.utils.jax import dataclass, field, no_jax_tracing, no_post_init
 from kups.core.utils.math import next_higher_power
 
 
@@ -110,20 +110,21 @@ class UniversalNeighborlistParameters:
 
         sys = Table.join(systems, particles_per_system, cutoffs)
         total_candidates = total_image_candidates = total_edges = max_cells = 0
-        for _, (s, n_p, c) in sys:
-            n_bins = num_cells(s, c).prod()
-            candidates = min(n_p / n_bins * (3**3), n_p)
-            # A cutoff reaching past perp/2 replicates each candidate once per
-            # periodic image (product of per-axis image counts). Summing per
-            # system keeps the estimate tight for heterogeneous cutoffs instead
-            # of assuming every system replicates at the maximum rate.
-            images = candidate_image_counts(s.cell, c).prod()
-            total_candidates += candidates
-            total_image_candidates += _next_power(candidates) * images
-            total_edges += _estimate_avg_num_edges(
-                n_p, s.cell.volume, c, base, multiplier
-            )
-            max_cells = max(n_bins, max_cells)
+        with no_post_init():
+            for _, (s, n_p, c) in sys:
+                n_bins = num_cells(s, c).prod()
+                candidates = min(n_p / n_bins * (3**3), n_p)
+                # A cutoff reaching past perp/2 replicates each candidate once per
+                # periodic image (product of per-axis image counts). Summing per
+                # system keeps the estimate tight for heterogeneous cutoffs instead
+                # of assuming every system replicates at the maximum rate.
+                images = candidate_image_counts(s.cell, c).prod()
+                total_candidates += candidates
+                total_image_candidates += _next_power(candidates) * images
+                total_edges += _estimate_avg_num_edges(
+                    n_p, s.cell.volume, c, base, multiplier
+                )
+                max_cells = max(n_bins, max_cells)
 
         return UniversalNeighborlistParameters(
             avg_edges=int(total_edges // sys.size),

--- a/src/kups/core/utils/math.py
+++ b/src/kups/core/utils/math.py
@@ -242,6 +242,7 @@ def _ddexp2(x: Array, y: Array, z: Array) -> Array:
     return jnp.where(diff == 0.0, confluent, generic)
 
 
+@jit(static_argnames=("lower",))
 def triangular_3x3_expm(A: Array, *, lower: bool = True) -> Array:
     r"""Matrix exponential of triangular 3×3 matrices.
 
@@ -285,6 +286,7 @@ def triangular_3x3_expm(A: Array, *, lower: bool = True) -> Array:
     return out if lower else jnp.swapaxes(out, -1, -2)
 
 
+@jit(static_argnames=("lower",))
 def triangular_3x3_logm(A: Array, *, lower: bool = True) -> Array:
     r"""Principal matrix logarithm of triangular 3×3 matrices with positive diagonal.
 

--- a/test/core/neighborlist/test_edges.py
+++ b/test/core/neighborlist/test_edges.py
@@ -7,10 +7,15 @@ import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
 
-from kups.core.cell import PeriodicCell, TriclinicFrame
+from kups.core.cell import MatrixLogFrame, PeriodicCell, TriclinicFrame
 from kups.core.data.index import Index
 from kups.core.neighborlist.edges import Edges
 from kups.core.typing import ParticleId
+from kups.core.utils.math import (
+    GeneralSquareMatrix,
+    LowerTriangularSquareMatrix,
+    triangular_3x3_matmul,
+)
 
 from ._builders import make_lh, make_systems
 
@@ -101,3 +106,47 @@ class TestEdgeGeometry:
         edges, lh, systems = self._setup([1.0, 0.0, 0.0])
         abs_shifts = edges.absolute_shifts(lh, systems)
         npt.assert_allclose(abs_shifts, jnp.array([[[10.0, 0.0, 0.0]]]))
+
+
+class TestAbsoluteShiftsStructure:
+    """``absolute_shifts`` routes through the cell frame's static structure."""
+
+    def _edges(self, shift: jnp.ndarray) -> Edges:
+        # Two degree-2 edges so the per-edge product is exercised on a non-trivial
+        # ``(n_edges, 1, 3)`` shift array.
+        return Edges(
+            Index((ParticleId(0), ParticleId(1)), jnp.array([[0, 1], [0, 1]])),
+            shift[:, None, :].astype(float),  # (n_edges, 1, 3)
+        )
+
+    def _lh(self):
+        positions = jnp.array([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+        return make_lh(positions, jnp.zeros(2, dtype=int))
+
+    def test_lower_triangular_matches_old_triangular_matmul(self):
+        """Lower-triangular fast path is behaviour-preserving."""
+        lattice = jnp.array([[10.0, 0.0, 0.0], [1.0, 11.0, 0.0], [2.0, 3.0, 12.0]])
+        cell = PeriodicCell(TriclinicFrame.from_matrix(lattice[None]))
+        systems, _ = make_systems(cell, jnp.array([1.0]))
+        assert isinstance(cell.frame.matrix, LowerTriangularSquareMatrix)
+        shift = jnp.array([[1.0, -2.0, 1.0], [0.0, 1.0, 0.0]])
+        edges = self._edges(shift)
+        new = edges.absolute_shifts(self._lh(), systems)
+        vecs = cell.frame.vectors[0]
+        old = triangular_3x3_matmul(vecs[None, None], edges.shifts)
+        npt.assert_allclose(new, old, atol=1e-6)
+
+    def test_general_rotated_cell_matches_dense_reference(self):
+        """General (rotated, non-lower-tri) cell uses the full 3x3 product."""
+        # A general 3x3 lattice with a non-zero upper triangle.
+        lattice = jnp.array([[10.0, 1.5, 0.7], [0.4, 11.0, 2.1], [1.2, 0.9, 12.0]])
+        cell = PeriodicCell(MatrixLogFrame.from_matrix(lattice[None]))
+        systems, _ = make_systems(cell, jnp.array([1.0]))
+        assert type(cell.frame.matrix) is GeneralSquareMatrix
+        shift = jnp.array([[1.0, -2.0, 1.0], [0.0, 1.0, 0.0]])
+        edges = self._edges(shift)
+        new = edges.absolute_shifts(self._lh(), systems)
+        vecs = cell.frame.vectors[0]
+        # Dense RIGHT-side reference: shifts @ vecs per edge/Degree slot.
+        ref = jnp.einsum("ji,nkj->nki", vecs, edges.shifts)
+        npt.assert_allclose(new, ref, atol=1e-5)

--- a/test/core/test_cell.py
+++ b/test/core/test_cell.py
@@ -3,23 +3,26 @@
 
 """Tests for Frame and Cell types."""
 
-from typing import Callable, override
+from typing import Callable, cast, override
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import numpy.testing as npt
 import pytest
+from jax import Array
 from jax.scipy.linalg import expm
 
 from kups.core.cell import (
     BaseFrame,
     Cell,
     CoordinateSpace,
+    DeformedFrame,
     Frame,
-    FrechetFrame,
     LinearFrame,
     LogTriclinicFrame,
     MaterializedFrame,
+    MatrixLogFrame,
     OrthogonalFrame,
     PeriodicCell,
     TriclinicFrame,
@@ -33,6 +36,7 @@ from kups.core.cell import (
 from kups.core.data import Sliceable
 from kups.core.lens import lens
 from kups.core.utils.jax import dataclass
+from kups.core.utils.math import GeneralSquareMatrix, LowerTriangularSquareMatrix
 
 
 class TestTriclinicFrame:
@@ -695,9 +699,10 @@ class _ExpFrame(BaseFrame, Sliceable):
         return type(self)(self.log_lengths + jnp.log(jnp.asarray(other)))
 
 
-# A general lower-triangular matrix; each frame keeps the part it can represent.
-_GRAD_PRIMAL = jnp.array([[2.0, 0.0, 0.0], [0.5, 3.0, 0.0], [0.1, 0.2, 4.0]])
-_CELL_GRAD = jnp.arange(9.0).reshape(3, 3)
+# A batched (1, 3, 3) general lower-triangular matrix; each frame keeps the part
+# it can represent.
+_GRAD_PRIMAL = jnp.array([[2.0, 0.0, 0.0], [0.5, 3.0, 0.0], [0.1, 0.2, 4.0]])[None]
+_CELL_GRAD = jnp.arange(9.0).reshape(1, 3, 3)
 
 # (frame class, projection of a cartesian grad onto the frame's representable DOF)
 # for the linear parameterisations whose Jacobian is orthonormal.
@@ -717,7 +722,7 @@ _LINEAR_FRAME_CLASSES = [
 _GRAD_FRAME_CLASSES = [
     *_LINEAR_FRAME_CLASSES,
     pytest.param(LogTriclinicFrame, id="log_triclinic"),
-    pytest.param(FrechetFrame, id="frechet"),
+    pytest.param(DeformedFrame, id="deformed"),
     pytest.param(_ExpFrame, id="exp_nonlinear"),
 ]
 
@@ -757,7 +762,9 @@ class TestFrameGradients:
     def test_vectors_gradient_batched(
         self, frame_cls: _FrameClass, project: _Projector
     ):
-        frames = frame_cls.from_matrix(jnp.stack([_GRAD_PRIMAL, _GRAD_PRIMAL * 1.5]))
+        frames = frame_cls.from_matrix(
+            jnp.concatenate([_GRAD_PRIMAL, _GRAD_PRIMAL * 1.5])
+        )
         cell_grad = jnp.broadcast_to(_CELL_GRAD, (2, 3, 3))
         param_grad = frames.parameter_gradient(cell_grad)
         out = frames.vectors_gradient(param_grad)
@@ -784,8 +791,8 @@ class TestFrameGradients:
         npt.assert_allclose(g_h - jnp.diag(jnp.diag(g_h)), 0.0, atol=1e-6)
 
     def test_materialized_frame_gradient_identity(self):
-        frame = MaterializedFrame.from_matrix(_GRAD_PRIMAL[None])
-        cell_grad = jnp.tril(_CELL_GRAD)[None]
+        frame = MaterializedFrame.from_matrix(_GRAD_PRIMAL)
+        cell_grad = jnp.tril(_CELL_GRAD)
         param_grad = frame.parameter_gradient(cell_grad)
         npt.assert_allclose(frame.vectors_gradient(param_grad), cell_grad, atol=1e-6)
 
@@ -793,16 +800,17 @@ class TestFrameGradients:
 # One frame per implementation, all batched so ``vectors`` is ``(B, 3, 3)``; each
 # describes its own lower-triangular parallelepiped. The triclinic case carries a
 # second batch entry to exercise batched geometry.
-_M_ORTHO = jnp.diag(jnp.array([2.0, 3.0, 4.0]))
-_M_TRICLINIC = jnp.array([[2.0, 0.0, 0.0], [0.5, 3.0, 0.0], [0.1, 0.2, 4.0]])
+_M_ORTHO = jnp.diag(jnp.array([2.0, 3.0, 4.0]))[None]
+_M_TRICLINIC = jnp.array([[2.0, 0.0, 0.0], [0.5, 3.0, 0.0], [0.1, 0.2, 4.0]])[None]
 _GEOMETRY_FRAMES = [
     pytest.param(
-        TriclinicFrame.from_matrix(jnp.stack([_M_TRICLINIC, _M_ORTHO])), id="triclinic"
+        TriclinicFrame.from_matrix(jnp.concatenate([_M_TRICLINIC, _M_ORTHO])),
+        id="triclinic",
     ),
-    pytest.param(OrthogonalFrame.from_matrix(_M_ORTHO[None]), id="orthogonal"),
-    pytest.param(MaterializedFrame.from_matrix(_M_TRICLINIC[None]), id="materialized"),
-    pytest.param(LogTriclinicFrame.from_matrix(_M_TRICLINIC[None]), id="log_triclinic"),
-    pytest.param(FrechetFrame.from_matrix(_M_TRICLINIC[None]), id="frechet"),
+    pytest.param(OrthogonalFrame.from_matrix(_M_ORTHO), id="orthogonal"),
+    pytest.param(MaterializedFrame.from_matrix(_M_TRICLINIC), id="materialized"),
+    pytest.param(LogTriclinicFrame.from_matrix(_M_TRICLINIC), id="log_triclinic"),
+    pytest.param(DeformedFrame.from_matrix(_M_TRICLINIC), id="deformed"),
 ]
 _frame_case = pytest.mark.parametrize("frame", _GEOMETRY_FRAMES)
 
@@ -884,83 +892,260 @@ class TestLogTriclinicFrame:
 
     def test_vectors_is_expm_of_lower_triangular(self):
         a = jnp.array([[0.7, 0.0, 0.0], [0.5, 1.1, 0.0], [0.1, 0.2, 1.4]])
-        tril = jnp.array([0.7, 0.5, 1.1, 0.1, 0.2, 1.4])
-        frame = LogTriclinicFrame(tril)
-        npt.assert_allclose(frame.vectors, expm(a), atol=1e-6)
+        tril = jnp.array([[0.7, 0.5, 1.1, 0.1, 0.2, 1.4]])
+        frame = LogTriclinicFrame(tril, jnp.ones(1))
+        npt.assert_allclose(frame.vectors, expm(a)[None], atol=1e-6)
         # expm of a lower-triangular matrix stays lower-triangular.
         npt.assert_allclose(jnp.triu(frame.vectors, 1), 0.0, atol=1e-6)
 
     def test_volume_is_exp_trace(self):
-        tril = jnp.array([0.7, 0.5, 1.1, 0.1, 0.2, 1.4])
-        frame = LogTriclinicFrame(tril)
-        trace = tril[0] + tril[2] + tril[5]
+        tril = jnp.array([[0.7, 0.5, 1.1, 0.1, 0.2, 1.4]])
+        frame = LogTriclinicFrame(tril, cell_factor=jnp.ones(1))
+        trace = tril[0, 0] + tril[0, 2] + tril[0, 5]
         npt.assert_allclose(frame.volume, jnp.exp(trace), atol=1e-6)
         # The exponential map always yields a positive-volume cell.
-        assert float(frame.volume) > 0.0
+        assert float(frame.volume[0]) > 0.0
 
     def test_from_matrix_roundtrips_through_expm(self):
         """``from_matrix`` (triangular logm) then ``vectors`` (expm) recovers the
         input lattice. Degenerate-diagonal robustness is covered by
         ``test_math.TestTriangular3x3Logm``."""
         lattice = expm(jnp.array([[0.7, 0, 0], [0.5, 1.1, 0], [0.3, 0.2, 1.4]]))
-        frame = LogTriclinicFrame.from_matrix(lattice)
-        npt.assert_allclose(frame.vectors, lattice, atol=1e-5)
+        frame = LogTriclinicFrame.from_matrix(lattice[None])
+        npt.assert_allclose(frame.vectors, lattice[None], atol=1e-5)
 
     def test_uses_general_nonlinear_gradient_path(self):
         """``vectors`` is nonlinear in the parameters, so the frame is a plain
         ``BaseFrame`` (general inverse-Jacobian), not a ``LinearFrame``."""
-        frame = LogTriclinicFrame.from_matrix(jnp.eye(3) * 2.0)
+        frame = LogTriclinicFrame.from_matrix(jnp.eye(3)[None] * 2.0)
         assert isinstance(frame, BaseFrame)
         assert not isinstance(frame, LinearFrame)
 
-
-class TestFrechetFrame:
-    """Deformation parameterisation: ``vectors == base @ expm(A / cell_factor)``
-    anchored at a fixed reference ``base`` (held stop-gradient, so only ``A`` is
-    optimised)."""
-
-    def test_vectors_is_base_times_expm(self):
+    def test_cell_factor_scales_exponential_map(self):
+        """``cell_factor`` divides ``A`` inside the exponential map."""
         a = jnp.array([[0.7, 0.0, 0.0], [0.5, 1.1, 0.0], [0.1, 0.2, 1.4]])
-        tril = jnp.array([0.7, 0.5, 1.1, 0.1, 0.2, 1.4])
+        tril = jnp.array([[0.7, 0.5, 1.1, 0.1, 0.2, 1.4]])
+        frame = LogTriclinicFrame(tril, jnp.array([4.0]))
+        npt.assert_allclose(frame.vectors, expm(a / 4.0)[None], atol=1e-6)
+
+    def test_from_matrix_cell_factor_roundtrips(self):
+        """``from_matrix(L, cell_factor=k).vectors == L`` regardless of ``k``."""
+        lattice = expm(jnp.array([[0.7, 0, 0], [0.5, 1.1, 0], [0.3, 0.2, 1.4]]))
+        frame = LogTriclinicFrame.from_matrix(lattice[None], cell_factor=4.0)
+        npt.assert_allclose(frame.vectors, lattice[None], atol=1e-5)
+
+
+class TestDeformedFrame:
+    """Deformation parameterisation: ``vectors == base @ deformation`` with the
+    fixed reference ``base`` held stop-gradient, so only the deformation is
+    optimised. With a ``LogTriclinicFrame`` deformation this is ASE's
+    ``FrechetCellFilter``: ``vectors == base @ expm(A / cell_factor)``."""
+
+    def test_vectors_is_base_times_deformation(self):
+        a = jnp.array([[0.7, 0.0, 0.0], [0.5, 1.1, 0.0], [0.1, 0.2, 1.4]])
+        tril = jnp.array([[0.7, 0.5, 1.1, 0.1, 0.2, 1.4]])
         base = TriclinicFrame.from_matrix(_M_TRICLINIC)
-        frame = FrechetFrame(tril, base)
+        frame = DeformedFrame(base, LogTriclinicFrame(tril, jnp.ones(1)))
         # Right-multiplication (Cartesian deformation), matching ASE's
         # FrechetCellFilter; left-multiplication would recombine lattice vectors.
         npt.assert_allclose(frame.vectors, base.vectors @ expm(a), atol=1e-6)
+        npt.assert_allclose(
+            frame.vectors, base.vectors @ frame.deformation.vectors, atol=1e-6
+        )
         # base @ expm(A) of two lower-triangular factors stays lower-triangular.
         npt.assert_allclose(jnp.triu(frame.vectors, 1), 0.0, atol=1e-6)
 
     def test_from_frame_anchors_at_base(self):
-        """``A = 0`` reproduces the reference frame exactly."""
+        """The identity deformation (``A = 0``) reproduces the reference frame."""
         base = TriclinicFrame.from_matrix(_M_TRICLINIC)
-        frame = FrechetFrame.from_frame(base)
-        npt.assert_allclose(frame.tril, 0.0)
+        frame = DeformedFrame.from_frame(base)
+        deformation = cast(LogTriclinicFrame, frame.deformation)
+        npt.assert_allclose(deformation.tril, 0.0, atol=1e-6)
         npt.assert_allclose(frame.vectors, base.vectors, atol=1e-6)
+        npt.assert_allclose(frame.reference_vectors, base.vectors, atol=1e-6)
 
     def test_base_held_fixed_under_gradient(self):
-        """The cartesian→parameter pullback flows entirely into ``A``; the
-        stop-gradient base receives no gradient."""
-        frame = FrechetFrame.from_matrix(_M_TRICLINIC)
+        """The cartesian→parameter pullback flows entirely into the deformation;
+        the stop-gradient base receives no gradient."""
+        frame = DeformedFrame.from_matrix(_M_TRICLINIC)
         grad = frame.parameter_gradient(_CELL_GRAD)
-        assert isinstance(grad, FrechetFrame)
-        assert isinstance(grad.base, TriclinicFrame)
-        npt.assert_allclose(grad.base.tril, 0.0, atol=1e-6)
-        assert bool(jnp.any(grad.tril != 0.0))
+        assert isinstance(grad, DeformedFrame)
+        npt.assert_allclose(grad.base.vectors, 0.0, atol=1e-6)
+        assert bool(jnp.any(cast(LogTriclinicFrame, grad.deformation).tril != 0.0))
 
     def test_cell_factor_stiffens_deformation_and_gradient(self):
         """``cell_factor`` (ASE's exp_cell_factor) scales the deformation to
         ``expm(A / cell_factor)`` and divides the parameter gradient by it."""
         a = jnp.array([[0.3, 0, 0], [0.2, 0.1, 0], [0.05, 0.1, 0.2]])
-        tril = jnp.array([0.3, 0.2, 0.1, 0.05, 0.1, 0.2])
+        tril = jnp.array([[0.3, 0.2, 0.1, 0.05, 0.1, 0.2]])
         base = TriclinicFrame.from_matrix(_M_TRICLINIC)
+        defm4 = cast(
+            LogTriclinicFrame,
+            DeformedFrame.from_frame(base, cell_factor=4.0).deformation,
+        )
+        cf4 = defm4.cell_factor
         npt.assert_allclose(
-            FrechetFrame(tril, base, cell_factor=4.0).vectors,
+            DeformedFrame(base, LogTriclinicFrame(tril, cf4)).vectors,
             base.vectors @ expm(a / 4.0),
             atol=1e-6,
         )
         # At A = 0 the deformation Jacobian is the base Jacobian times
         # 1 / cell_factor, so the parameter gradient scales exactly by it.
-        z = jnp.zeros(6)
-        g1 = FrechetFrame(z, base, cell_factor=1.0).parameter_gradient(_CELL_GRAD).tril
-        g4 = FrechetFrame(z, base, cell_factor=4.0).parameter_gradient(_CELL_GRAD).tril
+        z = jnp.zeros((1, 6))
+        cf1 = cast(
+            LogTriclinicFrame,
+            DeformedFrame.from_frame(base, cell_factor=1.0).deformation,
+        ).cell_factor
+        g1 = cast(
+            LogTriclinicFrame,
+            DeformedFrame(base, LogTriclinicFrame(z, cf1))
+            .parameter_gradient(_CELL_GRAD)
+            .deformation,
+        ).tril
+        g4 = cast(
+            LogTriclinicFrame,
+            DeformedFrame(base, LogTriclinicFrame(z, cf4))
+            .parameter_gradient(_CELL_GRAD)
+            .deformation,
+        ).tril
         npt.assert_allclose(g4, g1 / 4.0, atol=1e-6)
+
+    def test_per_system_cell_factor(self):
+        """A per-system ``cell_factor`` array threads through ``from_frame`` and
+        ``vectors``, deforming each system by its own factor."""
+        a = jnp.array([[0.3, 0, 0], [0.2, 0.1, 0], [0.05, 0.1, 0.2]])
+        tril = jnp.array([0.3, 0.2, 0.1, 0.05, 0.1, 0.2])
+        base = TriclinicFrame.from_matrix(jnp.broadcast_to(_M_TRICLINIC, (3, 3, 3)))
+        cell_factor = jnp.array([1.0, 2.0, 4.0])
+        frame = DeformedFrame.from_frame(base, cell_factor=cell_factor)
+        deformation = cast(LogTriclinicFrame, frame.deformation)
+        # Stored per parameter slot (shares ``tril``'s leading dim); ``factor``
+        # exposes the per-system value.
+        assert deformation.cell_factor.shape == (3, 1)
+        npt.assert_allclose(deformation.tril, 0.0)
+        batched = DeformedFrame(
+            base,
+            LogTriclinicFrame(jnp.broadcast_to(tril, (3, 6)), deformation.cell_factor),
+        )
+        for i, cf in enumerate([1.0, 2.0, 4.0]):
+            npt.assert_allclose(
+                batched.vectors[i], _M_TRICLINIC[0] @ expm(a / cf), atol=1e-6
+            )
+
+    def test_per_system_cell_factor_zero_gradient(self):
+        """``from_frame`` stop-gradients ``cell_factor`` even as a per-system
+        array, so it receives no gradient."""
+        base = TriclinicFrame.from_matrix(jnp.broadcast_to(_M_TRICLINIC, (3, 3, 3)))
+        cell_factor = jnp.array([1.0, 2.0, 4.0])
+
+        def loss(cf: Array) -> Array:
+            built = cast(
+                LogTriclinicFrame,
+                DeformedFrame.from_frame(base, cell_factor=cf).deformation,
+            )
+            frame = DeformedFrame(
+                base, LogTriclinicFrame(jnp.ones((3, 6)) * 0.1, built.cell_factor)
+            )
+            return jnp.sum(frame.vectors)
+
+        grad = jax.grad(loss)(cell_factor)
+        npt.assert_allclose(grad, 0.0)
+
+
+_M_ROTATED = jnp.array([[2.0, 0.3, -0.1], [0.4, 3.0, 0.2], [-0.2, 0.5, 4.0]])[
+    None
+]  # batched (1, 3, 3) full (non-triangular) basis
+
+
+def _frechet(base: Array, deformation: MatrixLogFrame) -> DeformedFrame:
+    """Full-3×3 Frechet basis: ``DeformedFrame(MatrixLog base, MatrixLog deformation)``."""
+    return DeformedFrame(MatrixLogFrame.from_lower_triangular(base), deformation)
+
+
+class TestMatrixLogFrame:
+    """Full-3×3 matrix-log frame and its ``DeformedFrame(MatrixLog, MatrixLog)`` use."""
+
+    @pytest.fixture(autouse=True)
+    def _x64(self):
+        prev = jax.config.read("jax_enable_x64")
+        jax.config.update("jax_enable_x64", True)
+        yield
+        jax.config.update("jax_enable_x64", prev)
+
+    def test_structure_is_general(self):
+        matrix = MatrixLogFrame.from_matrix(_M_ROTATED).matrix
+        assert type(matrix) is GeneralSquareMatrix
+
+    def test_deformed_matrix_log_structure_is_general(self):
+        base = TriclinicFrame.from_matrix(_M_TRICLINIC)
+        frame = DeformedFrame.from_frame(base, deformation=MatrixLogFrame)
+        assert type(frame.matrix) is GeneralSquareMatrix
+
+    def test_deformed_log_triclinic_structure_unchanged(self):
+        base = TriclinicFrame.from_matrix(_M_TRICLINIC)
+        frame = DeformedFrame.from_frame(base)  # default LogTriclinicFrame
+        assert type(frame.matrix) is LowerTriangularSquareMatrix
+
+    def test_vectors_is_expm_of_log(self):
+        from scipy.linalg import expm as scipy_expm
+
+        A = jnp.asarray([[0.05, 0.10, -0.03], [0.02, 0.07, 0.04], [-0.06, 0.01, 0.08]])
+        cf = 2.0
+        frame = MatrixLogFrame(A[None], jnp.asarray([cf]))
+        ref = jnp.asarray(scipy_expm(np.asarray(A) / cf))
+        npt.assert_allclose(frame.vectors, ref[None], atol=1e-10)
+
+    def test_parameter_gradient_matches_expm_frechet_adjoint(self):
+        """The deformation's ``log_matrix`` gradient is the ``expm_frechet`` adjoint."""
+        from itertools import product
+
+        from scipy.linalg import expm_frechet
+
+        A = np.array([[0.05, 0.10, -0.03], [0.02, 0.07, 0.04], [-0.06, 0.01, 0.08]])
+        cell_grad = np.array(
+            [[0.20, -0.07, 0.11], [-0.07, 0.05, 0.15], [0.11, 0.15, -0.20]]
+        )
+        frame = MatrixLogFrame(jnp.asarray(A)[None], jnp.ones(1))
+        grad = frame.parameter_gradient(jnp.asarray(cell_grad)[None])
+        ours = np.asarray(grad.log_matrix[0])
+
+        expected = np.zeros((3, 3))
+        for mu, nu in product(range(3), repeat=2):
+            d = np.zeros((3, 3))
+            d[mu, nu] = 1.0
+            expected[mu, nu] = np.sum(
+                expm_frechet(A, d, compute_expm=False) * cell_grad
+            )
+        npt.assert_allclose(ours, expected, atol=1e-9)
+
+    def test_base_roundtrip_exactness(self):
+        """``DeformedFrame.from_frame(.., MatrixLogFrame)`` at identity deformation
+        reproduces the triclinic reference (exact triangular log of the base)."""
+        ref = TriclinicFrame.from_matrix(_M_TRICLINIC)
+        frame = DeformedFrame.from_frame(
+            ref, cell_factor=8.0, deformation=MatrixLogFrame
+        )
+        npt.assert_allclose(frame.vectors, ref.vectors, atol=1e-12)
+        npt.assert_allclose(frame.reference_vectors, ref.vectors, atol=1e-12)
+
+    def test_batched_safety_table_slice(self):
+        defm = MatrixLogFrame(jnp.zeros((2, 3, 3)), jnp.ones(2))
+        frame = _frechet(jnp.broadcast_to(_M_TRICLINIC, (2, 3, 3)), defm)
+        sliced = frame[0:1]
+        npt.assert_allclose(sliced.vectors, _M_TRICLINIC, atol=1e-10)
+
+    def test_rotated_cell_is_not_lower_triangular(self):
+        A = jnp.asarray([[0.1, 0.2, 0.0], [0.0, 0.1, 0.0], [0.3, 0.0, 0.1]])
+        frame = _frechet(jnp.eye(3)[None], MatrixLogFrame(A[None], jnp.ones(1)))
+        vecs = frame.vectors[0]
+        upper = vecs[0, 1] ** 2 + vecs[0, 2] ** 2 + vecs[1, 2] ** 2
+        assert upper > 1e-6  # genuinely non-triangular
+
+    def test_rotated_cell_inverse_volume_roundtrip(self):
+        A = jnp.asarray([[0.1, 0.2, 0.0], [0.0, 0.1, 0.0], [0.3, 0.0, 0.1]])
+        frame = _frechet(_M_TRICLINIC, MatrixLogFrame(A[None], jnp.ones(1)))
+        vecs = frame.vectors
+        npt.assert_allclose(frame.inverse_vectors @ vecs, jnp.eye(3)[None], atol=1e-10)
+        npt.assert_allclose(frame.volume, jnp.abs(jnp.linalg.det(vecs)), atol=1e-10)
+        r = jnp.array([[0.7, -0.3, 0.4]])
+        npt.assert_allclose(frame.to_real(frame.to_fractional(r)), r, atol=1e-10)


### PR DESCRIPTION
Replaces `FrechetFrame` with a composable `DeformedFrame` + `MatrixLogFrame` design, and adds a `structure` property to the `Frame` protocol so that geometric primitives (inverse, volume, coordinate transforms) dispatch to the appropriate fast path.

**`DeformedFrame`** separates the fixed reference (`base`, stop-gradient) from the differentiable `deformation` frame, rather than hard-coding a lower-triangular `tril` array and a scalar `cell_factor`. The deformation type is now a constructor argument: passing `LogTriclinicFrame` (default) reproduces the previous ASE `FrechetCellFilter` behaviour with a `(6,)` lower-triangular parameterisation; passing `MatrixLogFrame` gives a full `3×3` exponential-map deformation that supports rotated/sheared cells and keeps every leaf `(..., 3, 3)` so per-system batched slicing works uniformly.

**`MatrixLogFrame`** stores a full `3×3` generator `A` and computes `vectors = expm(A / cell_factor)` via `jax.scipy.linalg.expm`. Its VJP is the `expm_frechet` adjoint, so `parameter_gradient` / `vectors_gradient` are exact with no custom rule. Construction from a lower-triangular reference uses the exact `triangular_3x3_logm` to avoid numerical issues with repeated eigenvalues (cubic/tetragonal cells).

**`structure` property** is added to the `Frame` protocol with three values — `LOWER_TRIANGULAR`, `DIAGONAL`, and `GENERAL` — and implemented on every concrete frame. `BaseFrame` uses it to route `inverse_vectors`, `volume`, `to_fractional`, `to_real`, and `materialize` through `structured_det_and_inverse` / `structured_matmul` instead of the previously hard-coded triangular helpers. `MaterializedFrame` stores and propagates the structure flag so materialized frames keep the fast path of their source. `DeformedFrame.structure` is derived from the product of its base and deformation structures via `matmul_structure`.

**`cell_factor` handling** is generalised from a static scalar to a per-system array in both `LogTriclinicFrame` and `MatrixLogFrame`. It is broadcast to the full parameter shape (sharing the leading batch dimension) and stored as a stop-gradient leaf, with a `.factor` property exposing the per-system scalar. `relax_state_from_ase` now computes `cell_factor` as a per-system atom count via `bincount` over system indices rather than a single global count.

**`Edges.absolute_shifts`** is updated to call `cell.materialize().to_real(shifts)` instead of the hard-coded `triangular_3x3_matmul`, so it correctly handles general (non-triangular) cells.