### PR TITLE
feat: Add `UMAInferenceSettings`/`UMATaskName` type aliases and `turbo_f64` preset

### DIFF
--- a/src/kups/application/simulations/relax_torch.py
+++ b/src/kups/application/simulations/relax_torch.py
@@ -39,6 +39,8 @@ from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass
 from kups.potential.mliap.torch import (
     TorchMliap,
+    UMAInferenceSettings,
+    UMATaskName,
     load_mace,
     load_uma,
     make_torch_mliap_from_state,
@@ -71,8 +73,8 @@ class UMAModelConfig(BaseModel):
     backend: Literal["uma"] = "uma"
     model_path: str | Path
     device: Literal["cpu", "cuda"] = "cuda"
-    task_name: Literal["omat", "omol", "oc20", "odac", "omc"] = "omat"
-    inference_settings: Literal["default", "turbo"] = "default"
+    task_name: UMATaskName = "omat"
+    inference_settings: UMAInferenceSettings = "default"
 
 
 type ModelConfig = Annotated[

--- a/src/kups/potential/mliap/torch/__init__.py
+++ b/src/kups/potential/mliap/torch/__init__.py
@@ -34,7 +34,12 @@ from kups.potential.mliap.torch.interface import (
     torch_mliap_model_fn,
 )
 from kups.potential.mliap.torch.mace import MACEModule, load_mace
-from kups.potential.mliap.torch.uma import UMAModule, load_uma
+from kups.potential.mliap.torch.uma import (
+    UMAInferenceSettings,
+    UMAModule,
+    UMATaskName,
+    load_uma,
+)
 
 __all__ = [
     "AtomGraphInput",
@@ -43,7 +48,9 @@ __all__ = [
     "MACEModule",
     "TorchMliap",
     "TorchMliapForward",
+    "UMAInferenceSettings",
     "UMAModule",
+    "UMATaskName",
     "lattice_gradient_from_virial",
     "load_mace",
     "load_uma",

--- a/src/kups/potential/mliap/torch/uma.py
+++ b/src/kups/potential/mliap/torch/uma.py
@@ -41,10 +41,11 @@ from kups.potential.mliap.torch.interface import (
     lattice_gradient_from_virial,
 )
 
-__all__ = ["UMAModule", "load_uma"]
+__all__ = ["UMAInferenceSettings", "UMAModule", "UMATaskName", "load_uma"]
 
 
 type UMATaskName = Literal["omat", "omol", "oc20", "odac", "omc"]
+type UMAInferenceSettings = Literal["default", "turbo", "turbo_f64"]
 
 
 class UMAModule(torch.nn.Module):
@@ -260,7 +261,7 @@ def load_uma(
     task_name: UMATaskName | str = "omat",
     compute_cell_gradients: bool = False,
     cutoff: float = 6.0,
-    inference_settings: str = "default",
+    inference_settings: UMAInferenceSettings = "default",
 ) -> TorchMliap:
     """Load a Meta FAIR Chemistry UMA checkpoint into a ``TorchMliap``.
 
@@ -273,9 +274,9 @@ def load_uma(
         compute_cell_gradients: Whether to also return cell gradients
             (stress). See ``UMAModule`` for convention caveats.
         cutoff: Cutoff radius [Å]. UMA-s-1.2 defaults to 6.0.
-        inference_settings: Forwarded to
-            ``fairchem.core.units.mlip_unit.load_predict_unit`` —
-            ``"default"`` or ``"turbo"``.
+        inference_settings: ``"default"`` or ``"turbo"`` (resolved by
+            fairchem's ``guess_inference_settings``), or ``"turbo_f64"`` for
+            a compiled, MOLE-merged float64 preset.
 
     Returns:
         ``TorchMliap`` ready to be wired into the kUPS interface.
@@ -300,6 +301,7 @@ def load_uma(
             load_predict_unit,
         )
         from fairchem.core.units.mlip_unit.api.inference import (  # pyright: ignore[reportMissingImports]
+            InferenceSettings,
             guess_inference_settings,
         )
     except ImportError as exc:
@@ -314,7 +316,22 @@ def load_uma(
     # reason to recompute it inside the model. UMA's internal
     # ``radius_graph_pbc_v2`` also has compile/SymInt issues that go away
     # entirely when ``otf_graph=False``.
-    settings = guess_inference_settings(inference_settings)
+    # Custom presets beyond fairchem's named "default"/"turbo"; extend to add more.
+    custom_settings = {
+        "turbo_f64": InferenceSettings(
+            base_precision_dtype=torch.float64,
+            tf32=False,
+            activation_checkpointing=False,
+            merge_mole=True,
+            compile=True,
+            external_graph_gen=False,
+            internal_graph_gen_version=2,
+            execution_mode="general",
+        ),
+    }
+    settings = custom_settings.get(inference_settings) or guess_inference_settings(
+        inference_settings
+    )
     settings = replace(settings, external_graph_gen=True)
 
     predict_unit = load_predict_unit(


### PR DESCRIPTION
## Add `turbo_f64` inference preset and export `UMATaskName`/`UMAInferenceSettings` types

Introduces a new `"turbo_f64"` inference setting for UMA models — a compiled, MOLE-merged float64 preset built directly from `InferenceSettings` rather than delegating to fairchem's `guess_inference_settings`. This complements the existing `"default"` and `"turbo"` options.

The `UMATaskName` and `UMAInferenceSettings` type aliases are now exported from the `torch` subpackage and used directly in `UMAModelConfig`, replacing the previously duplicated inline `Literal` definitions. This ensures the config and the loader stay in sync automatically as valid values evolve.