### PR TITLE
ci: Restrict push triggers to `main` branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Restricts the CI workflow's `push` trigger to only run on the `main` branch, preventing CI from running on every pushed branch while still running on all pull requests.