### PR TITLE
refactor: Move make from state functions to application

### DIFF
--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -90,7 +90,7 @@ potential = make_lennard_jones_from_state(
 propagator = make_md_propagator(state_lens, config.md.integrator, potential)
 ```
 
-[make_lennard_jones_from_state][kups.potential.classical.lennard_jones.make_lennard_jones_from_state] reads particles, systems, and LJ parameters through the state lens. [make_md_propagator][kups.application.md.simulation.make_md_propagator] composes a [PotentialAsPropagator][kups.core.potential.PotentialAsPropagator], the integrator's momentum and position steps, a step counter, and a [ResetOnErrorPropagator][kups.core.propagator.ResetOnErrorPropagator] inside one [SequentialPropagator][kups.core.propagator.SequentialPropagator].
+[make_lennard_jones_from_state][kups.application.potential.classical.lennard_jones.make_lennard_jones_from_state] reads particles, systems, and LJ parameters through the state lens. [make_md_propagator][kups.application.md.simulation.make_md_propagator] composes a [PotentialAsPropagator][kups.core.potential.PotentialAsPropagator], the integrator's momentum and position steps, a step counter, and a [ResetOnErrorPropagator][kups.core.propagator.ResetOnErrorPropagator] inside one [SequentialPropagator][kups.core.propagator.SequentialPropagator].
 
 **Running.** The loop lives on the host side.
 

--- a/docs/notebooks/potentials.ipynb
+++ b/docs/notebooks/potentials.ipynb
@@ -24,6 +24,9 @@
     "import jax.numpy as jnp\n",
     "from jax import Array\n",
     "\n",
+    "from kups.application.potential.classical.lennard_jones import (\n",
+    "    make_lennard_jones_from_state,\n",
+    ")\n",
     "from kups.core.cell import PeriodicCell, TriclinicFrame\n",
     "from kups.core.data import Index, Table\n",
     "from kups.core.data.wrappers import WithCache, WithIndices\n",
@@ -37,10 +40,7 @@
     "from kups.core.potential import EMPTY, PotentialOut, sum_potentials\n",
     "from kups.core.typing import ExclusionId, InclusionId, Label, ParticleId, SystemId\n",
     "from kups.core.utils.jax import dataclass\n",
-    "from kups.potential.classical.lennard_jones import (\n",
-    "    LennardJonesParameters,\n",
-    "    make_lennard_jones_from_state,\n",
-    ")"
+    "from kups.potential.classical.lennard_jones import LennardJonesParameters"
    ]
   },
   {
@@ -179,7 +179,7 @@
    "source": [
     "## Evaluating the Potential\n",
     "\n",
-    "[make_lennard_jones_from_state][kups.potential.classical.lennard_jones.make_lennard_jones_from_state] wires together the graph constructor, energy function, and autodiff gradient machinery from a single [Lens][kups.core.lens.Lens] into the state. It is a shorthand that assumes the state follows the naming conventions."
+    "[make_lennard_jones_from_state][kups.application.potential.classical.lennard_jones.make_lennard_jones_from_state] wires together the graph constructor, energy function, and autodiff gradient machinery from a single [Lens][kups.core.lens.Lens] into the state. It is a shorthand that assumes the state follows the naming conventions."
    ]
   },
   {
@@ -573,10 +573,11 @@
    "source": [
     "## Tojax: Machine-Learned Force Fields\n",
     "\n",
-    "Machine-learned potentials (MACE, UMA, ORB) are integrated via [Tojax](https://github.com/cusp-ai-oss/tojax). The model is exported from PyTorch to JAX (see the [Tojax MLFF examples](https://github.com/cusp-ai-oss/tojax/tree/main/examples/mlff) for how to convert each model), then wrapped as a standard <em>k</em>UPS [Potential][kups.core.potential.Potential] via [TojaxedMliap][kups.potential.mliap.tojax.TojaxedMliap] and [make_tojaxed_from_state][kups.potential.mliap.tojax.make_tojaxed_from_state]:\n",
+    "Machine-learned potentials (MACE, UMA, ORB) are integrated via [Tojax](https://github.com/cusp-ai-oss/tojax). The model is exported from PyTorch to JAX (see the [Tojax MLFF examples](https://github.com/cusp-ai-oss/tojax/tree/main/examples/mlff) for how to convert each model), then wrapped as a standard <em>k</em>UPS [Potential][kups.core.potential.Potential] via [TojaxedMliap][kups.potential.mliap.tojax.TojaxedMliap] and [make_tojaxed_from_state][kups.application.potential.mliap.tojax.make_tojaxed_from_state]:\n",
     "\n",
     "```python\n",
-    "from kups.potential.mliap.tojax import TojaxedMliap, make_tojaxed_from_state\n",
+    "from kups.potential.mliap.tojax import TojaxedMliap\n",
+    "from kups.application.potential.mliap.tojax import make_tojaxed_from_state\n",
     "\n",
     "model = TojaxedMliap.from_zip_file(\"model.zip\")\n",
     "potential = make_tojaxed_from_state(\n",

--- a/src/kups/application/md/integrators.py
+++ b/src/kups/application/md/integrators.py
@@ -1,0 +1,259 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructor for MD integration steps.
+
+Dispatches on an integrator key to the state-agnostic step factories in
+[kups.md.integrators][], binding particle and system views from a concrete
+simulation state and wrapping them with a periodic-boundary-aware flow.
+
+Integrator parameters may live on the state (``systems.data.integrator_params``)
+or be passed directly via ``parameters=``; in the latter case they are overlaid
+onto the systems view with a constant lens and the state need not carry them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, overload, override
+
+from kups.core.cell import Periodic3D, require_periodic_3d_triclinic
+from kups.core.data import Table
+from kups.core.lens import BaseLens, Lens, bind
+from kups.core.propagator import Propagator
+from kups.core.typing import HasCell, IsState, SystemId
+from kups.core.utils.jax import dataclass, field
+from kups.md.integrators import (
+    Integrator,
+    IsBAOABLangevinParams,
+    IsBAOABNPTLangevinParams,
+    IsBAOABNPTLangevinSystem,
+    IsBAOABNPTLangevinSystemBase,
+    IsCSVRNPTParams,
+    IsCSVRParams,
+    IsMDSystem,
+    IsMDSystemNPT,
+    IsMDSystemNPTBase,
+    IsVerletParams,
+    WrapFlow,
+    _MDParticleData,
+    euclidean_flow,
+    make_baoab_langevin_step,
+    make_baoab_npt_langevin_step,
+    make_csvr_npt_step,
+    make_csvr_step,
+    make_velocity_verlet_step,
+)
+
+
+@dataclass
+class _IntegratorParamsOverlay(BaseLens[Any, Any]):
+    """Systems lens that overlays a constant ``integrator_params`` on read.
+
+    ``get`` returns the underlying systems table with its ``integrator_params``
+    replaced by the constant; ``set`` delegates to the base lens so dynamic
+    system fields (cell, cell momentum, …) are written back to the state.
+    """
+
+    base: Lens[Any, Any] = field(static=True)
+    parameters: Any
+
+    @override
+    def get(self, state: Any) -> Any:
+        return bind(self.base.get(state), lambda t: t.data.integrator_params).apply(
+            lambda _: self.parameters
+        )
+
+    @override
+    def set(self, state: Any, value: Any) -> Any:
+        return self.base.set(state, value)
+
+
+def require_baoab_npt_langevin_state(
+    systems: Table[SystemId, IsBAOABNPTLangevinSystem],
+) -> None:
+    """Runtime check that the system table satisfies the BAOAB NPT Langevin shape.
+
+    Call this once on the initial state (outside of jit) before constructing
+    the integrator. Verifies that the cell is a 3D-periodic
+    :class:`TriclinicFrame` and that the integrator-params is a
+    :class:`BAOABNPTLangevinParams`-shaped bundle.
+    """
+    require_periodic_3d_triclinic(systems.data.cell)
+
+
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsVerletParams]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["verlet"],
+    *,
+    parameters: None = None,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsBAOABLangevinParams]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["baoab_langevin"],
+    *,
+    parameters: None = None,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsCSVRParams]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["csvr"],
+    *,
+    parameters: None = None,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystemNPT]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["csvr_npt"],
+    *,
+    parameters: None = None,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsBAOABNPTLangevinSystem]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["baoab_npt_langevin"],
+    *,
+    parameters: None = None,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, HasCell[Periodic3D]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["verlet"],
+    *,
+    parameters: IsVerletParams,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, HasCell[Periodic3D]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["baoab_langevin"],
+    *,
+    parameters: IsBAOABLangevinParams,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, HasCell[Periodic3D]]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["csvr"],
+    *,
+    parameters: IsCSVRParams,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsMDSystemNPTBase]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["csvr_npt"],
+    *,
+    parameters: IsCSVRNPTParams,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, IsState[_MDParticleData, IsBAOABNPTLangevinSystemBase]],
+    derivative_computation: Propagator[State],
+    integrator: Literal["baoab_npt_langevin"],
+    *,
+    parameters: IsBAOABNPTLangevinParams,
+) -> Propagator[State]: ...
+@overload
+def make_md_step_from_state[State](
+    state: Lens[State, Any],
+    derivative_computation: Propagator[State],
+    integrator: Integrator,
+    *,
+    parameters: Any = None,
+) -> Propagator[State]: ...
+
+
+def make_md_step_from_state[State](
+    state: Lens[State, Any],
+    derivative_computation: Propagator[State],
+    integrator: Integrator,
+    *,
+    parameters: Any = None,
+) -> Propagator[State]:
+    """Build a single MD integration step from a typed state.
+
+    Constructs the appropriate integrator propagator by extracting views for
+    particles and systems from ``state`` and wrapping them with a
+    [WrapFlow][kups.md.integrators.WrapFlow]
+    for periodic-boundary-condition-aware distance computations.
+
+    Supported integrators:
+
+    - ``"verlet"`` — [Velocity Verlet][kups.md.integrators.make_velocity_verlet_step]
+      (NVE ensemble, no thermostat). Requires ``integrator_params: IsVerletParams``.
+    - ``"baoab_langevin"`` — [BAOAB Langevin][kups.md.integrators.make_baoab_langevin_step]
+      (NVT via Langevin friction/noise). Requires
+      ``integrator_params: IsBAOABLangevinParams``.
+    - ``"csvr"`` — [CSVR][kups.md.integrators.make_csvr_step]
+      (NVT via canonical-sampling velocity rescaling, constant volume). Requires
+      ``integrator_params: IsCSVRParams``.
+    - ``"csvr_npt"`` — [CSVR-NPT][kups.md.integrators.make_csvr_npt_step]
+      (NPT via CSVR thermostat with barostat). Requires
+      ``integrator_params: IsCSVRNPTParams`` and a ``cell_gradients`` leaf on each system.
+    - ``"baoab_npt_langevin"`` — [BAOAB NPT Langevin][kups.md.integrators.make_baoab_npt_langevin_step]
+      (Gao–Fang–Wang JCP 2016 fully-flexible-cell NPT). Requires
+      ``integrator_params: IsBAOABNPTLangevinParams`` plus ``cell_momentum``
+      and ``cell_gradients`` leaves on each system, and a
+      :class:`~kups.core.cell.TriclinicFrame` cell.
+
+    The overloads narrow the required state protocol per ``integrator`` literal.
+
+    Args:
+        state: Lens into the sub-state with ``particles`` and ``systems``.
+        derivative_computation: Propagator that computes forces/gradients and
+            updates the state (e.g. a wrapped potential).
+        integrator: String key selecting the integration algorithm.
+        parameters: Constant integrator parameters. When given they are overlaid
+            onto the systems view with a constant lens, so the state need not
+            carry ``integrator_params`` on each system.
+
+    Returns:
+        [Propagator][kups.core.propagator.Propagator] that advances the
+        simulation by one time step.
+
+    Raises:
+        ValueError: If ``integrator`` is not one of the supported keys.
+    """
+    flow = WrapFlow(
+        state.focus(
+            lambda x: x.systems.map_data(lambda x: x.cell.materialize())[
+                x.particles.data.system
+            ]
+        ),
+        euclidean_flow,
+    )
+    particles_lens = state.focus(lambda x: x.particles)
+    systems_lens: Lens[State, Any] = state.focus(lambda x: x.systems)
+    if parameters is not None:
+        systems_lens = _IntegratorParamsOverlay(systems_lens, parameters)
+    match integrator:
+        case "verlet":
+            return make_velocity_verlet_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
+        case "baoab_langevin":
+            return make_baoab_langevin_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
+        case "csvr":
+            return make_csvr_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
+        case "csvr_npt":
+            return make_csvr_npt_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
+        case "baoab_npt_langevin":
+            return make_baoab_npt_langevin_step(
+                particles_lens, systems_lens, derivative_computation, flow
+            )
+        case _:
+            raise ValueError(f"Unknown integrator: {integrator}")

--- a/src/kups/application/md/simulation.py
+++ b/src/kups/application/md/simulation.py
@@ -11,6 +11,7 @@ from kups.application.md.data import (
     MdRunConfig,
     MDSystems,
 )
+from kups.application.md.integrators import make_md_step_from_state
 from kups.application.md.logging import MDLoggedData
 from kups.application.utils.propagate import (
     make_cycle_function,
@@ -41,7 +42,7 @@ from kups.core.propagator import (
 from kups.core.storage import HDF5StorageWriter
 from kups.core.typing import IsState, ParticleId, SystemId
 from kups.core.utils.jax import key_chain
-from kups.md.integrators import Integrator, make_md_step_from_state
+from kups.md.integrators import Integrator
 
 
 class IsMdGradients(Protocol):

--- a/src/kups/application/observables/__init__.py
+++ b/src/kups/application/observables/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0

--- a/src/kups/application/observables/stress.py
+++ b/src/kups/application/observables/stress.py
@@ -1,0 +1,52 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for virial stress observables.
+
+These adapters extract particles, groups, and systems from a concrete
+simulation state and delegate to the state-agnostic virial-theorem functions in
+[kups.observables.stress][].
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from jax import Array
+
+from kups.core.data import Table
+from kups.core.typing import GroupId, HasSystemIndex, IsState, SystemId
+from kups.observables.stress import (
+    IsMolecularVirialParticles,
+    IsVirialParticles,
+    IsVirialSystems,
+    molecular_stress_via_virial_theorem,
+    stress_via_virial_theorem,
+)
+
+
+class IsMolecularVirialState(
+    IsState[IsMolecularVirialParticles, IsVirialSystems], Protocol
+):
+    """State with groups for molecular virial stress."""
+
+    @property
+    def groups(self) -> Table[GroupId, HasSystemIndex]: ...
+
+
+def virial_stress_from_state(
+    key: Array, state: IsState[IsVirialParticles, IsVirialSystems]
+) -> Table[SystemId, Array]:
+    """Compute atomic virial stress from a state."""
+    del key
+    return stress_via_virial_theorem(state.particles, state.systems)
+
+
+def molecular_virial_stress_from_state(
+    key: Array, state: IsMolecularVirialState
+) -> Table[SystemId, Array]:
+    """Compute molecular virial stress from a state."""
+    del key
+    return molecular_stress_via_virial_theorem(
+        state.particles, state.groups, state.systems
+    )

--- a/src/kups/application/potential/__init__.py
+++ b/src/kups/application/potential/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0

--- a/src/kups/application/potential/classical/__init__.py
+++ b/src/kups/application/potential/classical/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0

--- a/src/kups/application/potential/classical/blocking.py
+++ b/src/kups/application/potential/classical/blocking.py
@@ -1,0 +1,154 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for blocking sphere potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, groups, systems, neighbor list, and parameters
+into the state-agnostic factories in
+[kups.potential.classical.blocking][].
+
+Parameters may live on the state (``state.blocking_spheres_parameters``) or be
+passed directly via ``parameters=``; in the latter case they are bound with a
+constant lens and the state need not carry a parameter field.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, overload
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.data import Table
+from kups.core.lens import Lens, const_lens
+from kups.core.neighborlist import (
+    IsAdaptiveCutoffNeighborListState,
+    IsUniversalNeighborlistParams,
+    NeighborListFactory,
+    adaptive_cutoff_neighborlist_from_state,
+)
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    Potential,
+    empty_patch_idx_view,
+)
+from kups.core.typing import GroupId, HasCell, HasMotifIndex, IsState
+from kups.potential.classical.blocking import (
+    BlockingSpheresNeighborListFactory,
+    BlockingSpheresParameters,
+    IsBlockingSpheresProbe,
+    _BlockingParticles,
+    make_blocking_spheres_potential,
+)
+
+
+class IsBlockingSpheresGraphState(
+    IsState[_BlockingParticles, HasCell[AnyPeriodicity]],
+    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
+    Protocol,
+):
+    """Particles, groups, systems, and neighbor list (no parameters)."""
+
+    @property
+    def groups(self) -> Table[GroupId, HasMotifIndex]: ...
+
+
+class IsBlockingSpheresState(IsBlockingSpheresGraphState, Protocol):
+    """:class:`IsBlockingSpheresGraphState` that also carries parameters on the state."""
+
+    @property
+    def blocking_spheres_parameters(self) -> BlockingSpheresParameters: ...
+
+
+@overload
+def make_blocking_spheres_from_state[State](
+    state: Lens[State, IsBlockingSpheresState],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    neighborlist_factory: NeighborListFactory[IsBlockingSpheresState] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_blocking_spheres_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsBlockingSpheresState],
+    probe: Probe[State, P, IsBlockingSpheresProbe],
+    *,
+    parameters: None = None,
+    neighborlist_factory: NeighborListFactory[IsBlockingSpheresState] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_blocking_spheres_from_state[State](
+    state: Lens[State, IsBlockingSpheresGraphState],
+    probe: None = None,
+    *,
+    parameters: BlockingSpheresParameters,
+    neighborlist_factory: NeighborListFactory[IsBlockingSpheresGraphState] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_blocking_spheres_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsBlockingSpheresGraphState],
+    probe: Probe[State, P, IsBlockingSpheresProbe],
+    *,
+    parameters: BlockingSpheresParameters,
+    neighborlist_factory: NeighborListFactory[IsBlockingSpheresGraphState] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+def make_blocking_spheres_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: BlockingSpheresParameters | None = None,
+    neighborlist_factory: NeighborListFactory[
+        Any
+    ] = adaptive_cutoff_neighborlist_from_state,
+) -> Any:
+    """Create a blocking spheres potential, optionally with incremental updates.
+
+    Args:
+        state: Lens into the sub-state providing particles, groups, systems, and
+            neighbor list (plus ``blocking_spheres_parameters`` when
+            ``parameters`` is not given).
+        probe: Probe returning a IsBlockingSpheresProbe; ``None`` for full
+            recomputation.
+        parameters: Constant blocking sphere parameters. When given they are
+            bound with a constant lens and the state need not carry
+            ``blocking_spheres_parameters``.
+        neighborlist_factory: Builds a ``NeighborList[Literal[2]]`` from the
+            sub-state and per-system cutoffs.
+
+    Returns:
+        Configured blocking spheres Potential.
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if probe is not None:
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+
+    if parameters is not None:
+        param_view: Any = const_lens(parameters)
+    else:
+        param_view = state.focus(lambda x: x.blocking_spheres_parameters)
+
+    def neighborlist_view(s: Any) -> BlockingSpheresNeighborListFactory:
+        return lambda cutoffs: neighborlist_factory(state(s), cutoffs)
+
+    return make_blocking_spheres_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.groups),
+        state.focus(lambda x: x.systems),
+        param_view,
+        neighborlist_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view,
+    )

--- a/src/kups/application/potential/classical/cosine_angle.py
+++ b/src/kups/application/potential/classical/cosine_angle.py
@@ -1,0 +1,232 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for cosine angle potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, angle indices, and parameters into the
+state-agnostic factories in
+[kups.potential.classical.cosine_angle][].
+
+Parameters may live on the state (``state.cosine_angle_parameters``) or be passed
+directly via ``parameters=``; in the latter case they are bound with a constant
+lens and the state need not carry a parameter field. For incremental (probe)
+updates with constant parameters, the cache is read from a conventional
+``cosine_angle_cache`` attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.data import Index
+from kups.core.lens import Lens, SimpleLens, const_lens
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    Potential,
+    PotentialOut,
+    empty_patch_idx_view,
+)
+from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.potential.classical.cosine_angle import (
+    CosineAngleInput,
+    CosineAngleParameters,
+    IsBondedParticles,
+    make_cosine_angle_potential,
+)
+from kups.potential.common.energy import PositionAndCell, position_and_cell_idx_view
+from kups.potential.common.graph import IsGraphProbe
+
+
+class IsCosineAngleGraphState(
+    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
+):
+    """Particles, systems, and angle indices for a cosine angle graph (no parameters)."""
+
+    @property
+    def cosine_angle_edge_indices(self) -> Index[ParticleId]: ...
+
+
+class IsCosineAngleState[Params](IsCosineAngleGraphState, Protocol):
+    """:class:`IsCosineAngleGraphState` that also carries parameters on the state."""
+
+    @property
+    def cosine_angle_parameters(self) -> Params: ...
+
+
+class IsCachedCosineAngleGraphState[Cache](IsCosineAngleGraphState, Protocol):
+    """:class:`IsCosineAngleGraphState` carrying an incremental-update cache (params passed in)."""
+
+    @property
+    def cosine_angle_cache(self) -> Cache: ...
+
+
+@overload
+def make_cosine_angle_from_state[State](
+    state: Lens[
+        State,
+        IsCosineAngleState[MaybeCached[CosineAngleParameters, Any]],
+    ],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_cosine_angle_from_state[State](
+    state: Lens[
+        State,
+        IsCosineAngleState[MaybeCached[CosineAngleParameters, Any]],
+    ],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_cosine_angle_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsCosineAngleState[
+            HasCache[CosineAngleParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_cosine_angle_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsCosineAngleState[
+            HasCache[CosineAngleParameters, PotentialOut[PositionAndCell, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_cosine_angle_from_state[State](
+    state: Lens[State, IsCosineAngleGraphState],
+    probe: None = None,
+    *,
+    parameters: CosineAngleParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_cosine_angle_from_state[State](
+    state: Lens[State, IsCosineAngleGraphState],
+    probe: None = None,
+    *,
+    parameters: CosineAngleParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_cosine_angle_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State, IsCachedCosineAngleGraphState[PotentialOut[EmptyType, EmptyType]]
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
+    *,
+    parameters: CosineAngleParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_cosine_angle_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State, IsCachedCosineAngleGraphState[PotentialOut[PositionAndCell, EmptyType]]
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
+    *,
+    parameters: CosineAngleParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_cosine_angle_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: CosineAngleParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+) -> Any:
+    """Create a cosine angle potential from a typed state, optionally with incremental updates.
+
+    Args:
+        state: Lens into the sub-state providing particles, cell, and angle
+            indices (plus ``cosine_angle_parameters`` when ``parameters`` is not
+            given).
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
+        parameters: Constant cosine angle parameters. When given they are bound
+            with a constant lens and the state need not carry
+            ``cosine_angle_parameters``; with a ``probe``, the cache is read from
+            ``state.cosine_angle_cache``.
+        compute_position_and_cell_gradients: When True, computes gradients
+            w.r.t. particle positions and lattice vectors.
+
+    Returns:
+        Configured cosine angle [Potential][kups.core.potential.Potential].
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[CosineAngleInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if parameters is not None:
+        param_view = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.cosine_angle_parameters.data
+                if isinstance(x.cosine_angle_parameters, HasCache)
+                else x.cosine_angle_parameters
+            )
+        )
+    cache_view = None
+    if probe is not None:
+        if parameters is None:
+            param_view = state.focus(lambda x: x.cosine_angle_parameters.data)
+            cache_view = state.focus(lambda x: x.cosine_angle_parameters.cache)
+        else:
+            cache_view = state.focus(lambda x: x.cosine_angle_cache)
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+    return make_cosine_angle_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.cosine_angle_edge_indices),
+        state.focus(lambda x: x.systems),
+        param_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
+    )

--- a/src/kups/application/potential/classical/coulomb.py
+++ b/src/kups/application/potential/classical/coulomb.py
@@ -1,0 +1,211 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for Coulomb vacuum potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, neighbor list, and cutoff into the
+state-agnostic factories in [kups.potential.classical.coulomb][].
+
+The cutoff may live on the state (``state.coulomb_cutoff``) or be passed directly
+via ``parameters=``; in the latter case it is bound with a constant lens and the
+state need not carry a cutoff field.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from jax import Array
+
+from kups.core.cell import Vacuum
+from kups.core.data import Table
+from kups.core.lens import Lens, SimpleLens, const_lens
+from kups.core.neighborlist import (
+    IsAdaptiveCutoffNeighborListState,
+    IsUniversalNeighborlistParams,
+    NeighborList,
+    NeighborListFactory,
+    adaptive_cutoff_neighborlist_from_state,
+)
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    Potential,
+    empty_patch_idx_view,
+)
+from kups.core.typing import HasCell, IsState, SystemId
+from kups.potential.classical.coulomb import (
+    CoulombVacuumInput,
+    IsCoulombGraphParticles,
+    make_coulomb_vacuum_potential,
+)
+from kups.potential.common.energy import PositionAndCell, position_and_cell_idx_view
+from kups.potential.common.graph import IsGraphProbe
+
+
+class IsCoulombVacuumGraphState(
+    IsState[IsCoulombGraphParticles, HasCell[Vacuum]],
+    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
+    Protocol,
+):
+    """Particles, systems, and neighbor list for a Coulomb vacuum graph (no cutoff)."""
+
+
+class IsCoulombVacuumState(IsCoulombVacuumGraphState, Protocol):
+    """:class:`IsCoulombVacuumGraphState` that also carries the cutoff on the state."""
+
+    @property
+    def coulomb_cutoff(self) -> Table[SystemId, Array]: ...
+
+
+@overload
+def make_coulomb_vacuum_from_state[State](
+    state: Lens[State, IsCoulombVacuumState],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_coulomb_vacuum_from_state[State](
+    state: Lens[State, IsCoulombVacuumState],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_coulomb_vacuum_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCoulombVacuumState],
+    probe: Probe[State, P, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_coulomb_vacuum_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCoulombVacuumState],
+    probe: Probe[State, P, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_coulomb_vacuum_from_state[State](
+    state: Lens[State, IsCoulombVacuumGraphState],
+    probe: None = None,
+    *,
+    parameters: Table[SystemId, Array],
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsCoulombVacuumGraphState] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_coulomb_vacuum_from_state[State](
+    state: Lens[State, IsCoulombVacuumGraphState],
+    probe: None = None,
+    *,
+    parameters: Table[SystemId, Array],
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsCoulombVacuumGraphState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_coulomb_vacuum_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCoulombVacuumGraphState],
+    probe: Probe[State, P, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]],
+    *,
+    parameters: Table[SystemId, Array],
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsCoulombVacuumGraphState] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_coulomb_vacuum_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCoulombVacuumGraphState],
+    probe: Probe[State, P, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]],
+    *,
+    parameters: Table[SystemId, Array],
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsCoulombVacuumGraphState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_coulomb_vacuum_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: Table[SystemId, Array] | None = None,
+    compute_position_and_cell_gradients: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        Any
+    ] = adaptive_cutoff_neighborlist_from_state,
+) -> Any:
+    """Create a Coulomb vacuum potential from a typed state, optionally with incremental updates.
+
+    Convenience wrapper around
+    [make_coulomb_vacuum_potential][kups.potential.classical.coulomb.make_coulomb_vacuum_potential].
+    When ``probe`` is ``None``, creates a plain potential for states satisfying
+    [IsCoulombVacuumState][kups.potential.classical.coulomb.IsCoulombVacuumState].
+    When a ``probe`` is provided, wires incremental patch-based updates for the same state type.
+
+    Args:
+        state: Lens into the sub-state providing particles, systems, and neighbor
+            list (plus ``coulomb_cutoff`` when ``parameters`` is not given).
+        probe: Detects which particles and neighbor-list edges changed since the last step.
+            Pass ``None`` (default) for a non-incremental potential.
+        parameters: Constant per-system cutoff. When given it is bound with a
+            constant lens and the state need not carry ``coulomb_cutoff``.
+        compute_position_and_cell_gradients: When ``True``, compute gradients
+            w.r.t. particle positions and lattice vectors.
+
+    Returns:
+        Configured Coulomb vacuum [Potential][kups.core.potential.Potential].
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[CoulombVacuumInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if probe is not None:
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+    if parameters is not None:
+        cutoff_view: Any = const_lens(parameters)
+    else:
+        cutoff_view = state.focus(lambda x: x.coulomb_cutoff)
+
+    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
+        return neighborlist_factory(state(s), cutoff_view(s))
+
+    return make_coulomb_vacuum_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.systems),
+        neighborlist_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view,
+    )

--- a/src/kups/application/potential/classical/dihedral.py
+++ b/src/kups/application/potential/classical/dihedral.py
@@ -1,0 +1,222 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for dihedral/torsion potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, dihedral indices, and parameters into the
+state-agnostic factories in [kups.potential.classical.dihedral][].
+
+Parameters may live on the state (``state.dihedral_parameters``) or be passed
+directly via ``parameters=``; in the latter case they are bound with a constant
+lens and the state need not carry a parameter field. For incremental (probe)
+updates with constant parameters, the cache is read from a conventional
+``dihedral_cache`` attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.data import Index
+from kups.core.lens import Lens, SimpleLens, const_lens
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    Potential,
+    PotentialOut,
+    empty_patch_idx_view,
+)
+from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.potential.classical.dihedral import (
+    DihedralInput,
+    DihedralParameters,
+    IsBondedParticles,
+    make_dihedral_potential,
+)
+from kups.potential.common.energy import PositionAndCell, position_and_cell_idx_view
+from kups.potential.common.graph import IsGraphProbe
+
+
+class IsDihedralGraphState(
+    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
+):
+    """Particles, systems, and dihedral indices (no parameters)."""
+
+    @property
+    def dihedral_edge_indices(self) -> Index[ParticleId]: ...
+
+
+class IsDihedralState[Params](IsDihedralGraphState, Protocol):
+    """:class:`IsDihedralGraphState` that also carries dihedral parameters."""
+
+    @property
+    def dihedral_parameters(self) -> Params: ...
+
+
+class IsCachedDihedralGraphState[Cache](IsDihedralGraphState, Protocol):
+    """:class:`IsDihedralGraphState` carrying an incremental-update cache (params passed in)."""
+
+    @property
+    def dihedral_cache(self) -> Cache: ...
+
+
+@overload
+def make_dihedral_from_state[State](
+    state: Lens[State, IsDihedralState[MaybeCached[DihedralParameters, Any]]],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_dihedral_from_state[State](
+    state: Lens[State, IsDihedralState[MaybeCached[DihedralParameters, Any]]],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_dihedral_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsDihedralState[
+            HasCache[DihedralParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_dihedral_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsDihedralState[
+            HasCache[DihedralParameters, PotentialOut[PositionAndCell, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_dihedral_from_state[State](
+    state: Lens[State, IsDihedralGraphState],
+    probe: None = None,
+    *,
+    parameters: DihedralParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_dihedral_from_state[State](
+    state: Lens[State, IsDihedralGraphState],
+    probe: None = None,
+    *,
+    parameters: DihedralParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_dihedral_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedDihedralGraphState[PotentialOut[EmptyType, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
+    *,
+    parameters: DihedralParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_dihedral_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State, IsCachedDihedralGraphState[PotentialOut[PositionAndCell, EmptyType]]
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
+    *,
+    parameters: DihedralParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_dihedral_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: DihedralParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+) -> Any:
+    """Create a dihedral potential from a typed state, optionally with incremental updates.
+
+    Args:
+        state: Lens into the sub-state providing particles, cell, and dihedral
+            indices (plus ``dihedral_parameters`` when ``parameters`` is not
+            given).
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
+        parameters: Constant dihedral parameters. When given they are bound with
+            a constant lens and the state need not carry ``dihedral_parameters``;
+            with a ``probe``, the cache is read from ``state.dihedral_cache``.
+        compute_position_and_cell_gradients: When True, computes gradients
+            w.r.t. particle positions and lattice vectors.
+
+    Returns:
+        Configured dihedral [Potential][kups.core.potential.Potential].
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[DihedralInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if parameters is not None:
+        param_view = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.dihedral_parameters.data
+                if isinstance(x.dihedral_parameters, HasCache)
+                else x.dihedral_parameters
+            )
+        )
+    cache_view = None
+    if probe is not None:
+        if parameters is None:
+            param_view = state.focus(lambda x: x.dihedral_parameters.data)
+            cache_view = state.focus(lambda x: x.dihedral_parameters.cache)
+        else:
+            cache_view = state.focus(lambda x: x.dihedral_cache)
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+    return make_dihedral_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.dihedral_edge_indices),
+        state.focus(lambda x: x.systems),
+        param_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
+    )

--- a/src/kups/application/potential/classical/ewald.py
+++ b/src/kups/application/potential/classical/ewald.py
@@ -1,0 +1,268 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for Ewald potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, neighbor list, and parameters into the
+state-agnostic factories in [kups.potential.classical.ewald][].
+
+Parameters may live on the state (``state.ewald_parameters``) or be passed
+directly via ``parameters=``; in the latter case they are bound with a constant
+lens and the state need not carry a parameter field. For incremental (probe)
+updates with constant parameters, the cache is read from a conventional
+``ewald_cache`` attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from kups.core.cell import Periodic3D
+from kups.core.lens import Lens, SimpleLens, const_lens
+from kups.core.neighborlist import (
+    IsAdaptiveCutoffNeighborListState,
+    IsUniversalNeighborlistParams,
+    NeighborList,
+    NeighborListFactory,
+    adaptive_cutoff_neighborlist_from_state,
+)
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    empty_patch_idx_view,
+)
+from kups.core.typing import HasCache, HasCell, IsState, MaybeCached
+from kups.potential.classical.ewald import (
+    EwaldCache,
+    EwaldParameters,
+    EwaldPotential,
+    IsEwaldPointData,
+    make_ewald_potential,
+)
+from kups.potential.common.energy import PositionAndCell, position_and_cell_idx_view
+from kups.potential.common.graph import IsGraphProbe, PointCloud
+
+
+class IsEwaldGraphState(
+    IsState[IsEwaldPointData, HasCell[Periodic3D]],
+    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
+    Protocol,
+):
+    """Particles, systems, and neighbor list for an Ewald graph (no parameters)."""
+
+
+class IsEwaldState[Params](IsEwaldGraphState, Protocol):
+    """:class:`IsEwaldGraphState` that also carries Ewald parameters on the state."""
+
+    @property
+    def ewald_parameters(self) -> Params: ...
+
+
+class IsCachedEwaldGraphState[Cache](IsEwaldGraphState, Protocol):
+    """:class:`IsEwaldGraphState` carrying an incremental-update cache (params passed in)."""
+
+    @property
+    def ewald_cache(self) -> Cache: ...
+
+
+@overload
+def make_ewald_from_state[State](
+    state: Lens[State, IsEwaldState[MaybeCached[EwaldParameters, Any]]],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        IsEwaldState[MaybeCached[EwaldParameters, Any]]
+    ] = ...,
+) -> EwaldPotential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_ewald_from_state[State](
+    state: Lens[State, IsEwaldState[MaybeCached[EwaldParameters, Any]]],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        IsEwaldState[MaybeCached[EwaldParameters, Any]]
+    ] = ...,
+) -> EwaldPotential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_ewald_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State, IsEwaldState[HasCache[EwaldParameters, EwaldCache[EmptyType, EmptyType]]]
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsEwaldPointData, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        IsEwaldState[HasCache[EwaldParameters, EwaldCache[EmptyType, EmptyType]]]
+    ] = ...,
+) -> EwaldPotential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_ewald_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsEwaldState[HasCache[EwaldParameters, EwaldCache[PositionAndCell, EmptyType]]],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsEwaldPointData, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        IsEwaldState[HasCache[EwaldParameters, EwaldCache[PositionAndCell, EmptyType]]]
+    ] = ...,
+) -> EwaldPotential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_ewald_from_state[State](
+    state: Lens[State, IsEwaldGraphState],
+    probe: None = None,
+    *,
+    parameters: EwaldParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[IsEwaldGraphState] = ...,
+) -> EwaldPotential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_ewald_from_state[State](
+    state: Lens[State, IsEwaldGraphState],
+    probe: None = None,
+    *,
+    parameters: EwaldParameters,
+    compute_position_and_cell_gradients: Literal[True],
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[IsEwaldGraphState] = ...,
+) -> EwaldPotential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_ewald_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedEwaldGraphState[EwaldCache[EmptyType, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsEwaldPointData, Literal[2]]],
+    *,
+    parameters: EwaldParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        IsCachedEwaldGraphState[EwaldCache[EmptyType, EmptyType]]
+    ] = ...,
+) -> EwaldPotential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_ewald_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedEwaldGraphState[EwaldCache[PositionAndCell, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsEwaldPointData, Literal[2]]],
+    *,
+    parameters: EwaldParameters,
+    compute_position_and_cell_gradients: Literal[True],
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        IsCachedEwaldGraphState[EwaldCache[PositionAndCell, EmptyType]]
+    ] = ...,
+) -> EwaldPotential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_ewald_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: EwaldParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+    include_exclusion_mask: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        Any
+    ] = adaptive_cutoff_neighborlist_from_state,
+) -> Any:
+    """Create an Ewald potential from a typed state, optionally with incremental updates.
+
+    When ``probe`` is ``None``, builds a static potential by extracting
+    components directly from the state.  When a probe is provided, the
+    potential supports incremental (cached) evaluation via the probe's
+    patch mechanism.
+
+    Args:
+        state: Lens focusing on the Ewald state (particles, systems,
+            neighborlist, plus ``ewald_parameters`` when ``parameters`` is not
+            given).
+        probe: Probe for incremental updates. ``None`` for a static
+            potential.
+        parameters: Constant Ewald parameters. When given they are bound with a
+            constant lens and the state need not carry ``ewald_parameters``;
+            with a ``probe``, the cache is read from ``state.ewald_cache``.
+        compute_position_and_cell_gradients: When ``True``, the
+            returned potential computes gradients w.r.t. particle
+            positions and lattice vectors (for forces / stress).
+            Gradient type becomes ``PositionAndCell``.
+        include_exclusion_mask: Whether to include the exclusion
+            correction term in the returned potential.
+
+    Returns:
+        An ``EwaldPotential`` combining short-range, long-range,
+        self-energy, and (optionally) exclusion-correction terms.
+        Gradient type is ``PositionAndCell`` when gradients are
+        requested, ``EmptyType`` otherwise.
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view = empty_patch_idx_view
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[
+            PointCloud[IsEwaldPointData, HasCell[Periodic3D]], PositionAndCell
+        ](
+            lambda pc: PositionAndCell(
+                pc.particles.map_data(lambda p: p.positions),
+                pc.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if parameters is not None:
+        param_view = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.ewald_parameters.data
+                if isinstance(x.ewald_parameters, HasCache)
+                else x.ewald_parameters
+            )
+        )
+    cache_view = None
+    if probe is not None:
+        if parameters is None:
+            param_view = state.focus(lambda x: x.ewald_parameters.data)
+            cache_view = state.focus(lambda x: x.ewald_parameters.cache)
+        else:
+            cache_view = state.focus(lambda x: x.ewald_cache)
+
+    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
+        return neighborlist_factory(state(s), param_view(s).cutoff)
+
+    return make_ewald_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.systems),
+        neighborlist_view,
+        param_view,
+        cache_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view=patch_idx_view,
+        include_exclusion_mask=include_exclusion_mask,
+    )

--- a/src/kups/application/potential/classical/harmonic.py
+++ b/src/kups/application/potential/classical/harmonic.py
@@ -1,0 +1,440 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for harmonic bonded potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, bond/angle indices, and parameters into
+the state-agnostic factories in
+[kups.potential.classical.harmonic][].
+
+Parameters may live on the state (``state.harmonic_bond_parameters`` /
+``state.harmonic_angle_parameters``) or be passed directly via ``parameters=``;
+in the latter case they are bound with a constant lens and the state need not
+carry a parameter field. For incremental (probe) updates with constant
+parameters, the cache is read from a conventional ``harmonic_bond_cache`` /
+``harmonic_angle_cache`` attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.data import Index
+from kups.core.lens import Lens, SimpleLens, const_lens
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    Potential,
+    PotentialOut,
+    empty_patch_idx_view,
+)
+from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.potential.classical.harmonic import (
+    HarmonicAngleInput,
+    HarmonicAngleParameters,
+    HarmonicBondInput,
+    HarmonicBondParameters,
+    IsBondedParticles,
+    make_harmonic_angle_potential,
+    make_harmonic_bond_potential,
+)
+from kups.potential.common.energy import PositionAndCell, position_and_cell_idx_view
+from kups.potential.common.graph import IsGraphProbe
+
+
+class HasBondedParticlesAndSystems(
+    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
+): ...
+
+
+class IsHarmonicBondGraphState(HasBondedParticlesAndSystems, Protocol):
+    """Particles, systems, and bond indices for a harmonic bond graph (no parameters)."""
+
+    @property
+    def harmonic_bond_indices(self) -> Index[ParticleId]: ...
+
+
+class IsHarmonicBondState[Params](IsHarmonicBondGraphState, Protocol):
+    """:class:`IsHarmonicBondGraphState` that also carries bond parameters on the state."""
+
+    @property
+    def harmonic_bond_parameters(self) -> Params: ...
+
+
+class IsCachedHarmonicBondState[Cache](IsHarmonicBondGraphState, Protocol):
+    """:class:`IsHarmonicBondGraphState` carrying an incremental-update cache (params passed in)."""
+
+    @property
+    def harmonic_bond_cache(self) -> Cache: ...
+
+
+@overload
+def make_harmonic_bond_from_state[State](
+    state: Lens[
+        State,
+        IsHarmonicBondState[MaybeCached[HarmonicBondParameters, Any]],
+    ],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_harmonic_bond_from_state[State](
+    state: Lens[
+        State,
+        IsHarmonicBondState[MaybeCached[HarmonicBondParameters, Any]],
+    ],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_harmonic_bond_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsHarmonicBondState[
+            HasCache[HarmonicBondParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_harmonic_bond_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsHarmonicBondState[
+            HasCache[HarmonicBondParameters, PotentialOut[PositionAndCell, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_harmonic_bond_from_state[State](
+    state: Lens[State, IsHarmonicBondGraphState],
+    probe: None = None,
+    *,
+    parameters: HarmonicBondParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_harmonic_bond_from_state[State](
+    state: Lens[State, IsHarmonicBondGraphState],
+    probe: None = None,
+    *,
+    parameters: HarmonicBondParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_harmonic_bond_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedHarmonicBondState[PotentialOut[EmptyType, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
+    *,
+    parameters: HarmonicBondParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_harmonic_bond_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State, IsCachedHarmonicBondState[PotentialOut[PositionAndCell, EmptyType]]
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
+    *,
+    parameters: HarmonicBondParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_harmonic_bond_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: HarmonicBondParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+) -> Any:
+    """Create a harmonic bond potential, optionally with incremental updates.
+
+    Convenience wrapper around
+    [make_harmonic_bond_potential][kups.potential.classical.harmonic.make_harmonic_bond_potential].
+    When `probe` is `None`, builds a plain potential from
+    [IsHarmonicBondState][kups.application.potential.classical.harmonic.IsHarmonicBondState].
+    When a `probe` is provided, builds an incrementally-updated potential from
+    a state with `HasCache`-wrapped parameters.
+
+    Args:
+        state: Lens into the sub-state providing particles, cell, and bond
+            indices (plus ``harmonic_bond_parameters`` when ``parameters`` is
+            not given).
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
+        parameters: Constant harmonic bond parameters. When given they are bound
+            with a constant lens and the state need not carry
+            ``harmonic_bond_parameters``; with a ``probe``, the cache is read
+            from ``state.harmonic_bond_cache``.
+        compute_position_and_cell_gradients: When ``True``, the returned
+            potential computes gradients w.r.t. particle positions and lattice
+            vectors (for forces / stress).
+
+    Returns:
+        Configured harmonic bond [Potential][kups.core.potential.Potential].
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[HarmonicBondInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if parameters is not None:
+        param_view = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.harmonic_bond_parameters.data
+                if isinstance(x.harmonic_bond_parameters, HasCache)
+                else x.harmonic_bond_parameters
+            )
+        )
+    cache_view = None
+    if probe is not None:
+        if parameters is None:
+            param_view = state.focus(lambda x: x.harmonic_bond_parameters.data)
+            cache_view = state.focus(lambda x: x.harmonic_bond_parameters.cache)
+        else:
+            cache_view = state.focus(lambda x: x.harmonic_bond_cache)
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+    return make_harmonic_bond_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.bond_edge_indices),
+        state.focus(lambda x: x.systems),
+        param_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
+    )
+
+
+class IsHarmonicAngleGraphState(HasBondedParticlesAndSystems, Protocol):
+    """Particles, systems, and angle indices for a harmonic angle graph (no parameters)."""
+
+    @property
+    def harmonic_angle_indices(self) -> Index[ParticleId]: ...
+
+
+class IsHarmonicAngleState[Params](IsHarmonicAngleGraphState, Protocol):
+    """:class:`IsHarmonicAngleGraphState` that also carries angle parameters on the state."""
+
+    @property
+    def harmonic_angle_parameters(self) -> Params: ...
+
+
+class IsCachedHarmonicAngleState[Cache](IsHarmonicAngleGraphState, Protocol):
+    """:class:`IsHarmonicAngleGraphState` carrying an incremental-update cache (params passed in)."""
+
+    @property
+    def harmonic_angle_cache(self) -> Cache: ...
+
+
+@overload
+def make_harmonic_angle_from_state[State](
+    state: Lens[
+        State,
+        IsHarmonicAngleState[MaybeCached[HarmonicAngleParameters, Any]],
+    ],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_harmonic_angle_from_state[State](
+    state: Lens[
+        State,
+        IsHarmonicAngleState[MaybeCached[HarmonicAngleParameters, Any]],
+    ],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_harmonic_angle_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsHarmonicAngleState[
+            HasCache[HarmonicAngleParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_harmonic_angle_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsHarmonicAngleState[
+            HasCache[HarmonicAngleParameters, PotentialOut[PositionAndCell, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_harmonic_angle_from_state[State](
+    state: Lens[State, IsHarmonicAngleGraphState],
+    probe: None = None,
+    *,
+    parameters: HarmonicAngleParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_harmonic_angle_from_state[State](
+    state: Lens[State, IsHarmonicAngleGraphState],
+    probe: None = None,
+    *,
+    parameters: HarmonicAngleParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_harmonic_angle_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedHarmonicAngleState[PotentialOut[EmptyType, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
+    *,
+    parameters: HarmonicAngleParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_harmonic_angle_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State, IsCachedHarmonicAngleState[PotentialOut[PositionAndCell, EmptyType]]
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
+    *,
+    parameters: HarmonicAngleParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_harmonic_angle_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: HarmonicAngleParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+) -> Any:
+    """Create a harmonic angle potential, optionally with incremental updates.
+
+    Convenience wrapper around
+    [make_harmonic_angle_potential][kups.potential.classical.harmonic.make_harmonic_angle_potential].
+    When `probe` is `None`, builds a plain potential from
+    [IsHarmonicAngleState][kups.application.potential.classical.harmonic.IsHarmonicAngleState].
+    When a `probe` is provided, builds an incrementally-updated potential from
+    a state with `HasCache`-wrapped parameters.
+
+    Args:
+        state: Lens into the sub-state providing particles, cell, and angle
+            indices (plus ``harmonic_angle_parameters`` when ``parameters`` is
+            not given).
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
+        parameters: Constant harmonic angle parameters. When given they are
+            bound with a constant lens and the state need not carry
+            ``harmonic_angle_parameters``; with a ``probe``, the cache is read
+            from ``state.harmonic_angle_cache``.
+        compute_position_and_cell_gradients: When ``True``, the returned
+            potential computes gradients w.r.t. particle positions and lattice
+            vectors (for forces / stress).
+
+    Returns:
+        Configured harmonic angle [Potential][kups.core.potential.Potential].
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[HarmonicAngleInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if parameters is not None:
+        param_view = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.harmonic_angle_parameters.data
+                if isinstance(x.harmonic_angle_parameters, HasCache)
+                else x.harmonic_angle_parameters
+            )
+        )
+    cache_view = None
+    if probe is not None:
+        if parameters is None:
+            param_view = state.focus(lambda x: x.harmonic_angle_parameters.data)
+            cache_view = state.focus(lambda x: x.harmonic_angle_parameters.cache)
+        else:
+            cache_view = state.focus(lambda x: x.harmonic_angle_cache)
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+    return make_harmonic_angle_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.angle_edge_indices),
+        state.focus(lambda x: x.systems),
+        param_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
+    )

--- a/src/kups/application/potential/classical/inversion.py
+++ b/src/kups/application/potential/classical/inversion.py
@@ -1,0 +1,230 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for UFF-style inversion potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, inversion connectivity, and parameters
+into the state-agnostic factories in
+[kups.potential.classical.inversion][].
+
+Parameters may live on the state (``state.inversion_parameters``) or be passed
+directly via ``parameters=``; in the latter case they are bound with a constant
+lens and the state need not carry a parameter field. For incremental (probe)
+updates with constant parameters, the cache is read from a conventional
+``inversion_cache`` attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.data import Index
+from kups.core.lens import Lens, SimpleLens, const_lens
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    Potential,
+    PotentialOut,
+    empty_patch_idx_view,
+)
+from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.potential.classical.inversion import (
+    InversionInput,
+    InversionParameters,
+    IsBondedParticles,
+    make_inversion_potential,
+)
+from kups.potential.common.energy import PositionAndCell, position_and_cell_idx_view
+from kups.potential.common.graph import IsGraphProbe
+
+
+class IsInversionGraphState(
+    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
+):
+    """Particles, systems, and inversion connectivity (no parameters)."""
+
+    @property
+    def inversion_edge_indices(self) -> Index[ParticleId]: ...
+
+
+class IsInversionState[Params](IsInversionGraphState, Protocol):
+    """:class:`IsInversionGraphState` that also carries inversion parameters."""
+
+    @property
+    def inversion_parameters(self) -> Params: ...
+
+
+class IsCachedInversionGraphState[Cache](IsInversionGraphState, Protocol):
+    """:class:`IsInversionGraphState` carrying an incremental-update cache (params passed in)."""
+
+    @property
+    def inversion_cache(self) -> Cache: ...
+
+
+@overload
+def make_inversion_from_state[State](
+    state: Lens[
+        State,
+        IsInversionState[MaybeCached[InversionParameters, Any]],
+    ],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_inversion_from_state[State](
+    state: Lens[
+        State,
+        IsInversionState[MaybeCached[InversionParameters, Any]],
+    ],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_inversion_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsInversionState[
+            HasCache[InversionParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_inversion_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsInversionState[
+            HasCache[InversionParameters, PotentialOut[PositionAndCell, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_inversion_from_state[State](
+    state: Lens[State, IsInversionGraphState],
+    probe: None = None,
+    *,
+    parameters: InversionParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_inversion_from_state[State](
+    state: Lens[State, IsInversionGraphState],
+    probe: None = None,
+    *,
+    parameters: InversionParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_inversion_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedInversionGraphState[PotentialOut[EmptyType, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
+    *,
+    parameters: InversionParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_inversion_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State, IsCachedInversionGraphState[PotentialOut[PositionAndCell, EmptyType]]
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
+    *,
+    parameters: InversionParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_inversion_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: InversionParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+) -> Any:
+    """Create an inversion potential, optionally with incremental updates.
+
+    Args:
+        state: Lens into the sub-state providing particles, cell, inversion
+            indices, and inversion parameters (the latter only when
+            ``parameters`` is not given).
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
+        parameters: Constant inversion parameters. When given they are bound
+            with a constant lens and the state need not carry
+            ``inversion_parameters``; with a ``probe``, the cache is read from
+            ``state.inversion_cache``.
+        compute_position_and_cell_gradients: When True, computes gradients
+            w.r.t. particle positions and lattice vectors.
+
+    Returns:
+        Configured inversion [Potential][kups.core.potential.Potential].
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[InversionInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if parameters is not None:
+        param_view = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.inversion_parameters.data
+                if isinstance(x.inversion_parameters, HasCache)
+                else x.inversion_parameters
+            )
+        )
+    cache_view = None
+    if probe is not None:
+        if parameters is None:
+            param_view = state.focus(lambda x: x.inversion_parameters.data)
+            cache_view = state.focus(lambda x: x.inversion_parameters.cache)
+        else:
+            cache_view = state.focus(lambda x: x.inversion_cache)
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+    return make_inversion_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.inversion_edge_indices),
+        state.focus(lambda x: x.systems),
+        param_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
+    )

--- a/src/kups/application/potential/classical/lennard_jones.py
+++ b/src/kups/application/potential/classical/lennard_jones.py
@@ -1,0 +1,390 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for Lennard-Jones potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, neighbor list, and parameters into the
+state-agnostic factories in
+[kups.potential.classical.lennard_jones][].
+
+Parameters may live on the state (``state.lj_parameters``) or be passed directly
+via ``parameters=``; in the latter case they are bound with a constant lens and
+the state need not carry a parameter field. For incremental (probe) updates with
+constant parameters, the cache is read from a conventional ``lj_cache`` attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, cast, overload
+
+from jax import Array
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.data import Table
+from kups.core.lens import Lens, SimpleLens, const_lens, identity_lens
+from kups.core.neighborlist import (
+    IsAdaptiveCutoffNeighborListState,
+    IsUniversalNeighborlistParams,
+    NeighborList,
+    NeighborListFactory,
+    adaptive_cutoff_neighborlist_from_state,
+)
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    Potential,
+    PotentialOut,
+    empty_patch_idx_view,
+)
+from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, SystemId
+from kups.potential.classical.lennard_jones import (
+    GCLJInp,
+    GlobalTailCorrectedLennardJonesParameters,
+    IsLJGraphParticles,
+    LennardJonesParameters,
+    LJRadiusInp,
+    make_global_lennard_jones_tail_correction_potential,
+    make_global_lennard_jones_tail_correction_pressure,
+    make_lennard_jones_potential,
+)
+from kups.potential.common.energy import PositionAndCell, position_and_cell_idx_view
+from kups.potential.common.graph import IsGraphProbe
+
+
+class HasLJParticlesAndSystems(
+    IsState[IsLJGraphParticles, HasCell[AnyPeriodicity]], Protocol
+): ...
+
+
+class IsLJGraphState(
+    HasLJParticlesAndSystems,
+    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
+    Protocol,
+):
+    """Particles, systems, and neighbor list for an LJ graph (no parameters)."""
+
+
+class IsLJState[Params](IsLJGraphState, Protocol):
+    """:class:`IsLJGraphState` that also carries LJ parameters on the state."""
+
+    @property
+    def lj_parameters(self) -> Params: ...
+
+
+class IsCachedLJGraphState[Cache](IsLJGraphState, Protocol):
+    """:class:`IsLJGraphState` carrying an incremental-update cache (params passed in)."""
+
+    @property
+    def lj_cache(self) -> Cache: ...
+
+
+@overload
+def make_lennard_jones_from_state[State](
+    state: Lens[State, IsLJState[MaybeCached[LennardJonesParameters, Any]]],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[
+        IsLJState[MaybeCached[LennardJonesParameters, Any]]
+    ] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_lennard_jones_from_state[State](
+    state: Lens[State, IsLJState[MaybeCached[LennardJonesParameters, Any]]],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[
+        IsLJState[MaybeCached[LennardJonesParameters, Any]]
+    ] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_lennard_jones_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsLJState[HasCache[LennardJonesParameters, PotentialOut[EmptyType, EmptyType]]],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[
+        IsLJState[HasCache[LennardJonesParameters, PotentialOut[EmptyType, EmptyType]]]
+    ] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_lennard_jones_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsLJState[
+            HasCache[LennardJonesParameters, PotentialOut[PositionAndCell, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[
+        IsLJState[
+            HasCache[LennardJonesParameters, PotentialOut[PositionAndCell, EmptyType]]
+        ]
+    ] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_lennard_jones_from_state[State](
+    state: Lens[State, IsLJGraphState],
+    probe: None = None,
+    *,
+    parameters: LennardJonesParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsLJGraphState] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_lennard_jones_from_state[State](
+    state: Lens[State, IsLJGraphState],
+    probe: None = None,
+    *,
+    parameters: LennardJonesParameters,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsLJGraphState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_lennard_jones_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedLJGraphState[PotentialOut[EmptyType, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
+    *,
+    parameters: LennardJonesParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[
+        IsCachedLJGraphState[PotentialOut[EmptyType, EmptyType]]
+    ] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_lennard_jones_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedLJGraphState[PotentialOut[PositionAndCell, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
+    *,
+    parameters: LennardJonesParameters,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[
+        IsCachedLJGraphState[PotentialOut[PositionAndCell, EmptyType]]
+    ] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_lennard_jones_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: LennardJonesParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        Any
+    ] = adaptive_cutoff_neighborlist_from_state,
+) -> Any:
+    """Create a LJ potential from a typed state, optionally with incremental updates.
+
+    Args:
+        state: Lens into the sub-state providing particles, systems, and neighbor
+            list (plus ``lj_parameters`` when ``parameters`` is not given).
+        probe: Detects which particles changed since the last step.
+            ``None`` for full recomputation.
+        parameters: Constant LJ parameters. When given they are bound with a
+            constant lens and the state need not carry ``lj_parameters``; with a
+            ``probe``, the cache is read from ``state.lj_cache``.
+        compute_position_and_cell_gradients: When ``True``, the returned
+            potential computes gradients w.r.t. particle positions and lattice
+            vectors. Gradient type becomes ``PositionAndCell``.
+
+    Returns:
+        Configured Lennard-Jones potential.
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[LJRadiusInp, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if parameters is not None:
+        param_view = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.lj_parameters.data
+                if isinstance(x.lj_parameters, HasCache)
+                else x.lj_parameters
+            )
+        )
+    cache_view = None
+    if probe is not None:
+        if parameters is None:
+            param_view = state.focus(lambda x: x.lj_parameters.data)
+            cache_view = state.focus(lambda x: x.lj_parameters.cache)
+        else:
+            cache_view = state.focus(lambda x: x.lj_cache)
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+
+    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
+        return neighborlist_factory(state(s), param_view(s).cutoff)
+
+    return make_lennard_jones_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.systems),
+        neighborlist_view,
+        param_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view,
+        cache_view,
+    )
+
+
+type IsGlobalTailCorrectedIsLJState = IsLJState[
+    MaybeCached[
+        GlobalTailCorrectedLennardJonesParameters,
+        PotentialOut[Any, Any],
+    ]
+]
+
+
+@overload
+def make_lennard_jones_tail_correction_from_state[
+    InState,
+    State: IsGlobalTailCorrectedIsLJState,
+](
+    state: Lens[InState, State],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[InState, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_lennard_jones_tail_correction_from_state[
+    InState,
+    State: IsGlobalTailCorrectedIsLJState,
+](
+    state: Lens[InState, State],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[InState, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_lennard_jones_tail_correction_from_state[State](
+    state: Lens[State, IsLJGraphState],
+    *,
+    parameters: GlobalTailCorrectedLennardJonesParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_lennard_jones_tail_correction_from_state[State](
+    state: Lens[State, IsLJGraphState],
+    *,
+    parameters: GlobalTailCorrectedLennardJonesParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+def make_lennard_jones_tail_correction_from_state(
+    state: Any,
+    *,
+    parameters: GlobalTailCorrectedLennardJonesParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+) -> Any:
+    """Create a global tail-corrected LJ potential from a typed state.
+
+    Args:
+        state: Lens into the sub-state providing particles and systems (plus
+            ``lj_parameters`` when ``parameters`` is not given).
+        parameters: Constant tail-correction parameters, bound with a constant
+            lens when given (state need not carry ``lj_parameters``).
+        compute_position_and_cell_gradients: When ``True``, the returned
+            potential computes gradients w.r.t. particle positions and lattice
+            vectors. Gradient type becomes ``PositionAndCell``.
+
+    Returns:
+        Configured tail-corrected Lennard-Jones potential.
+    """
+    gradient_lens: Any = EMPTY_LENS
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[GCLJInp, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+    if parameters is not None:
+        param_view: Any = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.lj_parameters.data
+                if isinstance(x.lj_parameters, HasCache)
+                else x.lj_parameters
+            )
+        )
+    return make_global_lennard_jones_tail_correction_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.systems),
+        cast(Any, param_view),
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+    )
+
+
+def global_lennard_jones_tail_correction_pressure_from_state(
+    key: Array,
+    state: IsGlobalTailCorrectedIsLJState,
+    *,
+    parameters: GlobalTailCorrectedLennardJonesParameters | None = None,
+) -> Table[SystemId, Array]:
+    """Create long-range pressure correction from a typed state.
+
+    When ``parameters`` is given it is bound with a constant lens and the state
+    need not carry ``lj_parameters``.
+    """
+    state_lens = identity_lens(type(state))
+    if parameters is not None:
+        param_view: Any = const_lens(parameters)
+    else:
+        param_view = state_lens.focus(
+            lambda x: (
+                x.lj_parameters.data
+                if isinstance(x.lj_parameters, HasCache)
+                else x.lj_parameters
+            )
+        )
+    return make_global_lennard_jones_tail_correction_pressure(
+        state_lens.focus(lambda x: x.particles),
+        state_lens.focus(lambda x: x.systems),
+        cast(Any, param_view),
+    )(key, state)

--- a/src/kups/application/potential/classical/morse.py
+++ b/src/kups/application/potential/classical/morse.py
@@ -1,0 +1,225 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for Morse bond potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, bond indices, and parameters into the
+state-agnostic factories in
+[kups.potential.classical.morse][].
+
+Parameters may live on the state (``state.morse_bond_parameters``) or be passed
+directly via ``parameters=``; in the latter case they are bound with a constant
+lens and the state need not carry a parameter field. For incremental (probe)
+updates with constant parameters, the cache is read from a conventional
+``morse_bond_cache`` attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.data import Index
+from kups.core.lens import Lens, SimpleLens, const_lens
+from kups.core.patch import Patch, Probe
+from kups.core.potential import (
+    EMPTY_LENS,
+    EmptyType,
+    Potential,
+    PotentialOut,
+    empty_patch_idx_view,
+)
+from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.potential.classical.morse import (
+    IsBondedParticles,
+    MorseBondInput,
+    MorseBondParameters,
+    make_morse_bond_potential,
+)
+from kups.potential.common.energy import PositionAndCell, position_and_cell_idx_view
+from kups.potential.common.graph import IsGraphProbe
+
+
+class IsMorseBondGraphState(
+    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
+):
+    """Particles, systems, and bond indices for a Morse bond (no parameters)."""
+
+    @property
+    def bond_edge_indices(self) -> Index[ParticleId]: ...
+
+
+class IsMorseBondState[Params](IsMorseBondGraphState, Protocol):
+    """:class:`IsMorseBondGraphState` that also carries Morse bond parameters."""
+
+    @property
+    def morse_bond_parameters(self) -> Params: ...
+
+
+class IsCachedMorseBondGraphState[Cache](IsMorseBondGraphState, Protocol):
+    """:class:`IsMorseBondGraphState` carrying an incremental-update cache (params passed in)."""
+
+    @property
+    def morse_bond_cache(self) -> Cache: ...
+
+
+@overload
+def make_morse_bond_from_state[State](
+    state: Lens[State, IsMorseBondState[MaybeCached[MorseBondParameters, Any]]],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_morse_bond_from_state[State](
+    state: Lens[State, IsMorseBondState[MaybeCached[MorseBondParameters, Any]]],
+    probe: None = None,
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_morse_bond_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsMorseBondState[
+            HasCache[MorseBondParameters, PotentialOut[EmptyType, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_morse_bond_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State,
+        IsMorseBondState[
+            HasCache[MorseBondParameters, PotentialOut[PositionAndCell, EmptyType]]
+        ],
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+@overload
+def make_morse_bond_from_state[State](
+    state: Lens[State, IsMorseBondGraphState],
+    probe: None = None,
+    *,
+    parameters: MorseBondParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_morse_bond_from_state[State](
+    state: Lens[State, IsMorseBondGraphState],
+    probe: None = None,
+    *,
+    parameters: MorseBondParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_morse_bond_from_state[State, P: Patch[Any]](
+    state: Lens[State, IsCachedMorseBondGraphState[PotentialOut[EmptyType, EmptyType]]],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
+    *,
+    parameters: MorseBondParameters,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+) -> Potential[State, EmptyType, EmptyType, P]: ...
+
+
+@overload
+def make_morse_bond_from_state[State, P: Patch[Any]](
+    state: Lens[
+        State, IsCachedMorseBondGraphState[PotentialOut[PositionAndCell, EmptyType]]
+    ],
+    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
+    *,
+    parameters: MorseBondParameters,
+    compute_position_and_cell_gradients: Literal[True],
+) -> Potential[State, PositionAndCell, EmptyType, P]: ...
+
+
+def make_morse_bond_from_state(
+    state: Any,
+    probe: Any = None,
+    *,
+    parameters: MorseBondParameters | None = None,
+    compute_position_and_cell_gradients: bool = False,
+) -> Any:
+    """Create a Morse bond potential from a typed state, optionally with incremental updates.
+
+    Args:
+        state: Lens into the sub-state providing particles, cell, and bond
+            indices (plus ``morse_bond_parameters`` when ``parameters`` is not
+            given).
+        probe: If provided, detects particle changes and supplies the
+            before/after fixed-edge neighbor lists for incremental updates.
+            Those neighbor lists carry any required update capacity.
+        parameters: Constant Morse bond parameters. When given they are bound
+            with a constant lens and the state need not carry
+            ``morse_bond_parameters``; with a ``probe``, the cache is read from
+            ``state.morse_bond_cache``.
+        compute_position_and_cell_gradients: When ``True``, the returned
+            potential computes gradients w.r.t. particle positions and lattice
+            vectors (for forces / stress).
+
+    Returns:
+        Configured Morse bond [Potential][kups.core.potential.Potential].
+    """
+    gradient_lens: Any = EMPTY_LENS
+    patch_idx_view: Any = None
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[MorseBondInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+        patch_idx_view = position_and_cell_idx_view
+    if parameters is not None:
+        param_view = const_lens(parameters)
+    else:
+        param_view = state.focus(
+            lambda x: (
+                x.morse_bond_parameters.data
+                if isinstance(x.morse_bond_parameters, HasCache)
+                else x.morse_bond_parameters
+            )
+        )
+    cache_view = None
+    if probe is not None:
+        if parameters is None:
+            param_view = state.focus(lambda x: x.morse_bond_parameters.data)
+            cache_view = state.focus(lambda x: x.morse_bond_parameters.cache)
+        else:
+            cache_view = state.focus(lambda x: x.morse_bond_cache)
+        patch_idx_view = patch_idx_view or empty_patch_idx_view
+    return make_morse_bond_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.bond_edge_indices),
+        state.focus(lambda x: x.systems),
+        param_view,
+        probe,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+        patch_idx_view=patch_idx_view,
+        out_cache_lens=cache_view,
+    )

--- a/src/kups/application/potential/mliap/__init__.py
+++ b/src/kups/application/potential/mliap/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0

--- a/src/kups/application/potential/mliap/local.py
+++ b/src/kups/application/potential/mliap/local.py
@@ -1,0 +1,238 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for local MLIAP potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, neighbor list, and model into the
+state-agnostic factory in [kups.potential.mliap.local][].
+
+The model may live on the state (``state.local_mliap_model``) or be passed
+directly via ``parameters=``; in the latter case it is bound with a constant
+lens and the state need not carry a model field. For incremental (probe) updates
+with a constant model, the cache is read from a conventional ``local_mliap_cache``
+attribute.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+import jax.numpy as jnp
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.lens import Lens, bind, const_lens
+from kups.core.neighborlist import (
+    IsAdaptiveCutoffNeighborListState,
+    IsUniversalNeighborlistParams,
+    NeighborList,
+    NeighborListFactory,
+    adaptive_cutoff_neighborlist_from_state,
+)
+from kups.core.patch import Patch, Probe
+from kups.core.potential import EMPTY_LENS, Potential, PotentialOut
+from kups.core.typing import HasCache, HasCell, IsState, MaybeCached
+from kups.potential.common.graph import IsGraphProbe
+from kups.potential.mliap.local import (
+    IsLocalMLIAPGraphParticles,
+    LocalMLIAPData,
+    LocalMLIAPInput,
+    make_local_mliap_potential,
+)
+
+
+class IsLocalMLIAPGraphState(
+    IsState[IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
+    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
+    Protocol,
+):
+    """Particles, systems, and neighbor list for a local MLIAP graph (no model)."""
+
+
+class IsLocalMLIAPState[Model](IsLocalMLIAPGraphState, Protocol):
+    """:class:`IsLocalMLIAPGraphState` that also carries the MLIAP model on the state."""
+
+    @property
+    def local_mliap_model(self) -> Model: ...
+
+
+class IsCachedLocalMLIAPState[Cache](IsLocalMLIAPGraphState, Protocol):
+    """:class:`IsLocalMLIAPGraphState` carrying an incremental-update cache (model passed in)."""
+
+    @property
+    def local_mliap_cache(self) -> Cache: ...
+
+
+@overload
+def make_local_mliap_from_state[State, Gradient, Hessian](
+    state: Lens[State, IsLocalMLIAPState[MaybeCached[LocalMLIAPData, Any]]],
+    probe: None = None,
+    gradient_lens: Lens[
+        LocalMLIAPInput[State, IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
+        Gradient,
+    ] = ...,
+    hessian_lens: Lens[Gradient, Hessian] = ...,
+    hessian_idx_view: Lens[State, Hessian] = ...,
+    out_idx_view: None = None,
+    *,
+    parameters: None = None,
+    neighborlist_factory: NeighborListFactory[
+        IsLocalMLIAPState[MaybeCached[LocalMLIAPData, Any]]
+    ] = ...,
+) -> Potential[State, Gradient, Hessian, Patch[Any]]: ...
+
+
+@overload
+def make_local_mliap_from_state[State, Ptch: Patch[Any], Gradient, Hessian](
+    state: Lens[
+        State,
+        IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut[Gradient, Hessian]]],
+    ],
+    probe: Probe[State, Ptch, IsGraphProbe[IsLocalMLIAPGraphParticles, Literal[2]]],
+    gradient_lens: Lens[
+        LocalMLIAPInput[State, IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
+        Gradient,
+    ] = ...,
+    hessian_lens: Lens[Gradient, Hessian] = ...,
+    hessian_idx_view: Lens[State, Hessian] = ...,
+    out_idx_view: Lens[State, PotentialOut[Gradient, Hessian]] | None = None,
+    *,
+    parameters: None = None,
+    neighborlist_factory: NeighborListFactory[
+        IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut[Gradient, Hessian]]]
+    ] = ...,
+) -> Potential[State, Gradient, Hessian, Ptch]: ...
+
+
+@overload
+def make_local_mliap_from_state[State, Gradient, Hessian](
+    state: Lens[State, IsLocalMLIAPGraphState],
+    probe: None = None,
+    gradient_lens: Lens[
+        LocalMLIAPInput[State, IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
+        Gradient,
+    ] = ...,
+    hessian_lens: Lens[Gradient, Hessian] = ...,
+    hessian_idx_view: Lens[State, Hessian] = ...,
+    out_idx_view: None = None,
+    *,
+    parameters: LocalMLIAPData,
+    neighborlist_factory: NeighborListFactory[IsLocalMLIAPGraphState] = ...,
+) -> Potential[State, Gradient, Hessian, Patch[Any]]: ...
+
+
+@overload
+def make_local_mliap_from_state[State, Ptch: Patch[Any], Gradient, Hessian](
+    state: Lens[State, IsCachedLocalMLIAPState[PotentialOut[Gradient, Hessian]]],
+    probe: Probe[State, Ptch, IsGraphProbe[IsLocalMLIAPGraphParticles, Literal[2]]],
+    gradient_lens: Lens[
+        LocalMLIAPInput[State, IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
+        Gradient,
+    ] = ...,
+    hessian_lens: Lens[Gradient, Hessian] = ...,
+    hessian_idx_view: Lens[State, Hessian] = ...,
+    out_idx_view: Lens[State, PotentialOut[Gradient, Hessian]] | None = None,
+    *,
+    parameters: LocalMLIAPData,
+    neighborlist_factory: NeighborListFactory[
+        IsCachedLocalMLIAPState[PotentialOut[Gradient, Hessian]]
+    ] = ...,
+) -> Potential[State, Gradient, Hessian, Ptch]: ...
+
+
+def make_local_mliap_from_state(
+    state: Any,
+    probe: Any = None,
+    gradient_lens: Any = EMPTY_LENS,
+    hessian_lens: Any = EMPTY_LENS,
+    hessian_idx_view: Any = EMPTY_LENS,
+    out_idx_view: Any = None,
+    *,
+    parameters: LocalMLIAPData | None = None,
+    neighborlist_factory: NeighborListFactory[
+        Any
+    ] = adaptive_cutoff_neighborlist_from_state,
+) -> Any:
+    """Create a local MLIAP potential from a typed state, optionally with incremental updates.
+
+    Convenience wrapper around
+    [make_local_mliap_potential][kups.potential.mliap.local.make_local_mliap_potential].
+    When ``probe`` is ``None``, extracts views from a state satisfying
+    [IsLocalMLIAPState][kups.application.potential.mliap.local.IsLocalMLIAPState].
+    When ``probe`` is provided, additionally wires the ``PotentialOut`` cache for
+    efficient incremental caching across Monte Carlo steps.
+
+    Args:
+        state: Lens into the sub-state providing particles, cell, neighbor list,
+            and local MLIAP model (when ``parameters`` is not given).
+        probe: Detects which particles and neighbor-list edges changed since the last
+            step. ``None`` for full-only computation.
+        gradient_lens: Specifies which gradients to compute (e.g., forces).
+        hessian_lens: Specifies which Hessians to compute.
+        hessian_idx_view: Index structure for Hessian updates.
+        out_idx_view: Index into the cached output for partial updates. Only used when
+            ``probe`` is not ``None``. Defaults to full re-indexing of the cached
+            ``total_energies``.
+        parameters: Constant MLIAP model. When given it is bound with a constant
+            lens and the state need not carry ``local_mliap_model``; with a
+            ``probe``, the cache is read from ``state.local_mliap_cache``.
+
+    Returns:
+        Configured local MLIAP [Potential][kups.core.potential.Potential].
+    """
+
+    def _model(x: Any) -> LocalMLIAPData:
+        m = x.local_mliap_model
+        return m.data if isinstance(m, HasCache) else m
+
+    if probe is None:
+        if parameters is not None:
+            model_lens = const_lens(parameters)
+        else:
+            model_lens = state.focus(_model)
+
+        def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
+            return neighborlist_factory(state(s), model_lens(s).cutoff)
+
+        return make_local_mliap_potential(
+            state.focus(lambda x: x.particles),
+            state.focus(lambda x: x.systems),
+            neighborlist_view,
+            model_lens,
+            None,
+            gradient_lens,
+            hessian_lens,
+            hessian_idx_view,
+            None,
+            None,
+        )
+
+    if parameters is not None:
+        model_lens = const_lens(parameters)
+        cache_view = state.focus(lambda x: x.local_mliap_cache)
+    else:
+        model_lens = state.focus(lambda x: x.local_mliap_model.data)
+        cache_view = state.focus(lambda x: x.local_mliap_model.cache)
+
+    if out_idx_view is None:
+        out_idx_view = cache_view.focus(
+            lambda c: bind(c, lambda x: x.total_energies.data).apply(
+                lambda x: jnp.arange(x.size, dtype=int)
+            )
+        )
+
+    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
+        return neighborlist_factory(state(s), model_lens(s).cutoff)
+
+    return make_local_mliap_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.systems),
+        neighborlist_view,
+        model_lens,
+        probe,
+        gradient_lens,
+        hessian_lens,
+        hessian_idx_view,
+        out_idx_view,
+        cache_view,
+    )

--- a/src/kups/application/potential/mliap/tojax.py
+++ b/src/kups/application/potential/mliap/tojax.py
@@ -1,0 +1,142 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for jaxified MLIAP potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, neighbor list, and jaxified model into the
+state-agnostic factories in [kups.potential.mliap.tojax][].
+
+The jaxified model may live on the state (``state.jaxified_model``) or be passed
+directly via ``parameters=``; in the latter case it is bound with a constant lens
+and the state need not carry a model field.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.lens import Lens, SimpleLens, const_lens
+from kups.core.neighborlist import (
+    IsAdaptiveCutoffNeighborListState,
+    IsUniversalNeighborlistParams,
+    NeighborList,
+    NeighborListFactory,
+    adaptive_cutoff_neighborlist_from_state,
+)
+from kups.core.patch import Patch
+from kups.core.potential import EMPTY_LENS, EmptyType, Potential
+from kups.core.typing import HasCell, IsState
+from kups.potential.common.energy import PositionAndCell
+from kups.potential.mliap.tojax import (
+    IsTojaxedParticles,
+    JaxifiedInput,
+    TojaxedMliap,
+    make_tojaxed_potential,
+)
+
+
+class IsTojaxedGraphState(
+    IsState[IsTojaxedParticles, HasCell[AnyPeriodicity]],
+    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
+    Protocol,
+):
+    """Particles, systems, and neighbor list for a jaxified graph (no model)."""
+
+
+class IsTojaxedState(IsTojaxedGraphState, Protocol):
+    """:class:`IsTojaxedGraphState` that also carries the jaxified model."""
+
+    @property
+    def jaxified_model(self) -> TojaxedMliap: ...
+
+
+@overload
+def make_tojaxed_from_state[State](
+    state: Lens[State, IsTojaxedState],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsTojaxedState] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_tojaxed_from_state[State](
+    state: Lens[State, IsTojaxedState],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsTojaxedState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_tojaxed_from_state[State](
+    state: Lens[State, IsTojaxedGraphState],
+    *,
+    parameters: TojaxedMliap,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsTojaxedGraphState] = ...,
+) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_tojaxed_from_state[State](
+    state: Lens[State, IsTojaxedGraphState],
+    *,
+    parameters: TojaxedMliap,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsTojaxedGraphState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+def make_tojaxed_from_state(
+    state: Any,
+    *,
+    parameters: TojaxedMliap | None = None,
+    compute_position_and_cell_gradients: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        Any
+    ] = adaptive_cutoff_neighborlist_from_state,
+) -> Any:
+    """Create a jaxified potential from a typed state.
+
+    Args:
+        state: Lens into the sub-state providing particles, cell, and neighbor
+            list (plus ``jaxified_model`` when ``parameters`` is not given).
+        parameters: Constant jaxified model. When given it is bound with a
+            constant lens and the state need not carry ``jaxified_model``.
+        compute_position_and_cell_gradients: When ``True``, compute
+            gradients w.r.t. particle positions and cell
+            (for forces / stress).
+
+    Returns:
+        Configured jaxified [Potential][kups.core.potential.Potential].
+    """
+    gradient_lens: Any = EMPTY_LENS
+    if compute_position_and_cell_gradients:
+        gradient_lens = SimpleLens[JaxifiedInput, PositionAndCell](
+            lambda x: PositionAndCell(
+                x.graph.particles.map_data(lambda p: p.positions),
+                x.graph.systems.map_data(lambda s: s.cell),
+            )
+        )
+    if parameters is not None:
+        model_view = const_lens(parameters)
+    else:
+        model_view = state.focus(lambda x: x.jaxified_model)
+
+    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
+        return neighborlist_factory(state(s), model_view(s).cutoff)
+
+    return make_tojaxed_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.systems),
+        neighborlist_view,
+        model_view,
+        gradient_lens,
+        EMPTY_LENS,
+        EMPTY_LENS,
+    )

--- a/src/kups/application/potential/mliap/torch.py
+++ b/src/kups/application/potential/mliap/torch.py
@@ -1,0 +1,134 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""State-binding constructors for torch MLFF potentials.
+
+These adapters take a :class:`~kups.core.lens.Lens` into a concrete simulation
+state and wire its particles, systems, neighbor list, and torch MLFF model into
+the state-agnostic factories in
+[kups.potential.mliap.torch.interface][].
+
+The model may live on the state (``state.torch_mliap_model``) or be passed
+directly via ``parameters=``; in the latter case it is bound with a constant
+lens and the state need not carry a model field.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, overload
+
+from jax import Array
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.lens import Lens, const_lens
+from kups.core.neighborlist import (
+    IsAdaptiveCutoffNeighborListState,
+    IsUniversalNeighborlistParams,
+    NeighborList,
+    NeighborListFactory,
+    adaptive_cutoff_neighborlist_from_state,
+)
+from kups.core.patch import Patch
+from kups.core.potential import EmptyType, Potential
+from kups.core.typing import HasCell, IsState
+from kups.potential.common.energy import PositionAndCell
+from kups.potential.mliap.torch.interface import (
+    IsTorchMliapParticles,
+    TorchMliap,
+    make_torch_mliap_potential,
+)
+
+
+class IsTorchMliapGraphState(
+    IsState[IsTorchMliapParticles, HasCell[AnyPeriodicity]],
+    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
+    Protocol,
+):
+    """Particles, systems, and neighbor list for a torch MLFF graph (no model)."""
+
+
+class IsTorchMliapState(IsTorchMliapGraphState, Protocol):
+    """:class:`IsTorchMliapGraphState` that also carries the model on the state."""
+
+    @property
+    def torch_mliap_model(self) -> TorchMliap: ...
+
+
+@overload
+def make_torch_mliap_from_state[State](
+    state: Lens[State, IsTorchMliapState],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsTorchMliapState] = ...,
+) -> Potential[State, Array, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_torch_mliap_from_state[State](
+    state: Lens[State, IsTorchMliapState],
+    *,
+    parameters: None = None,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsTorchMliapState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_torch_mliap_from_state[State](
+    state: Lens[State, IsTorchMliapGraphState],
+    *,
+    parameters: TorchMliap,
+    compute_position_and_cell_gradients: Literal[False] = ...,
+    neighborlist_factory: NeighborListFactory[IsTorchMliapGraphState] = ...,
+) -> Potential[State, Array, EmptyType, Patch[Any]]: ...
+
+
+@overload
+def make_torch_mliap_from_state[State](
+    state: Lens[State, IsTorchMliapGraphState],
+    *,
+    parameters: TorchMliap,
+    compute_position_and_cell_gradients: Literal[True],
+    neighborlist_factory: NeighborListFactory[IsTorchMliapGraphState] = ...,
+) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
+
+
+def make_torch_mliap_from_state(
+    state: Any,
+    *,
+    parameters: TorchMliap | None = None,
+    compute_position_and_cell_gradients: bool = False,
+    neighborlist_factory: NeighborListFactory[
+        Any
+    ] = adaptive_cutoff_neighborlist_from_state,
+) -> Any:
+    """Create a torch MLFF potential from a typed state.
+
+    Args:
+        state: Lens into a sub-state providing particles, systems, and neighbor
+            list (plus ``torch_mliap_model`` when ``parameters`` is not given).
+        parameters: Constant torch MLFF model. When given it is bound with a
+            constant lens and the state need not carry ``torch_mliap_model``.
+        compute_position_and_cell_gradients: When ``True``, exposes both
+            position and cell gradients. Requires the underlying
+            ``TorchMliap.compute_cell_gradients`` to be ``True``.
+
+    Returns:
+        Configured torch MLFF ``Potential``.
+    """
+    if parameters is not None:
+        model_view = const_lens(parameters)
+    else:
+        model_view = state.focus(lambda x: x.torch_mliap_model)
+
+    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
+        return neighborlist_factory(state(s), model_view(s).cutoff)
+
+    return make_torch_mliap_potential(
+        state.focus(lambda x: x.particles),
+        state.focus(lambda x: x.systems),
+        neighborlist_view,
+        model_view,
+        compute_cell_gradients=compute_position_and_cell_gradients,
+    )

--- a/src/kups/application/simulations/mcmc_rigid.py
+++ b/src/kups/application/simulations/mcmc_rigid.py
@@ -34,6 +34,18 @@ from kups.application.mcmc.data import (
     mcmc_state_from_config,
 )
 from kups.application.mcmc.logging import make_mcmc_logged_data
+from kups.application.observables.stress import molecular_virial_stress_from_state
+from kups.application.potential.classical.blocking import (
+    make_blocking_spheres_from_state,
+)
+from kups.application.potential.classical.ewald import (
+    make_ewald_from_state,
+)
+from kups.application.potential.classical.lennard_jones import (
+    global_lennard_jones_tail_correction_pressure_from_state,
+    make_lennard_jones_from_state,
+    make_lennard_jones_tail_correction_from_state,
+)
 from kups.core.capacity import Capacity, FixedCapacity
 from kups.core.data import Buffered, Table, WithCache, WithIndices
 from kups.core.data.buffered import add_buffers, system_view
@@ -85,22 +97,16 @@ from kups.mcmc.moves import (
 )
 from kups.mcmc.probability import make_muvt_probability_ratio
 from kups.observables.pressure import ideal_gas_pressure
-from kups.observables.stress import molecular_virial_stress_from_state
 from kups.potential.classical.blocking import (
     BlockingSpheresParameters,
-    make_blocking_spheres_from_state,
 )
 from kups.potential.classical.ewald import (
     EwaldCache,
     EwaldParameters,
-    make_ewald_from_state,
 )
 from kups.potential.classical.lennard_jones import (
     GlobalTailCorrectedLennardJonesParameters,
     MixingRule,
-    global_lennard_jones_tail_correction_pressure_from_state,
-    make_lennard_jones_from_state,
-    make_lennard_jones_tail_correction_from_state,
 )
 from kups.potential.common.energy import (
     PositionAndCell,

--- a/src/kups/application/simulations/mcmc_widom.py
+++ b/src/kups/application/simulations/mcmc_widom.py
@@ -31,6 +31,16 @@ from kups.application.mcmc.data import (
     mcmc_state_from_config,
 )
 from kups.application.mcmc.logging import IsWidomState, make_widom_logged_data
+from kups.application.potential.classical.blocking import (
+    make_blocking_spheres_from_state,
+)
+from kups.application.potential.classical.ewald import (
+    make_ewald_from_state,
+)
+from kups.application.potential.classical.lennard_jones import (
+    make_lennard_jones_from_state,
+    make_lennard_jones_tail_correction_from_state,
+)
 from kups.application.simulations.mcmc_rigid import (
     EwaldConfig,
     LJConfig,
@@ -81,17 +91,13 @@ from kups.mcmc.probability import make_muvt_probability_ratio
 from kups.mcmc.widom import GhostProbe, WidomStatistics
 from kups.potential.classical.blocking import (
     BlockingSpheresParameters,
-    make_blocking_spheres_from_state,
 )
 from kups.potential.classical.ewald import (
     EwaldCache,
     EwaldParameters,
-    make_ewald_from_state,
 )
 from kups.potential.classical.lennard_jones import (
     GlobalTailCorrectedLennardJonesParameters,
-    make_lennard_jones_from_state,
-    make_lennard_jones_tail_correction_from_state,
 )
 
 jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")

--- a/src/kups/application/simulations/md_lj.py
+++ b/src/kups/application/simulations/md_lj.py
@@ -22,6 +22,9 @@ from kups.application.md.data import (
     md_state_from_ase,
 )
 from kups.application.md.simulation import make_md_propagator, run_md
+from kups.application.potential.classical.lennard_jones import (
+    make_lennard_jones_from_state,
+)
 from kups.core.data import Table
 from kups.core.lens import identity_lens
 from kups.core.neighborlist import UniversalNeighborlistParameters
@@ -30,7 +33,6 @@ from kups.core.utils.jax import dataclass, key_chain
 from kups.potential.classical.lennard_jones import (
     LennardJonesParameters,
     MixingRule,
-    make_lennard_jones_from_state,
 )
 
 jax.config.update("jax_enable_x64", True)

--- a/src/kups/application/simulations/md_mlff.py
+++ b/src/kups/application/simulations/md_mlff.py
@@ -26,13 +26,14 @@ from kups.application.md.data import (
     md_state_from_ase,
 )
 from kups.application.md.simulation import make_md_propagator, run_md
+from kups.application.potential.mliap.tojax import make_tojaxed_from_state
 from kups.application.utils.path import get_model_path
 from kups.core.data import Table
 from kups.core.lens import identity_lens
 from kups.core.neighborlist import UniversalNeighborlistParameters
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass, key_chain
-from kups.potential.mliap.tojax import TojaxedMliap, make_tojaxed_from_state
+from kups.potential.mliap.tojax import TojaxedMliap
 
 jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
 jax.config.update("jax_enable_x64", True)

--- a/src/kups/application/simulations/relax_lj.py
+++ b/src/kups/application/simulations/relax_lj.py
@@ -17,6 +17,9 @@ from jax import Array
 from nanoargs import NanoArgs
 from pydantic import BaseModel
 
+from kups.application.potential.classical.lennard_jones import (
+    make_lennard_jones_from_state,
+)
 from kups.application.relaxation.analysis import analyze_relax_file
 from kups.application.relaxation.data import (
     RelaxParticles,
@@ -37,7 +40,6 @@ from kups.core.utils.jax import dataclass
 from kups.potential.classical.lennard_jones import (
     LennardJonesParameters,
     MixingRule,
-    make_lennard_jones_from_state,
 )
 from kups.relaxation.config import make_optimizer
 

--- a/src/kups/application/simulations/relax_mlff.py
+++ b/src/kups/application/simulations/relax_mlff.py
@@ -18,6 +18,7 @@ from jax import Array
 from nanoargs import NanoArgs
 from pydantic import BaseModel
 
+from kups.application.potential.mliap.tojax import make_tojaxed_from_state
 from kups.application.relaxation.analysis import analyze_relax_file
 from kups.application.relaxation.data import (
     RelaxParticles,
@@ -36,7 +37,7 @@ from kups.core.lens import identity_lens
 from kups.core.neighborlist import UniversalNeighborlistParameters
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass
-from kups.potential.mliap.tojax import TojaxedMliap, make_tojaxed_from_state
+from kups.potential.mliap.tojax import TojaxedMliap
 from kups.relaxation.config import make_optimizer
 
 jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")

--- a/src/kups/application/simulations/relax_torch.py
+++ b/src/kups/application/simulations/relax_torch.py
@@ -19,6 +19,7 @@ from jax import Array
 from nanoargs import NanoArgs
 from pydantic import BaseModel, Field
 
+from kups.application.potential.mliap.torch import make_torch_mliap_from_state
 from kups.application.relaxation.analysis import analyze_relax_file
 from kups.application.relaxation.data import (
     RelaxParticles,
@@ -43,7 +44,6 @@ from kups.potential.mliap.torch import (
     UMATaskName,
     load_mace,
     load_uma,
-    make_torch_mliap_from_state,
 )
 from kups.relaxation.config import make_optimizer
 

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, overload, runtime_checkable
+from typing import Any, Literal, runtime_checkable
 
 import jax
 import jax.numpy as jnp
@@ -14,7 +14,6 @@ from kups.core.cell import (
     AnyPeriodicity,
     Cell,
     Periodic3D,
-    require_periodic_3d_triclinic,
 )
 from kups.core.constants import BOLTZMANN_CONSTANT
 from kups.core.data import Table
@@ -39,7 +38,6 @@ from kups.core.typing import (
     HasTemperature,
     HasThermostatTimeConstant,
     HasTimeStep,
-    IsState,
     ParticleId,
     SystemId,
 )
@@ -711,11 +709,16 @@ class IsMDSystem[P](HasCell[Periodic3D], HasIntegratorParams[P], Protocol):
 
 
 @runtime_checkable
-class IsMDSystemNPT(IsMDSystem[IsCSVRNPTParams], Protocol):
-    r"""NPT MD system row: adds the cell-gradient leaf needed for the barostat."""
+class IsMDSystemNPTBase(HasCell[Periodic3D], Protocol):
+    r"""Params-free NPT MD system row: a periodic cell plus the barostat cell-gradient leaf."""
 
     @property
     def cell_gradients(self) -> Cell[Periodic3D]: ...
+
+
+@runtime_checkable
+class IsMDSystemNPT(IsMDSystemNPTBase, HasIntegratorParams[IsCSVRNPTParams], Protocol):
+    r"""NPT MD system row: :class:`IsMDSystemNPTBase` plus bundled integrator parameters."""
 
 
 @runtime_checkable
@@ -964,17 +967,21 @@ class IsBAOABNPTLangevinParams(
 
 
 @runtime_checkable
-class IsBAOABNPTLangevinSystem(
-    HasCell[Periodic3D],
-    HasCellMomentum,
-    HasIntegratorParams[IsBAOABNPTLangevinParams],
-    Protocol,
-):
-    r"""NPT Langevin MD system row: periodic cell, cell-momentum tensor, integrator
-    params, and a cell-gradient leaf for the virial."""
+class IsBAOABNPTLangevinSystemBase(HasCell[Periodic3D], HasCellMomentum, Protocol):
+    r"""Params-free NPT Langevin MD system row: periodic cell, cell-momentum tensor,
+    and a cell-gradient leaf for the virial."""
 
     @property
     def cell_gradients(self) -> Cell[Periodic3D]: ...
+
+
+@runtime_checkable
+class IsBAOABNPTLangevinSystem(
+    IsBAOABNPTLangevinSystemBase,
+    HasIntegratorParams[IsBAOABNPTLangevinParams],
+    Protocol,
+):
+    r"""NPT Langevin MD system row: :class:`IsBAOABNPTLangevinSystemBase` plus integrator params."""
 
 
 def _cell_velocity(cell_momentum: Array, barostat_mass: Array) -> Array:
@@ -1295,135 +1302,3 @@ def make_baoab_npt_langevin_step[State](
             CellMomentumKick(particles, systems),  # B^h  Δt/2
         )
     )
-
-
-def require_baoab_npt_langevin_state(
-    systems: Table[SystemId, IsBAOABNPTLangevinSystem],
-) -> None:
-    """Runtime check that the system table satisfies the BAOAB NPT Langevin shape.
-
-    Call this once on the initial state (outside of jit) before constructing
-    the integrator. Verifies that the cell is a 3D-periodic
-    :class:`TriclinicFrame` and that the integrator-params is a
-    :class:`BAOABNPTLangevinParams`-shaped bundle.
-    """
-    require_periodic_3d_triclinic(systems.data.cell)
-
-
-@overload
-def make_md_step_from_state[State](
-    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsVerletParams]]],
-    derivative_computation: Propagator[State],
-    integrator: Literal["verlet"],
-) -> Propagator[State]: ...
-@overload
-def make_md_step_from_state[State](
-    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsBAOABLangevinParams]]],
-    derivative_computation: Propagator[State],
-    integrator: Literal["baoab_langevin"],
-) -> Propagator[State]: ...
-@overload
-def make_md_step_from_state[State](
-    state: Lens[State, IsState[_MDParticleData, IsMDSystem[IsCSVRParams]]],
-    derivative_computation: Propagator[State],
-    integrator: Literal["csvr"],
-) -> Propagator[State]: ...
-@overload
-def make_md_step_from_state[State](
-    state: Lens[State, IsState[_MDParticleData, IsMDSystemNPT]],
-    derivative_computation: Propagator[State],
-    integrator: Literal["csvr_npt"],
-) -> Propagator[State]: ...
-@overload
-def make_md_step_from_state[State](
-    state: Lens[State, IsState[_MDParticleData, IsBAOABNPTLangevinSystem]],
-    derivative_computation: Propagator[State],
-    integrator: Literal["baoab_npt_langevin"],
-) -> Propagator[State]: ...
-@overload
-def make_md_step_from_state[State](
-    state: Lens[State, Any],
-    derivative_computation: Propagator[State],
-    integrator: Integrator,
-) -> Propagator[State]: ...
-
-
-def make_md_step_from_state[State](
-    state: Lens[State, Any],
-    derivative_computation: Propagator[State],
-    integrator: Integrator,
-) -> Propagator[State]:
-    """Build a single MD integration step from a typed state.
-
-    Constructs the appropriate integrator propagator by extracting views for
-    particles and systems from ``state`` and wrapping them with a
-    [WrapFlow][kups.md.integrators.WrapFlow]
-    for periodic-boundary-condition-aware distance computations.
-
-    Supported integrators:
-
-    - ``"verlet"`` — [Velocity Verlet][kups.md.integrators.make_velocity_verlet_step]
-      (NVE ensemble, no thermostat). Requires ``integrator_params: IsVerletParams``.
-    - ``"baoab_langevin"`` — [BAOAB Langevin][kups.md.integrators.make_baoab_langevin_step]
-      (NVT via Langevin friction/noise). Requires
-      ``integrator_params: IsBAOABLangevinParams``.
-    - ``"csvr"`` — [CSVR][kups.md.integrators.make_csvr_step]
-      (NVT via canonical-sampling velocity rescaling, constant volume). Requires
-      ``integrator_params: IsCSVRParams``.
-    - ``"csvr_npt"`` — [CSVR-NPT][kups.md.integrators.make_csvr_npt_step]
-      (NPT via CSVR thermostat with barostat). Requires
-      ``integrator_params: IsCSVRNPTParams`` and a ``cell_gradients`` leaf on each system.
-    - ``"baoab_npt_langevin"`` — [BAOAB NPT Langevin][kups.md.integrators.make_baoab_npt_langevin_step]
-      (Gao–Fang–Wang JCP 2016 fully-flexible-cell NPT). Requires
-      ``integrator_params: IsBAOABNPTLangevinParams`` plus ``cell_momentum``
-      and ``cell_gradients`` leaves on each system, and a
-      :class:`~kups.core.cell.TriclinicFrame` cell.
-
-    The overloads narrow the required state protocol per ``integrator`` literal.
-
-    Args:
-        state: Lens into the sub-state with ``particles`` and ``systems``.
-        derivative_computation: Propagator that computes forces/gradients and
-            updates the state (e.g. a wrapped potential).
-        integrator: String key selecting the integration algorithm.
-
-    Returns:
-        [Propagator][kups.core.propagator.Propagator] that advances the
-        simulation by one time step.
-
-    Raises:
-        ValueError: If ``integrator`` is not one of the supported keys.
-    """
-    flow = WrapFlow(
-        state.focus(
-            lambda x: x.systems.map_data(lambda x: x.cell.materialize())[
-                x.particles.data.system
-            ]
-        ),
-        euclidean_flow,
-    )
-    particles_lens = state.focus(lambda x: x.particles)
-    systems_lens = state.focus(lambda x: x.systems)
-    match integrator:
-        case "verlet":
-            return make_velocity_verlet_step(
-                particles_lens, systems_lens, derivative_computation, flow
-            )
-        case "baoab_langevin":
-            return make_baoab_langevin_step(
-                particles_lens, systems_lens, derivative_computation, flow
-            )
-        case "csvr":
-            return make_csvr_step(
-                particles_lens, systems_lens, derivative_computation, flow
-            )
-        case "csvr_npt":
-            return make_csvr_npt_step(
-                particles_lens, systems_lens, derivative_computation, flow
-            )
-        case "baoab_npt_langevin":
-            return make_baoab_npt_langevin_step(
-                particles_lens, systems_lens, derivative_computation, flow
-            )
-        case _:
-            raise ValueError(f"Unknown integrator: {integrator}")

--- a/src/kups/observables/stress.py
+++ b/src/kups/observables/stress.py
@@ -35,7 +35,6 @@ from kups.core.typing import (
     HasGroupIndex,
     HasPositions,
     HasSystemIndex,
-    IsState,
     ParticleId,
     SystemId,
 )
@@ -65,15 +64,6 @@ class IsMolecularVirialParticles(HasPositions, HasGroupIndex, HasSystemIndex, Pr
 
     @property
     def position_gradients(self) -> Array: ...
-
-
-class IsMolecularVirialState(
-    IsState[IsMolecularVirialParticles, IsVirialSystems], Protocol
-):
-    """State with groups for molecular virial stress."""
-
-    @property
-    def groups(self) -> Table[GroupId, HasSystemIndex]: ...
 
 
 def _symmetrize_from_lower(lower: Array) -> Array:
@@ -259,21 +249,3 @@ def molecular_stress_via_virial_theorem(
         cell,
     )
     return Table(systems.keys, stress)
-
-
-def virial_stress_from_state(
-    key: Array, state: IsState[IsVirialParticles, IsVirialSystems]
-) -> Table[SystemId, Array]:
-    """Compute atomic virial stress from a state."""
-    del key
-    return stress_via_virial_theorem(state.particles, state.systems)
-
-
-def molecular_virial_stress_from_state(
-    key: Array, state: IsMolecularVirialState
-) -> Table[SystemId, Array]:
-    """Compute molecular virial stress from a state."""
-    del key
-    return molecular_stress_via_virial_theorem(
-        state.particles, state.groups, state.systems
-    )

--- a/src/kups/potential/classical/blocking.py
+++ b/src/kups/potential/classical/blocking.py
@@ -20,7 +20,6 @@ from typing import (
     Literal,
     Protocol,
     Sequence,
-    overload,
 )
 
 import jax
@@ -32,20 +31,12 @@ from kups.core.data import Index, Table
 from kups.core.lens import Lens, View
 from kups.core.neighborlist import (
     Edges,
-    IsAdaptiveCutoffNeighborListState,
-    IsUniversalNeighborlistParams,
     NeighborList,
-    NeighborListFactory,
-    adaptive_cutoff_neighborlist_from_state,
 )
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
-    EMPTY_LENS,
-    EmptyType,
     Energy,
-    Potential,
     PotentialOut,
-    empty_patch_idx_view,
 )
 from kups.core.typing import (
     ExclusionId,
@@ -55,7 +46,6 @@ from kups.core.typing import (
     HasMotifIndex,
     HasPositionsAndSystemIndex,
     InclusionId,
-    IsState,
     MotifId,
     ParticleId,
     SystemId,
@@ -357,80 +347,6 @@ def make_blocking_spheres_potential[State, Gradients, Hessians, Ptch: Patch[Any]
         gradient_lens=gradient_lens,
         patch_idx_view=patch_idx_view,
         cache_lens=None,
-    )
-
-
-class IsBlockingSpheresState(
-    IsState[_BlockingParticles, HasCell[AnyPeriodicity]],
-    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
-    Protocol,
-):
-    """Protocol for states providing all inputs for the blocking spheres potential."""
-
-    @property
-    def groups(self) -> Table[GroupId, HasMotifIndex]: ...
-    @property
-    def blocking_spheres_parameters(self) -> BlockingSpheresParameters: ...
-
-
-@overload
-def make_blocking_spheres_from_state[State](
-    state: Lens[State, IsBlockingSpheresState],
-    probe: None = None,
-    *,
-    neighborlist_factory: NeighborListFactory[IsBlockingSpheresState] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_blocking_spheres_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsBlockingSpheresState],
-    probe: Probe[State, P, IsBlockingSpheresProbe],
-    *,
-    neighborlist_factory: NeighborListFactory[IsBlockingSpheresState] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-def make_blocking_spheres_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    neighborlist_factory: NeighborListFactory[
-        Any
-    ] = adaptive_cutoff_neighborlist_from_state,
-) -> Any:
-    """Create a blocking spheres potential, optionally with incremental updates.
-
-    Args:
-        state: Lens into the sub-state providing particles, groups, systems,
-            blocking sphere parameters, and neighbor list.
-        probe: Probe returning a IsBlockingSpheresProbe; ``None`` for full
-            recomputation.
-        neighborlist_factory: Builds a ``NeighborList[Literal[2]]`` from the
-            sub-state and per-system cutoffs.
-
-    Returns:
-        Configured blocking spheres Potential.
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if probe is not None:
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-
-    def neighborlist_view(s: Any) -> BlockingSpheresNeighborListFactory:
-        return lambda cutoffs: neighborlist_factory(state(s), cutoffs)
-
-    return make_blocking_spheres_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.groups),
-        state.focus(lambda x: x.systems),
-        state.focus(lambda x: x.blocking_spheres_parameters),
-        neighborlist_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view,
     )
 
 

--- a/src/kups/potential/classical/cosine_angle.py
+++ b/src/kups/potential/classical/cosine_angle.py
@@ -22,31 +22,25 @@ For linear angles ($\\theta_0 = 180°$), the coefficients are singular, so a spe
 form is used: $U(\\theta) = K (1 + \\cos\\theta)$.
 """
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import jax.numpy as jnp
 from jax import Array
 
 from kups.core.cell import AnyPeriodicity
 from kups.core.data import Index, Table
-from kups.core.lens import Lens, SimpleLens, View
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
-    EMPTY_LENS,
-    EmptyType,
     Energy,
     Potential,
     PotentialOut,
-    empty_patch_idx_view,
 )
 from kups.core.typing import (
-    HasCache,
     HasCell,
     HasPositionsAndLabels,
-    IsState,
     Label,
-    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -54,9 +48,7 @@ from kups.core.utils.jax import dataclass, field
 from kups.potential.classical.uff_utils import compute_uff_bond_length
 from kups.potential.common.energy import (
     EnergyFunction,
-    PositionAndCell,
     PotentialFromEnergy,
-    position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
     GraphConstructor,
@@ -279,125 +271,6 @@ def make_cosine_angle_potential[
         patch_idx_view=patch_idx_view,
     )
     return potential
-
-
-class IsCosineAngleState[Params](
-    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
-):
-    """Protocol for states providing full-evaluation cosine angle inputs."""
-
-    @property
-    def cosine_angle_edge_indices(self) -> Index[ParticleId]: ...
-    @property
-    def cosine_angle_parameters(self) -> Params: ...
-
-
-@overload
-def make_cosine_angle_from_state[State](
-    state: Lens[
-        State,
-        IsCosineAngleState[MaybeCached[CosineAngleParameters, Any]],
-    ],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_cosine_angle_from_state[State](
-    state: Lens[
-        State,
-        IsCosineAngleState[MaybeCached[CosineAngleParameters, Any]],
-    ],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_cosine_angle_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsCosineAngleState[
-            HasCache[CosineAngleParameters, PotentialOut[EmptyType, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_cosine_angle_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsCosineAngleState[
-            HasCache[CosineAngleParameters, PotentialOut[PositionAndCell, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_cosine_angle_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-) -> Any:
-    """Create a cosine angle potential from a typed state, optionally with incremental updates.
-
-    Args:
-        state: Lens into the sub-state providing particles, cell, angle indices,
-            and cosine angle parameters.
-        probe: If provided, detects particle changes and supplies the
-            before/after fixed-edge neighbor lists for incremental updates.
-            Those neighbor lists carry any required update capacity.
-        compute_position_and_cell_gradients: When True, computes gradients
-            w.r.t. particle positions and lattice vectors.
-
-    Returns:
-        Configured cosine angle [Potential][kups.core.potential.Potential].
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[CosineAngleInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    param_view = state.focus(
-        lambda x: (
-            x.cosine_angle_parameters.data
-            if isinstance(x.cosine_angle_parameters, HasCache)
-            else x.cosine_angle_parameters
-        )
-    )
-    cache_view = None
-    if probe is not None:
-        param_view = state.focus(lambda x: x.cosine_angle_parameters.data)
-        cache_view = state.focus(lambda x: x.cosine_angle_parameters.cache)
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-    return make_cosine_angle_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.cosine_angle_edge_indices),
-        state.focus(lambda x: x.systems),
-        param_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view=patch_idx_view,
-        out_cache_lens=cache_view,
-    )
 
 
 if TYPE_CHECKING:

--- a/src/kups/potential/classical/coulomb.py
+++ b/src/kups/potential/classical/coulomb.py
@@ -10,43 +10,32 @@ electrostatics, use [Ewald summation][kups.potential.classical.ewald] instead.
 Potential: $U = \\frac{1}{4\\pi\\epsilon_0} \\sum_{i<j} \\frac{q_i q_j}{r_{ij}}$
 """
 
-from typing import Any, Literal, Protocol, overload
+from typing import Any, Literal, Protocol
 
 import jax.numpy as jnp
-from jax import Array
 
 from kups.core.cell import AnyPeriodicity, Vacuum
 from kups.core.constants import BOHR, HARTREE
 from kups.core.data import Table
-from kups.core.lens import Lens, SimpleLens, View
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import (
-    IsAdaptiveCutoffNeighborListState,
-    IsUniversalNeighborlistParams,
     NeighborList,
-    NeighborListFactory,
-    adaptive_cutoff_neighborlist_from_state,
 )
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
-    EMPTY_LENS,
-    EmptyType,
     Energy,
     Potential,
     PotentialOut,
-    empty_patch_idx_view,
 )
 from kups.core.typing import (
     HasCell,
     HasCharges,
     HasPositionsAndSystemIndex,
-    IsState,
     ParticleId,
     SystemId,
 )
 from kups.potential.common.energy import (
-    PositionAndCell,
     PotentialFromEnergy,
-    position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
     GraphConstructor,
@@ -161,110 +150,3 @@ def make_coulomb_vacuum_potential[
         patch_idx_view=patch_idx_view,
     )
     return potential
-
-
-class IsCoulombVacuumState(
-    IsState[IsCoulombGraphParticles, HasCell[Vacuum]],
-    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
-    Protocol,
-):
-    """Protocol for states providing all inputs for the Coulomb vacuum potential."""
-
-    @property
-    def coulomb_cutoff(self) -> Table[SystemId, Array]: ...
-
-
-@overload
-def make_coulomb_vacuum_from_state[State](
-    state: Lens[State, IsCoulombVacuumState],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-    neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_coulomb_vacuum_from_state[State](
-    state: Lens[State, IsCoulombVacuumState],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-    neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_coulomb_vacuum_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCoulombVacuumState],
-    probe: Probe[State, P, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-    neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_coulomb_vacuum_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCoulombVacuumState],
-    probe: Probe[State, P, IsGraphProbe[IsCoulombGraphParticles, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-    neighborlist_factory: NeighborListFactory[IsCoulombVacuumState] = ...,
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_coulomb_vacuum_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        Any
-    ] = adaptive_cutoff_neighborlist_from_state,
-) -> Any:
-    """Create a Coulomb vacuum potential from a typed state, optionally with incremental updates.
-
-    Convenience wrapper around
-    [make_coulomb_vacuum_potential][kups.potential.classical.coulomb.make_coulomb_vacuum_potential].
-    When ``probe`` is ``None``, creates a plain potential for states satisfying
-    [IsCoulombVacuumState][kups.potential.classical.coulomb.IsCoulombVacuumState].
-    When a ``probe`` is provided, wires incremental patch-based updates for the same state type.
-
-    Args:
-        state: Lens into the sub-state providing particles, systems, and neighbor list.
-        probe: Detects which particles and neighbor-list edges changed since the last step.
-            Pass ``None`` (default) for a non-incremental potential.
-        compute_position_and_cell_gradients: When ``True``, compute gradients
-            w.r.t. particle positions and lattice vectors.
-
-    Returns:
-        Configured Coulomb vacuum [Potential][kups.core.potential.Potential].
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[CoulombVacuumInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    if probe is not None:
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-    cutoff_view = state.focus(lambda x: x.coulomb_cutoff)
-
-    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
-        return neighborlist_factory(state(s), cutoff_view(s))
-
-    return make_coulomb_vacuum_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.systems),
-        neighborlist_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view,
-    )

--- a/src/kups/potential/classical/dihedral.py
+++ b/src/kups/potential/classical/dihedral.py
@@ -20,40 +20,32 @@ where:
 - $\\phi_0$ is the equilibrium dihedral angle
 """
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import jax.numpy as jnp
 from jax import Array
 
 from kups.core.cell import AnyPeriodicity
 from kups.core.data import Index, Table
-from kups.core.lens import Lens, SimpleLens, View
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
-    EMPTY_LENS,
-    EmptyType,
     Energy,
     Potential,
     PotentialOut,
-    empty_patch_idx_view,
 )
 from kups.core.typing import (
-    HasCache,
     HasCell,
     HasPositionsAndLabels,
-    IsState,
     Label,
-    MaybeCached,
     ParticleId,
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field
 from kups.potential.common.energy import (
     EnergyFunction,
-    PositionAndCell,
     PotentialFromEnergy,
-    position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
     GraphConstructor,
@@ -331,119 +323,6 @@ def make_dihedral_potential[
         patch_idx_view=patch_idx_view,
     )
     return potential
-
-
-class IsDihedralState[Params](
-    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
-):
-    """Protocol for states providing full-evaluation dihedral inputs."""
-
-    @property
-    def dihedral_edge_indices(self) -> Index[ParticleId]: ...
-    @property
-    def dihedral_parameters(self) -> Params: ...
-
-
-@overload
-def make_dihedral_from_state[State](
-    state: Lens[State, IsDihedralState[MaybeCached[DihedralParameters, Any]]],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_dihedral_from_state[State](
-    state: Lens[State, IsDihedralState[MaybeCached[DihedralParameters, Any]]],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_dihedral_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsDihedralState[
-            HasCache[DihedralParameters, PotentialOut[EmptyType, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_dihedral_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsDihedralState[
-            HasCache[DihedralParameters, PotentialOut[PositionAndCell, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_dihedral_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-) -> Any:
-    """Create a dihedral potential from a typed state, optionally with incremental updates.
-
-    Args:
-        state: Lens into the sub-state providing particles, cell, dihedral
-            indices, and dihedral parameters.
-        probe: If provided, detects particle changes and supplies the
-            before/after fixed-edge neighbor lists for incremental updates.
-            Those neighbor lists carry any required update capacity.
-        compute_position_and_cell_gradients: When True, computes gradients
-            w.r.t. particle positions and lattice vectors.
-
-    Returns:
-        Configured dihedral [Potential][kups.core.potential.Potential].
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[DihedralInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    param_view = state.focus(
-        lambda x: (
-            x.dihedral_parameters.data
-            if isinstance(x.dihedral_parameters, HasCache)
-            else x.dihedral_parameters
-        )
-    )
-    cache_view = None
-    if probe is not None:
-        param_view = state.focus(lambda x: x.dihedral_parameters.data)
-        cache_view = state.focus(lambda x: x.dihedral_parameters.cache)
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-    return make_dihedral_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.dihedral_edge_indices),
-        state.focus(lambda x: x.systems),
-        param_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view=patch_idx_view,
-        out_cache_lens=cache_view,
-    )
 
 
 if TYPE_CHECKING:

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -18,7 +18,6 @@ from typing import (
     Callable,
     Literal,
     Protocol,
-    overload,
 )
 
 import einops
@@ -36,32 +35,23 @@ from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import Lens, NestedLens, SimpleLens, View, bind
 from kups.core.neighborlist import (
     EmptyNeighborList,
-    IsAdaptiveCutoffNeighborListState,
-    IsUniversalNeighborlistParams,
     NeighborList,
-    NeighborListFactory,
-    adaptive_cutoff_neighborlist_from_state,
     all_connected_neighborlist,
 )
 from kups.core.patch import Accept, IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
     EMPTY,
     EMPTY_LENS,
-    EmptyType,
     Energy,
     Potential,
     PotentialOut,
     SummedPotential,
-    empty_patch_idx_view,
 )
 from kups.core.typing import (
     ExclusionId,
-    HasCache,
     HasCell,
     HasCharges,
     InclusionId,
-    IsState,
-    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -72,12 +62,10 @@ from kups.core.utils.ops import where_broadcast_last
 from kups.potential.classical.coulomb import _pairwise_coulomb_energy
 from kups.potential.common.energy import (
     EnergyFunction,
-    PositionAndCell,
     PotentialFromEnergy,
     Sum,
     SumComposer,
     Summand,
-    position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
     GraphConstructor,
@@ -1063,151 +1051,6 @@ def make_ewald_potential[
             (sr_potential, lr_potential, self_potential, exclusion_correction)
         )
     return EwaldPotential((sr_potential, lr_potential, self_potential))
-
-
-class IsEwaldState[Params](
-    IsState[IsEwaldPointData, HasCell[Periodic3D]],
-    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
-    Protocol,
-):
-    """Protocol for states providing all inputs for the Ewald potential."""
-
-    @property
-    def ewald_parameters(self) -> Params: ...
-
-
-@overload
-def make_ewald_from_state[State](
-    state: Lens[State, IsEwaldState[MaybeCached[EwaldParameters, Any]]],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-    include_exclusion_mask: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        IsEwaldState[MaybeCached[EwaldParameters, Any]]
-    ] = ...,
-) -> EwaldPotential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_ewald_from_state[State](
-    state: Lens[State, IsEwaldState[MaybeCached[EwaldParameters, Any]]],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-    include_exclusion_mask: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        IsEwaldState[MaybeCached[EwaldParameters, Any]]
-    ] = ...,
-) -> EwaldPotential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_ewald_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State, IsEwaldState[HasCache[EwaldParameters, EwaldCache[EmptyType, EmptyType]]]
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsEwaldPointData, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-    include_exclusion_mask: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        IsEwaldState[HasCache[EwaldParameters, EwaldCache[EmptyType, EmptyType]]]
-    ] = ...,
-) -> EwaldPotential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_ewald_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsEwaldState[HasCache[EwaldParameters, EwaldCache[PositionAndCell, EmptyType]]],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsEwaldPointData, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-    include_exclusion_mask: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        IsEwaldState[HasCache[EwaldParameters, EwaldCache[PositionAndCell, EmptyType]]]
-    ] = ...,
-) -> EwaldPotential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_ewald_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-    include_exclusion_mask: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        Any
-    ] = adaptive_cutoff_neighborlist_from_state,
-) -> Any:
-    """Create an Ewald potential from a typed state, optionally with incremental updates.
-
-    When ``probe`` is ``None``, builds a static potential by extracting
-    components directly from the state.  When a probe is provided, the
-    potential supports incremental (cached) evaluation via the probe's
-    patch mechanism.
-
-    Args:
-        state: Lens focusing on the Ewald state (particles, systems,
-            neighborlist, and ewald_parameters).
-        probe: Probe for incremental updates. ``None`` for a static
-            potential.
-        compute_position_and_cell_gradients: When ``True``, the
-            returned potential computes gradients w.r.t. particle
-            positions and lattice vectors (for forces / stress).
-            Gradient type becomes ``PositionAndCell``.
-        include_exclusion_mask: Whether to include the exclusion
-            correction term in the returned potential.
-
-    Returns:
-        An ``EwaldPotential`` combining short-range, long-range,
-        self-energy, and (optionally) exclusion-correction terms.
-        Gradient type is ``PositionAndCell`` when gradients are
-        requested, ``EmptyType`` otherwise.
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view = empty_patch_idx_view
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[
-            PointCloud[IsEwaldPointData, HasCell[Periodic3D]], PositionAndCell
-        ](
-            lambda pc: PositionAndCell(
-                pc.particles.map_data(lambda p: p.positions),
-                pc.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    param_view = state.focus(
-        lambda x: (
-            x.ewald_parameters.data
-            if isinstance(x.ewald_parameters, HasCache)
-            else x.ewald_parameters
-        )
-    )
-    cache_view = None
-    if probe is not None:
-        param_view = state.focus(lambda x: x.ewald_parameters.data)
-        cache_view = state.focus(lambda x: x.ewald_parameters.cache)
-
-    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
-        return neighborlist_factory(state(s), param_view(s).cutoff)
-
-    return make_ewald_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.systems),
-        neighborlist_view,
-        param_view,
-        cache_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view=patch_idx_view,
-        include_exclusion_mask=include_exclusion_mask,
-    )
 
 
 @dataclass

--- a/src/kups/potential/classical/harmonic.py
+++ b/src/kups/potential/classical/harmonic.py
@@ -11,40 +11,32 @@ Bond potential: $U(r) = k(r - r_0)^2$
 Angle potential: $U(\\theta) = k(\\theta - \\theta_0)^2$
 """
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import jax.numpy as jnp
 from jax import Array
 
 from kups.core.cell import AnyPeriodicity
 from kups.core.data import Index, Table
-from kups.core.lens import Lens, SimpleLens, View
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
-    EMPTY_LENS,
-    EmptyType,
     Energy,
     Potential,
     PotentialOut,
-    empty_patch_idx_view,
 )
 from kups.core.typing import (
-    HasCache,
     HasCell,
     HasPositionsAndLabels,
-    IsState,
     Label,
-    MaybeCached,
     ParticleId,
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field
 from kups.potential.common.energy import (
     EnergyFunction,
-    PositionAndCell,
     PotentialFromEnergy,
-    position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
     GraphConstructor,
@@ -285,261 +277,6 @@ def make_harmonic_angle_potential[
         patch_idx_view=patch_idx_view,
     )
     return potential
-
-
-class HasBondedParticlesAndSystems(
-    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
-): ...
-
-
-class IsHarmonicBondState[Params](HasBondedParticlesAndSystems, Protocol):
-    """Protocol for states providing full-evaluation harmonic bond inputs."""
-
-    @property
-    def harmonic_bond_indices(self) -> Index[ParticleId]: ...
-    @property
-    def harmonic_bond_parameters(self) -> Params: ...
-
-
-@overload
-def make_harmonic_bond_from_state[State](
-    state: Lens[
-        State,
-        IsHarmonicBondState[MaybeCached[HarmonicBondParameters, Any]],
-    ],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_harmonic_bond_from_state[State](
-    state: Lens[
-        State,
-        IsHarmonicBondState[MaybeCached[HarmonicBondParameters, Any]],
-    ],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_harmonic_bond_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsHarmonicBondState[
-            HasCache[HarmonicBondParameters, PotentialOut[EmptyType, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_harmonic_bond_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsHarmonicBondState[
-            HasCache[HarmonicBondParameters, PotentialOut[PositionAndCell, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_harmonic_bond_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-) -> Any:
-    """Create a harmonic bond potential, optionally with incremental updates.
-
-    Convenience wrapper around
-    [make_harmonic_bond_potential][kups.potential.classical.harmonic.make_harmonic_bond_potential].
-    When `probe` is `None`, builds a plain potential from
-    [IsHarmonicBondState][kups.potential.classical.harmonic.IsHarmonicBondState].
-    When a `probe` is provided, builds an incrementally-updated potential from
-    a state with `HasCache`-wrapped parameters.
-
-    Args:
-        state: Lens into the sub-state providing particles, cell, bond indices,
-            and harmonic bond parameters.
-        probe: If provided, detects particle changes and supplies the
-            before/after fixed-edge neighbor lists for incremental updates.
-            Those neighbor lists carry any required update capacity.
-        compute_position_and_cell_gradients: When ``True``, the returned
-            potential computes gradients w.r.t. particle positions and lattice
-            vectors (for forces / stress).
-
-    Returns:
-        Configured harmonic bond [Potential][kups.core.potential.Potential].
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[HarmonicBondInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    param_view = state.focus(
-        lambda x: (
-            x.harmonic_bond_parameters.data
-            if isinstance(x.harmonic_bond_parameters, HasCache)
-            else x.harmonic_bond_parameters
-        )
-    )
-    cache_view = None
-    if probe is not None:
-        param_view = state.focus(lambda x: x.harmonic_bond_parameters.data)
-        cache_view = state.focus(lambda x: x.harmonic_bond_parameters.cache)
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-    return make_harmonic_bond_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.bond_edge_indices),
-        state.focus(lambda x: x.systems),
-        param_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view=patch_idx_view,
-        out_cache_lens=cache_view,
-    )
-
-
-class IsHarmonicAngleState[Params](HasBondedParticlesAndSystems, Protocol):
-    """Protocol for states providing full-evaluation harmonic angle inputs."""
-
-    @property
-    def harmonic_angle_indices(self) -> Index[ParticleId]: ...
-    @property
-    def harmonic_angle_parameters(self) -> Params: ...
-
-
-@overload
-def make_harmonic_angle_from_state[State](
-    state: Lens[
-        State,
-        IsHarmonicAngleState[MaybeCached[HarmonicAngleParameters, Any]],
-    ],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_harmonic_angle_from_state[State](
-    state: Lens[
-        State,
-        IsHarmonicAngleState[MaybeCached[HarmonicAngleParameters, Any]],
-    ],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_harmonic_angle_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsHarmonicAngleState[
-            HasCache[HarmonicAngleParameters, PotentialOut[EmptyType, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_harmonic_angle_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsHarmonicAngleState[
-            HasCache[HarmonicAngleParameters, PotentialOut[PositionAndCell, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_harmonic_angle_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-) -> Any:
-    """Create a harmonic angle potential, optionally with incremental updates.
-
-    Convenience wrapper around
-    [make_harmonic_angle_potential][kups.potential.classical.harmonic.make_harmonic_angle_potential].
-    When `probe` is `None`, builds a plain potential from
-    [IsHarmonicAngleState][kups.potential.classical.harmonic.IsHarmonicAngleState].
-    When a `probe` is provided, builds an incrementally-updated potential from
-    a state with `HasCache`-wrapped parameters.
-
-    Args:
-        state: Lens into the sub-state providing particles, cell, angle indices,
-            and harmonic angle parameters.
-        probe: If provided, detects particle changes and supplies the
-            before/after fixed-edge neighbor lists for incremental updates.
-            Those neighbor lists carry any required update capacity.
-        compute_position_and_cell_gradients: When ``True``, the returned
-            potential computes gradients w.r.t. particle positions and lattice
-            vectors (for forces / stress).
-
-    Returns:
-        Configured harmonic angle [Potential][kups.core.potential.Potential].
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[HarmonicAngleInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    param_view = state.focus(
-        lambda x: (
-            x.harmonic_angle_parameters.data
-            if isinstance(x.harmonic_angle_parameters, HasCache)
-            else x.harmonic_angle_parameters
-        )
-    )
-    cache_view = None
-    if probe is not None:
-        param_view = state.focus(lambda x: x.harmonic_angle_parameters.data)
-        cache_view = state.focus(lambda x: x.harmonic_angle_parameters.cache)
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-    return make_harmonic_angle_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.angle_edge_indices),
-        state.focus(lambda x: x.systems),
-        param_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view=patch_idx_view,
-        out_cache_lens=cache_view,
-    )
 
 
 if TYPE_CHECKING:

--- a/src/kups/potential/classical/inversion.py
+++ b/src/kups/potential/classical/inversion.py
@@ -33,40 +33,32 @@ Note: The UFF paper specifies that when all 3 inversions per center are used
 (IJ/IKL, IK/IJL, IL/IJK), each barrier should be divided by 3.
 """
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import jax.numpy as jnp
 from jax import Array
 
 from kups.core.cell import AnyPeriodicity
 from kups.core.data import Index, Table
-from kups.core.lens import Lens, SimpleLens, View
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
-    EMPTY_LENS,
-    EmptyType,
     Energy,
     Potential,
     PotentialOut,
-    empty_patch_idx_view,
 )
 from kups.core.typing import (
-    HasCache,
     HasCell,
     HasPositionsAndLabels,
-    IsState,
     Label,
-    MaybeCached,
     ParticleId,
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field
 from kups.potential.common.energy import (
     EnergyFunction,
-    PositionAndCell,
     PotentialFromEnergy,
-    position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
     GraphConstructor,
@@ -265,125 +257,6 @@ def make_inversion_potential[
         patch_idx_view=patch_idx_view,
     )
     return potential
-
-
-class IsInversionState[Params](
-    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
-):
-    """Protocol for states providing full-evaluation inversion inputs."""
-
-    @property
-    def inversion_edge_indices(self) -> Index[ParticleId]: ...
-    @property
-    def inversion_parameters(self) -> Params: ...
-
-
-@overload
-def make_inversion_from_state[State](
-    state: Lens[
-        State,
-        IsInversionState[MaybeCached[InversionParameters, Any]],
-    ],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_inversion_from_state[State](
-    state: Lens[
-        State,
-        IsInversionState[MaybeCached[InversionParameters, Any]],
-    ],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_inversion_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsInversionState[
-            HasCache[InversionParameters, PotentialOut[EmptyType, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_inversion_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsInversionState[
-            HasCache[InversionParameters, PotentialOut[PositionAndCell, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_inversion_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-) -> Any:
-    """Create an inversion potential, optionally with incremental updates.
-
-    Args:
-        state: Lens into the sub-state providing particles, cell, inversion
-            indices, and inversion parameters.
-        probe: If provided, detects particle changes and supplies the
-            before/after fixed-edge neighbor lists for incremental updates.
-            Those neighbor lists carry any required update capacity.
-        compute_position_and_cell_gradients: When True, computes gradients
-            w.r.t. particle positions and lattice vectors.
-
-    Returns:
-        Configured inversion [Potential][kups.core.potential.Potential].
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[InversionInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    param_view = state.focus(
-        lambda x: (
-            x.inversion_parameters.data
-            if isinstance(x.inversion_parameters, HasCache)
-            else x.inversion_parameters
-        )
-    )
-    cache_view = None
-    if probe is not None:
-        param_view = state.focus(lambda x: x.inversion_parameters.data)
-        cache_view = state.focus(lambda x: x.inversion_parameters.cache)
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-    return make_inversion_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.inversion_edge_indices),
-        state.focus(lambda x: x.systems),
-        param_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view=patch_idx_view,
-        out_cache_lens=cache_view,
-    )
 
 
 if TYPE_CHECKING:

--- a/src/kups/potential/classical/lennard_jones.py
+++ b/src/kups/potential/classical/lennard_jones.py
@@ -22,7 +22,6 @@ from typing import (
     Protocol,
     assert_never,
     cast,
-    overload,
     override,
     runtime_checkable,
 )
@@ -32,45 +31,33 @@ from jax import Array
 
 from kups.core.cell import AnyPeriodicity
 from kups.core.data import Table
-from kups.core.lens import Lens, SimpleLens, View, identity_lens
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import (
     EmptyNeighborList,
-    IsAdaptiveCutoffNeighborListState,
-    IsUniversalNeighborlistParams,
     NeighborList,
-    NeighborListFactory,
-    adaptive_cutoff_neighborlist_from_state,
 )
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
-    EMPTY_LENS,
-    EmptyType,
     Energy,
     Potential,
     PotentialOut,
-    empty_patch_idx_view,
 )
 from kups.core.propagator import StateProperty
 from kups.core.typing import (
-    HasCache,
     HasCell,
     HasExclusionIndex,
     HasInclusionIndex,
     HasLabels,
     HasPositions,
     HasSystemIndex,
-    IsState,
     Label,
-    MaybeCached,
     ParticleId,
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field, jit
 from kups.potential.common.energy import (
     EnergyFunction,
-    PositionAndCell,
     PotentialFromEnergy,
-    position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
     FullGraphSumComposer,
@@ -400,143 +387,6 @@ def make_lennard_jones_potential[
     )
 
 
-class HasLJParticlesAndSystems(
-    IsState[IsLJGraphParticles, HasCell[AnyPeriodicity]], Protocol
-): ...
-
-
-class IsLJState[Params](
-    HasLJParticlesAndSystems,
-    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
-    Protocol,
-):
-    """State with particles, systems, neighbor list, and LJ parameters."""
-
-    @property
-    def lj_parameters(self) -> Params: ...
-
-
-@overload
-def make_lennard_jones_from_state[State](
-    state: Lens[State, IsLJState[MaybeCached[LennardJonesParameters, Any]]],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-    neighborlist_factory: NeighborListFactory[
-        IsLJState[MaybeCached[LennardJonesParameters, Any]]
-    ] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_lennard_jones_from_state[State](
-    state: Lens[State, IsLJState[MaybeCached[LennardJonesParameters, Any]]],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-    neighborlist_factory: NeighborListFactory[
-        IsLJState[MaybeCached[LennardJonesParameters, Any]]
-    ] = ...,
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_lennard_jones_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsLJState[HasCache[LennardJonesParameters, PotentialOut[EmptyType, EmptyType]]],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-    neighborlist_factory: NeighborListFactory[
-        IsLJState[HasCache[LennardJonesParameters, PotentialOut[EmptyType, EmptyType]]]
-    ] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_lennard_jones_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsLJState[
-            HasCache[LennardJonesParameters, PotentialOut[PositionAndCell, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-    neighborlist_factory: NeighborListFactory[
-        IsLJState[
-            HasCache[LennardJonesParameters, PotentialOut[PositionAndCell, EmptyType]]
-        ]
-    ] = ...,
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_lennard_jones_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        Any
-    ] = adaptive_cutoff_neighborlist_from_state,
-) -> Any:
-    """Create a LJ potential from a typed state, optionally with incremental updates.
-
-    Args:
-        state: Lens into the sub-state providing particles, systems, neighbor list,
-            and LJ parameters.
-        probe: Detects which particles changed since the last step.
-            ``None`` for full recomputation.
-        compute_position_and_cell_gradients: When ``True``, the returned
-            potential computes gradients w.r.t. particle positions and lattice
-            vectors. Gradient type becomes ``PositionAndCell``.
-
-    Returns:
-        Configured Lennard-Jones potential.
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[LJRadiusInp, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    param_view = state.focus(
-        lambda x: (
-            x.lj_parameters.data
-            if isinstance(x.lj_parameters, HasCache)
-            else x.lj_parameters
-        )
-    )
-    cache_view = None
-    if probe is not None:
-        param_view = state.focus(lambda x: x.lj_parameters.data)
-        cache_view = state.focus(lambda x: x.lj_parameters.cache)
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-
-    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
-        return neighborlist_factory(state(s), param_view(s).cutoff)
-
-    return make_lennard_jones_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.systems),
-        neighborlist_view,
-        param_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view,
-        cache_view,
-    )
-
-
 type PCLJInp = GraphPotentialInput[
     PairTailCorrectedLennardJonesParameters,
     IsLJGraphParticles,
@@ -622,80 +472,6 @@ def make_global_lennard_jones_tail_correction_potential[State, Gradients, Hessia
     )
 
 
-type IsGlobalTailCorrectedIsLJState = IsLJState[
-    MaybeCached[
-        GlobalTailCorrectedLennardJonesParameters,
-        PotentialOut[Any, Any],
-    ]
-]
-
-
-@overload
-def make_lennard_jones_tail_correction_from_state[
-    InState,
-    State: IsGlobalTailCorrectedIsLJState,
-](
-    state: Lens[InState, State],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[InState, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_lennard_jones_tail_correction_from_state[
-    InState,
-    State: IsGlobalTailCorrectedIsLJState,
-](
-    state: Lens[InState, State],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[InState, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-def make_lennard_jones_tail_correction_from_state(
-    state: Any,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-) -> Any:
-    """Create a global tail-corrected LJ potential from a typed state.
-
-    Args:
-        state: Lens into the sub-state providing particles, systems, and
-            LJ tail correction parameters.
-        compute_position_and_cell_gradients: When ``True``, the returned
-            potential computes gradients w.r.t. particle positions and lattice
-            vectors. Gradient type becomes ``PositionAndCell``.
-
-    Returns:
-        Configured tail-corrected Lennard-Jones potential.
-    """
-    gradient_lens: Any = EMPTY_LENS
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[GCLJInp, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-    return make_global_lennard_jones_tail_correction_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.systems),
-        cast(
-            Any,
-            state.focus(
-                lambda x: (
-                    x.lj_parameters.data
-                    if isinstance(x.lj_parameters, HasCache)
-                    else x.lj_parameters
-                )
-            ),
-        ),
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-    )
-
-
 def make_global_lennard_jones_tail_correction_pressure[State](
     particles_view: View[State, Table[ParticleId, IsLJGraphParticles]],
     systems_view: View[State, Table[SystemId, HasCell[AnyPeriodicity]]],
@@ -718,27 +494,6 @@ def make_global_lennard_jones_tail_correction_pressure[State](
         ).data
 
     return pressure
-
-
-def global_lennard_jones_tail_correction_pressure_from_state(
-    key: Array, state: IsGlobalTailCorrectedIsLJState
-) -> Table[SystemId, Array]:
-    """Create long-range pressure correction from a typed state."""
-    state_lens = identity_lens(type(state))
-    return make_global_lennard_jones_tail_correction_pressure(
-        state_lens.focus(lambda x: x.particles),
-        state_lens.focus(lambda x: x.systems),
-        cast(
-            Any,
-            state_lens.focus(
-                lambda x: (
-                    x.lj_parameters.data
-                    if isinstance(x.lj_parameters, HasCache)
-                    else x.lj_parameters
-                )
-            ),
-        ),
-    )(key, state)
 
 
 if TYPE_CHECKING:

--- a/src/kups/potential/classical/morse.py
+++ b/src/kups/potential/classical/morse.py
@@ -17,31 +17,25 @@ dissociation behavior. Near equilibrium, Morse approximates harmonic
 with force constant $k = 2 D \\alpha^2$.
 """
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, overload, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import jax.numpy as jnp
 from jax import Array
 
 from kups.core.cell import AnyPeriodicity
 from kups.core.data import Index, Table
-from kups.core.lens import Lens, SimpleLens, View
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import FixedEdgesNeighborList
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import (
-    EMPTY_LENS,
-    EmptyType,
     Energy,
     Potential,
     PotentialOut,
-    empty_patch_idx_view,
 )
 from kups.core.typing import (
-    HasCache,
     HasCell,
     HasPositionsAndLabels,
-    IsState,
     Label,
-    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -49,9 +43,7 @@ from kups.core.utils.jax import dataclass, field
 from kups.potential.classical.uff_utils import compute_uff_bond_length
 from kups.potential.common.energy import (
     EnergyFunction,
-    PositionAndCell,
     PotentialFromEnergy,
-    position_and_cell_idx_view,
 )
 from kups.potential.common.graph import (
     GraphConstructor,
@@ -226,120 +218,6 @@ def make_morse_bond_potential[
         patch_idx_view=patch_idx_view,
     )
     return potential
-
-
-class IsMorseBondState[Params](
-    IsState[IsBondedParticles, HasCell[AnyPeriodicity]], Protocol
-):
-    """Protocol for states providing full-evaluation Morse bond inputs."""
-
-    @property
-    def bond_edge_indices(self) -> Index[ParticleId]: ...
-    @property
-    def morse_bond_parameters(self) -> Params: ...
-
-
-@overload
-def make_morse_bond_from_state[State](
-    state: Lens[State, IsMorseBondState[MaybeCached[MorseBondParameters, Any]]],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_morse_bond_from_state[State](
-    state: Lens[State, IsMorseBondState[MaybeCached[MorseBondParameters, Any]]],
-    probe: None = None,
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_morse_bond_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsMorseBondState[
-            HasCache[MorseBondParameters, PotentialOut[EmptyType, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-) -> Potential[State, EmptyType, EmptyType, P]: ...
-
-
-@overload
-def make_morse_bond_from_state[State, P: Patch[Any]](
-    state: Lens[
-        State,
-        IsMorseBondState[
-            HasCache[MorseBondParameters, PotentialOut[PositionAndCell, EmptyType]]
-        ],
-    ],
-    probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-) -> Potential[State, PositionAndCell, EmptyType, P]: ...
-
-
-def make_morse_bond_from_state(
-    state: Any,
-    probe: Any = None,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-) -> Any:
-    """Create a Morse bond potential from a typed state, optionally with incremental updates.
-
-    Args:
-        state: Lens into the sub-state providing particles, cell, bond indices,
-            and Morse bond parameters.
-        probe: If provided, detects particle changes and supplies the
-            before/after fixed-edge neighbor lists for incremental updates.
-            Those neighbor lists carry any required update capacity.
-        compute_position_and_cell_gradients: When ``True``, the returned
-            potential computes gradients w.r.t. particle positions and lattice
-            vectors (for forces / stress).
-
-    Returns:
-        Configured Morse bond [Potential][kups.core.potential.Potential].
-    """
-    gradient_lens: Any = EMPTY_LENS
-    patch_idx_view: Any = None
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[MorseBondInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-        patch_idx_view = position_and_cell_idx_view
-    param_view = state.focus(
-        lambda x: (
-            x.morse_bond_parameters.data
-            if isinstance(x.morse_bond_parameters, HasCache)
-            else x.morse_bond_parameters
-        )
-    )
-    cache_view = None
-    if probe is not None:
-        param_view = state.focus(lambda x: x.morse_bond_parameters.data)
-        cache_view = state.focus(lambda x: x.morse_bond_parameters.cache)
-        patch_idx_view = patch_idx_view or empty_patch_idx_view
-    return make_morse_bond_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.bond_edge_indices),
-        state.focus(lambda x: x.systems),
-        param_view,
-        probe,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
-        patch_idx_view=patch_idx_view,
-        out_cache_lens=cache_view,
-    )
 
 
 if TYPE_CHECKING:

--- a/src/kups/potential/mliap/local.py
+++ b/src/kups/potential/mliap/local.py
@@ -42,7 +42,7 @@ import json
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal, Protocol, overload
+from typing import Any, Literal, Protocol
 
 import jax
 import jax.numpy as jnp
@@ -53,21 +53,14 @@ from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import Lens, View, bind
 from kups.core.neighborlist import (
     Edges,
-    IsAdaptiveCutoffNeighborListState,
-    IsUniversalNeighborlistParams,
     NeighborList,
-    NeighborListFactory,
-    adaptive_cutoff_neighborlist_from_state,
 )
 from kups.core.patch import Accept, Patch, Probe, WithPatch
-from kups.core.potential import EMPTY_LENS, Energy, Potential, PotentialOut
+from kups.core.potential import Energy, Potential, PotentialOut
 from kups.core.typing import (
-    HasCache,
     HasCell,
     HasPositionsAndAtomicNumbers,
     HasSystemIndex,
-    IsState,
-    MaybeCached,
     ParticleId,
     SystemId,
 )
@@ -595,139 +588,3 @@ def make_local_mliap_potential[
         patch_idx_view=patch_idx_view,
     )
     return potential
-
-
-class IsLocalMLIAPState[Model](
-    IsState[IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
-    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
-    Protocol,
-):
-    """Protocol for states providing all inputs for the local MLIAP potential."""
-
-    @property
-    def local_mliap_model(self) -> Model: ...
-
-
-@overload
-def make_local_mliap_from_state[State, Gradient, Hessian](
-    state: Lens[State, IsLocalMLIAPState[MaybeCached[LocalMLIAPData, Any]]],
-    probe: None = None,
-    gradient_lens: Lens[
-        LocalMLIAPInput[State, IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
-        Gradient,
-    ] = ...,
-    hessian_lens: Lens[Gradient, Hessian] = ...,
-    hessian_idx_view: Lens[State, Hessian] = ...,
-    out_idx_view: None = None,
-    *,
-    neighborlist_factory: NeighborListFactory[
-        IsLocalMLIAPState[MaybeCached[LocalMLIAPData, Any]]
-    ] = ...,
-) -> Potential[State, Gradient, Hessian, Patch[Any]]: ...
-
-
-@overload
-def make_local_mliap_from_state[State, Ptch: Patch[Any], Gradient, Hessian](
-    state: Lens[
-        State,
-        IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut[Gradient, Hessian]]],
-    ],
-    probe: Probe[State, Ptch, IsGraphProbe[IsLocalMLIAPGraphParticles, Literal[2]]],
-    gradient_lens: Lens[
-        LocalMLIAPInput[State, IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
-        Gradient,
-    ] = ...,
-    hessian_lens: Lens[Gradient, Hessian] = ...,
-    hessian_idx_view: Lens[State, Hessian] = ...,
-    out_idx_view: Lens[State, PotentialOut[Gradient, Hessian]] | None = None,
-    *,
-    neighborlist_factory: NeighborListFactory[
-        IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut[Gradient, Hessian]]]
-    ] = ...,
-) -> Potential[State, Gradient, Hessian, Ptch]: ...
-
-
-def make_local_mliap_from_state(
-    state: Any,
-    probe: Any = None,
-    gradient_lens: Any = EMPTY_LENS,
-    hessian_lens: Any = EMPTY_LENS,
-    hessian_idx_view: Any = EMPTY_LENS,
-    out_idx_view: Any = None,
-    *,
-    neighborlist_factory: NeighborListFactory[
-        Any
-    ] = adaptive_cutoff_neighborlist_from_state,
-) -> Any:
-    """Create a local MLIAP potential from a typed state, optionally with incremental updates.
-
-    Convenience wrapper around
-    [make_local_mliap_potential][kups.potential.mliap.local.make_local_mliap_potential].
-    When ``probe`` is ``None``, extracts views from a state satisfying
-    [IsLocalMLIAPState][kups.potential.mliap.local.IsLocalMLIAPState].
-    When ``probe`` is provided, additionally wires the ``PotentialOut`` cache for
-    efficient incremental caching across Monte Carlo steps.
-
-    Args:
-        state: Lens into the sub-state providing particles, cell, neighbor list,
-            and local MLIAP model.
-        probe: Detects which particles and neighbor-list edges changed since the last
-            step. ``None`` for full-only computation.
-        gradient_lens: Specifies which gradients to compute (e.g., forces).
-        hessian_lens: Specifies which Hessians to compute.
-        hessian_idx_view: Index structure for Hessian updates.
-        out_idx_view: Index into the cached output for partial updates. Only used when
-            ``probe`` is not ``None``. Defaults to full re-indexing of
-            ``local_mliap_out_cache.total_energies``.
-
-    Returns:
-        Configured local MLIAP [Potential][kups.core.potential.Potential].
-    """
-
-    def _model(x: Any) -> LocalMLIAPData:
-        m = x.local_mliap_model
-        return m.data if isinstance(m, HasCache) else m
-
-    if probe is None:
-        model_lens = state.focus(_model)
-
-        def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
-            return neighborlist_factory(state(s), model_lens(s).cutoff)
-
-        return make_local_mliap_potential(
-            state.focus(lambda x: x.particles),
-            state.focus(lambda x: x.systems),
-            neighborlist_view,
-            model_lens,
-            None,
-            gradient_lens,
-            hessian_lens,
-            hessian_idx_view,
-            None,
-            None,
-        )
-
-    if out_idx_view is None:
-        out_idx_view = state.focus(
-            lambda x: bind(
-                x.local_mliap_model.cache, lambda x: x.total_energies.data
-            ).apply(lambda x: jnp.arange(x.size, dtype=int))
-        )
-
-    model_lens = state.focus(lambda x: x.local_mliap_model.data)
-
-    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
-        return neighborlist_factory(state(s), model_lens(s).cutoff)
-
-    return make_local_mliap_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.systems),
-        neighborlist_view,
-        model_lens,
-        probe,
-        gradient_lens,
-        hessian_lens,
-        hessian_idx_view,
-        out_idx_view,
-        state.focus(lambda x: x.local_mliap_model.cache),
-    )

--- a/src/kups/potential/mliap/tojax.py
+++ b/src/kups/potential/mliap/tojax.py
@@ -11,7 +11,7 @@ systems with graph-based atomic representations.
 import json
 import zipfile
 from pathlib import Path
-from typing import Any, Literal, Protocol, TypedDict, overload
+from typing import Any, Literal, Protocol, TypedDict
 
 import jax
 import jax.numpy as jnp
@@ -19,20 +19,16 @@ from jax import Array, export
 
 from kups.core.cell import AnyPeriodicity
 from kups.core.data import Table
-from kups.core.lens import Lens, SimpleLens, View
+from kups.core.lens import Lens, View
 from kups.core.neighborlist import (
-    IsAdaptiveCutoffNeighborListState,
-    IsUniversalNeighborlistParams,
     NeighborList,
-    NeighborListFactory,
-    adaptive_cutoff_neighborlist_from_state,
 )
 from kups.core.patch import IdPatch, Patch, WithPatch
-from kups.core.potential import EMPTY_LENS, EmptyType, Energy, Potential, PotentialOut
-from kups.core.typing import HasAtomicNumbers, HasCell, IsState, ParticleId, SystemId
+from kups.core.potential import Energy, PotentialOut
+from kups.core.typing import HasAtomicNumbers, HasCell, ParticleId, SystemId
 from kups.core.utils.jax import dataclass, field, sequential_vmap_with_vjp
 from kups.core.utils.msgpack import deserialize as msgpack_deserialize
-from kups.potential.common.energy import PositionAndCell, PotentialFromEnergy
+from kups.potential.common.energy import PotentialFromEnergy
 from kups.potential.common.graph import (
     FullGraphSumComposer,
     GraphConstructor,
@@ -220,77 +216,4 @@ def make_tojaxed_potential[State, Gradients, Hessians](
         hessian_idx_view=hessian_idx_view,
         cache_lens=out_cache_lens,
         patch_idx_view=patch_idx_view,
-    )
-
-
-class IsTojaxedState(
-    IsState[IsTojaxedParticles, HasCell[AnyPeriodicity]],
-    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
-    Protocol,
-):
-    """Protocol for states providing all inputs for the jaxified potential."""
-
-    @property
-    def jaxified_model(self) -> TojaxedMliap: ...
-
-
-@overload
-def make_tojaxed_from_state[State](
-    state: Lens[State, IsTojaxedState],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-    neighborlist_factory: NeighborListFactory[IsTojaxedState] = ...,
-) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_tojaxed_from_state[State](
-    state: Lens[State, IsTojaxedState],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-    neighborlist_factory: NeighborListFactory[IsTojaxedState] = ...,
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-def make_tojaxed_from_state(
-    state: Any,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        Any
-    ] = adaptive_cutoff_neighborlist_from_state,
-) -> Any:
-    """Create a jaxified potential from a typed state.
-
-    Args:
-        state: Lens into the sub-state providing particles, cell,
-            neighbor list, and jaxified model.
-        compute_position_and_cell_gradients: When ``True``, compute
-            gradients w.r.t. particle positions and cell
-            (for forces / stress).
-
-    Returns:
-        Configured jaxified [Potential][kups.core.potential.Potential].
-    """
-    gradient_lens: Any = EMPTY_LENS
-    if compute_position_and_cell_gradients:
-        gradient_lens = SimpleLens[JaxifiedInput, PositionAndCell](
-            lambda x: PositionAndCell(
-                x.graph.particles.map_data(lambda p: p.positions),
-                x.graph.systems.map_data(lambda s: s.cell),
-            )
-        )
-    model_view = state.focus(lambda x: x.jaxified_model)
-
-    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
-        return neighborlist_factory(state(s), model_view(s).cutoff)
-
-    return make_tojaxed_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.systems),
-        neighborlist_view,
-        model_view,
-        gradient_lens,
-        EMPTY_LENS,
-        EMPTY_LENS,
     )

--- a/src/kups/potential/mliap/torch/__init__.py
+++ b/src/kups/potential/mliap/torch/__init__.py
@@ -11,7 +11,8 @@ extraction, padding, and kUPS ``Potential`` wiring is shared.
 
 Example:
     ```python
-    from kups.potential.mliap.torch import load_mace, make_torch_mliap_from_state
+    from kups.application.potential.mliap.torch import make_torch_mliap_from_state
+    from kups.potential.mliap.torch import load_mace
 
     model = load_mace("mace.model", compute_cell_gradients=True)
     potential = make_torch_mliap_from_state(
@@ -25,11 +26,9 @@ Requires the ``torch_dev`` dependency group: ``uv sync --group torch_dev``.
 from kups.potential.mliap.torch.interface import (
     AtomGraphInput,
     IsTorchMliapParticles,
-    IsTorchMliapState,
     TorchMliap,
     TorchMliapForward,
     lattice_gradient_from_virial,
-    make_torch_mliap_from_state,
     make_torch_mliap_potential,
     torch_mliap_model_fn,
 )
@@ -44,7 +43,6 @@ from kups.potential.mliap.torch.uma import (
 __all__ = [
     "AtomGraphInput",
     "IsTorchMliapParticles",
-    "IsTorchMliapState",
     "MACEModule",
     "TorchMliap",
     "TorchMliapForward",
@@ -54,7 +52,6 @@ __all__ = [
     "lattice_gradient_from_virial",
     "load_mace",
     "load_uma",
-    "make_torch_mliap_from_state",
     "make_torch_mliap_potential",
     "torch_mliap_model_fn",
 ]

--- a/src/kups/potential/mliap/torch/interface.py
+++ b/src/kups/potential/mliap/torch/interface.py
@@ -42,18 +42,13 @@ from kups.core.cell import AnyPeriodicity, Cell
 from kups.core.data import Table
 from kups.core.lens import Lens, View, bind
 from kups.core.neighborlist import (
-    IsAdaptiveCutoffNeighborListState,
-    IsUniversalNeighborlistParams,
     NeighborList,
-    NeighborListFactory,
-    adaptive_cutoff_neighborlist_from_state,
 )
 from kups.core.patch import IdPatch, Patch, WithPatch
 from kups.core.potential import EMPTY, EmptyType, Potential, PotentialOut
 from kups.core.typing import (
     HasAtomicNumbers,
     HasCell,
-    IsState,
     ParticleId,
     SystemId,
 )
@@ -70,11 +65,9 @@ from kups.potential.mliap.direct import make_direct_mliap_potential
 __all__ = [
     "AtomGraphInput",
     "IsTorchMliapParticles",
-    "IsTorchMliapState",
     "TorchMliap",
     "TorchMliapForward",
     "lattice_gradient_from_virial",
-    "make_torch_mliap_from_state",
     "make_torch_mliap_potential",
     "torch_mliap_model_fn",
 ]
@@ -465,67 +458,4 @@ def make_torch_mliap_potential(
         model_view=model_view,
         patch_idx_view=patch_idx_view,
         out_cache_lens=out_cache_lens,
-    )
-
-
-class IsTorchMliapState(
-    IsState[IsTorchMliapParticles, HasCell[AnyPeriodicity]],
-    IsAdaptiveCutoffNeighborListState[IsUniversalNeighborlistParams],
-    Protocol,
-):
-    """Protocol for states providing all inputs for a torch MLFF potential."""
-
-    @property
-    def torch_mliap_model(self) -> TorchMliap: ...
-
-
-@overload
-def make_torch_mliap_from_state[State](
-    state: Lens[State, IsTorchMliapState],
-    *,
-    compute_position_and_cell_gradients: Literal[False] = ...,
-    neighborlist_factory: NeighborListFactory[IsTorchMliapState] = ...,
-) -> Potential[State, Array, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_torch_mliap_from_state[State](
-    state: Lens[State, IsTorchMliapState],
-    *,
-    compute_position_and_cell_gradients: Literal[True],
-    neighborlist_factory: NeighborListFactory[IsTorchMliapState] = ...,
-) -> Potential[State, PositionAndCell, EmptyType, Patch[Any]]: ...
-
-
-def make_torch_mliap_from_state(
-    state: Any,
-    *,
-    compute_position_and_cell_gradients: bool = False,
-    neighborlist_factory: NeighborListFactory[
-        Any
-    ] = adaptive_cutoff_neighborlist_from_state,
-) -> Any:
-    """Create a torch MLFF potential from a typed state.
-
-    Args:
-        state: Lens into a sub-state providing particles, systems, neighbor
-            list, and torch MLFF model.
-        compute_position_and_cell_gradients: When ``True``, exposes both
-            position and cell gradients. Requires the underlying
-            ``TorchMliap.compute_cell_gradients`` to be ``True``.
-
-    Returns:
-        Configured torch MLFF ``Potential``.
-    """
-    model_view = state.focus(lambda x: x.torch_mliap_model)
-
-    def neighborlist_view(s: Any) -> NeighborList[Literal[2]]:
-        return neighborlist_factory(state(s), model_view(s).cutoff)
-
-    return make_torch_mliap_potential(
-        state.focus(lambda x: x.particles),
-        state.focus(lambda x: x.systems),
-        neighborlist_view,
-        model_view,
-        compute_cell_gradients=compute_position_and_cell_gradients,
     )

--- a/src/kups/potential/mliap/torch/mace.py
+++ b/src/kups/potential/mliap/torch/mace.py
@@ -11,7 +11,8 @@ loader returning a [TorchMliap][kups.potential.mliap.torch.interface.TorchMliap]
 
 Example:
     ```python
-    from kups.potential.mliap.torch import load_mace, make_torch_mliap_from_state
+    from kups.application.potential.mliap.torch import make_torch_mliap_from_state
+    from kups.potential.mliap.torch import load_mace
 
     model = load_mace("mace.model", compute_cell_gradients=True)
     potential = make_torch_mliap_from_state(

--- a/src/kups/potential/mliap/torch/uma.py
+++ b/src/kups/potential/mliap/torch/uma.py
@@ -14,7 +14,8 @@ MOFs/direct-air-capture, ``"omc"`` for molecular crystals).
 
 Example:
     ```python
-    from kups.potential.mliap.torch import load_uma, make_torch_mliap_from_state
+    from kups.application.potential.mliap.torch import make_torch_mliap_from_state
+    from kups.potential.mliap.torch import load_uma
 
     model = load_uma(
         "uma-s-1.2.pt", task_name="omat", compute_cell_gradients=True,

--- a/test/application/test_relax_lj.py
+++ b/test/application/test_relax_lj.py
@@ -11,6 +11,9 @@ import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
 
+from kups.application.potential.classical.lennard_jones import (
+    make_lennard_jones_from_state,
+)
 from kups.application.relaxation.analysis import analyze_relax_file
 from kups.application.relaxation.data import RelaxRunConfig
 from kups.application.relaxation.simulation import make_relax_propagator
@@ -22,7 +25,6 @@ from kups.application.simulations.relax_lj import (
     run,
 )
 from kups.core.lens import identity_lens
-from kups.potential.classical.lennard_jones import make_lennard_jones_from_state
 from kups.relaxation.config import make_optimizer
 
 

--- a/test/md/test_integrators.py
+++ b/test/md/test_integrators.py
@@ -850,13 +850,13 @@ def test_stress_matches_ase():
     from ase.calculators.lj import LennardJones as ASELJ
 
     from kups.application.md.data import MdParameters, md_state_from_ase
+    from kups.application.potential.classical.lennard_jones import (
+        make_lennard_jones_from_state,
+    )
     from kups.core.lens import identity_lens
     from kups.core.neighborlist import UniversalNeighborlistParameters
     from kups.observables.stress import stress_via_virial_theorem
-    from kups.potential.classical.lennard_jones import (
-        LennardJonesParameters,
-        make_lennard_jones_from_state,
-    )
+    from kups.potential.classical.lennard_jones import LennardJonesParameters
 
     cif = (
         Path(__file__).parent.parent.parent
@@ -935,6 +935,87 @@ def test_stress_matches_ase():
     # NOTE: The NPT density comparison test (test_npt_density_matches_ase) lives
     # in the physical_validation PR where it uses propagate_and_fix. Keeping it
     # here would fail on CI JAX versions with the ShapedArray.vma issue.
+
+
+# ============================================================================
+# Tests: make_md_step_from_state parameters overlay
+# ============================================================================
+
+
+@dataclass
+class VerletSystemData:
+    cell: Cell
+    integrator_params: Any
+
+
+@dataclass
+class VerletState(HasLensFields):
+    particles: LensField[Table[ParticleId, ParticleData]]
+    systems: LensField[Table[SystemId, VerletSystemData]]
+
+
+def create_verlet_md_state(n_particles=5, k=1.0, dt=0.01, box_size=100.0):
+    """Verlet MD state with a periodic cell and VerletParams on each system."""
+    from kups.application.md.data import VerletParams
+
+    key1, key2 = jax.random.split(jax.random.key(42))
+    positions = jax.random.normal(key1, (n_particles, 3)) * 0.1
+    momenta = jax.random.normal(key2, (n_particles, 3))
+    forces = -k * positions
+    masses = jnp.ones(n_particles)
+    particles = Table.arange(
+        ParticleData(
+            positions=positions,
+            momenta=momenta,
+            forces=forces,
+            masses=masses,
+            system=Index.new([SystemId(0)] * n_particles),
+            position_gradients=-forces,
+        ),
+        label=ParticleId,
+    )
+    cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * box_size))
+    systems = Table.arange(
+        VerletSystemData(cell=cell, integrator_params=VerletParams(jnp.array([dt]))),
+        label=SystemId,
+    )
+    state = VerletState(particles=particles, systems=systems)
+
+    def derivative_step(key, s):
+        forces = -k * s.particles.data.positions
+        return VerletState.particles.focus(lambda p: p.data.forces).set(s, forces)
+
+    @dataclass
+    class DerivativeComputation(Propagator[VerletState]):
+        def __call__(self, key, s):
+            return derivative_step(key, s)
+
+    return state, DerivativeComputation()
+
+
+def test_make_md_step_from_state_parameters_overlay_matches_state_params():
+    """``parameters=`` overlay reproduces the path read from the state's params."""
+    from kups.application.md.integrators import make_md_step_from_state
+    from kups.core.lens import identity_lens
+
+    state, deriv = create_verlet_md_state()
+    state_lens = identity_lens(VerletState)
+    verlet_params = state.systems.data.integrator_params
+
+    from_state = make_md_step_from_state(state_lens, deriv, "verlet")
+    from_params = make_md_step_from_state(
+        state_lens, deriv, "verlet", parameters=verlet_params
+    )
+
+    def advance(step):
+        s = state
+        for i in range(3):
+            s = step(jax.random.key(i), s)
+        return s
+
+    a, b = advance(from_state), advance(from_params)
+    assert jnp.allclose(a.particles.data.positions, b.particles.data.positions)
+    assert jnp.allclose(a.particles.data.momenta, b.particles.data.momenta)
 
 
 # ============================================================================

--- a/test/potential/test_potential_update.py
+++ b/test/potential/test_potential_update.py
@@ -16,6 +16,19 @@ import jax.numpy as jnp
 import pytest
 from jax import Array
 
+from kups.application.potential.classical.cosine_angle import (
+    make_cosine_angle_from_state,
+)
+from kups.application.potential.classical.dihedral import make_dihedral_from_state
+from kups.application.potential.classical.harmonic import (
+    make_harmonic_angle_from_state,
+    make_harmonic_bond_from_state,
+)
+from kups.application.potential.classical.inversion import make_inversion_from_state
+from kups.application.potential.classical.lennard_jones import (
+    make_lennard_jones_from_state,
+)
+from kups.application.potential.classical.morse import make_morse_bond_from_state
 from kups.core.capacity import FixedCapacity
 from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
 from kups.core.data import WithCache, WithIndices
@@ -35,32 +48,15 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass
-from kups.potential.classical.cosine_angle import (
-    CosineAngleParameters,
-    make_cosine_angle_from_state,
-)
-from kups.potential.classical.dihedral import (
-    DihedralParameters,
-    make_dihedral_from_state,
-)
+from kups.potential.classical.cosine_angle import CosineAngleParameters
+from kups.potential.classical.dihedral import DihedralParameters
 from kups.potential.classical.harmonic import (
     HarmonicAngleParameters,
     HarmonicBondParameters,
-    make_harmonic_angle_from_state,
-    make_harmonic_bond_from_state,
 )
-from kups.potential.classical.inversion import (
-    InversionParameters,
-    make_inversion_from_state,
-)
-from kups.potential.classical.lennard_jones import (
-    LennardJonesParameters,
-    make_lennard_jones_from_state,
-)
-from kups.potential.classical.morse import (
-    MorseBondParameters,
-    make_morse_bond_from_state,
-)
+from kups.potential.classical.inversion import InversionParameters
+from kups.potential.classical.lennard_jones import LennardJonesParameters
+from kups.potential.classical.morse import MorseBondParameters
 
 # ---------------------------------------------------------------------------
 # Shared dataclasses
@@ -102,6 +98,7 @@ class State:
     particles: Table[ParticleId, ParticleData]
     systems: Table[SystemId, SystemData]
     lj_parameters: WithCache[LennardJonesParameters, EmptyCache]
+    lj_cache: EmptyCache
     bond_edge_indices: Index[ParticleId]
     harmonic_bond_parameters: WithCache[HarmonicBondParameters, EmptyCache]
     angle_edge_indices: Index[ParticleId]
@@ -268,6 +265,7 @@ def _make_state(positions: Array | None = None) -> State:
         particles=c.particles,
         systems=c.systems,
         lj_parameters=WithCache(c.lj, ec),
+        lj_cache=ec,
         bond_edge_indices=c.bond_edge_indices,
         harmonic_bond_parameters=WithCache(c.hb, ec),
         angle_edge_indices=c.angle_edge_indices,
@@ -661,4 +659,59 @@ class TestFromStateWithUpdates:
 
             assert jnp.allclose(e_incr, e_full, atol=1e-6), (
                 f"{pot.name}-{spec.name}: incremental {e_incr} != full {e_full}"
+            )
+
+
+class TestLJConstantParameters:
+    """LJ built with constant ``parameters=`` matches the state-based build."""
+
+    def test_full_matches_state_based(
+        self,
+        state: State,
+        state_lens: Lens[State, State],
+    ):
+        params = state.lj_parameters.data
+        state_pot = make_lennard_jones_from_state(
+            state_lens, neighborlist_factory=_test_nl_factory
+        )
+        const_pot = make_lennard_jones_from_state(
+            state_lens, parameters=params, neighborlist_factory=_test_nl_factory
+        )
+        e_state = state_pot(state).data.total_energies.data
+        e_const = const_pot(state).data.total_energies.data
+        assert jnp.allclose(e_state, e_const)
+
+    def test_incremental_matches_full(
+        self,
+        state: State,
+        state_lens: Lens[State, State],
+    ):
+        params = state.lj_parameters.data
+        basic_pot = make_lennard_jones_from_state(
+            state_lens, neighborlist_factory=_test_nl_factory
+        )
+        pot_cfg = PotentialConfig("lennard_jones", None, None, None)
+
+        for spec in (s for s in _PERTURBATIONS if s.edge_updates is None):
+            probe = _build_probe(pot_cfg, spec)
+            updates_pot = make_lennard_jones_from_state(
+                state_lens,
+                probe,
+                parameters=params,
+                neighborlist_factory=_test_nl_factory,
+            )
+
+            out_full = updates_pot(state, patch=None)
+            state_cached: State = out_full.patch(
+                state, state.systems.set_data(jnp.ones(len(state.systems), dtype=bool))
+            )
+
+            pos_patch = _make_patch(spec)
+            e_incr = updates_pot(state_cached, patch=pos_patch).data.total_energies.data
+
+            ref_state = _make_reference_state(state_cached, spec, pos_patch)
+            e_full = basic_pot(ref_state).data.total_energies.data
+
+            assert jnp.allclose(e_incr, e_full, atol=1e-6), (
+                f"lennard_jones-{spec.name}: incremental {e_incr} != full {e_full}"
             )

--- a/test/potential/test_torch_mace.py
+++ b/test/potential/test_torch_mace.py
@@ -306,11 +306,11 @@ class TestUniversalInterfaceAPI:
     """Smoke checks for the universal interface surface."""
 
     def test_imports(self):
+        from kups.application.potential.mliap.torch import make_torch_mliap_from_state
         from kups.potential.mliap.torch import (
             AtomGraphInput,
             TorchMliap,
             lattice_gradient_from_virial,
-            make_torch_mliap_from_state,
             make_torch_mliap_potential,
             torch_mliap_model_fn,
         )

--- a/test/potential/test_torch_mace_e2e.py
+++ b/test/potential/test_torch_mace_e2e.py
@@ -143,6 +143,7 @@ def test_kups_pipeline_matches_mace_calculator(tmp_path):
     import jax.numpy as jnp
     from mace.calculators import MACECalculator
 
+    from kups.application.potential.mliap.torch import make_torch_mliap_from_state
     from kups.application.relaxation.data import relax_state_from_ase
     from kups.application.simulations.relax_torch import RelaxTorchState
     from kups.core.cell import to_lower_triangular
@@ -150,7 +151,7 @@ def test_kups_pipeline_matches_mace_calculator(tmp_path):
     from kups.core.neighborlist import UniversalNeighborlistParameters
     from kups.core.result import as_result_function
     from kups.observables.stress import _stress_via_virial_theorem
-    from kups.potential.mliap.torch import load_mace, make_torch_mliap_from_state
+    from kups.potential.mliap.torch import load_mace
 
     model_path, _ = _resolve_or_create_mace_checkpoint(tmp_path)
 

--- a/test/potential/test_torch_uma_e2e.py
+++ b/test/potential/test_torch_uma_e2e.py
@@ -206,6 +206,7 @@ def test_kups_pipeline_matches_fairchem_uma(tmp_path):
     from fairchem.core import FAIRChemCalculator
     from fairchem.core.units.mlip_unit import load_predict_unit
 
+    from kups.application.potential.mliap.torch import make_torch_mliap_from_state
     from kups.application.relaxation.data import relax_state_from_ase
     from kups.application.simulations.relax_torch import RelaxTorchState
     from kups.core.cell import to_lower_triangular
@@ -213,7 +214,7 @@ def test_kups_pipeline_matches_fairchem_uma(tmp_path):
     from kups.core.neighborlist import UniversalNeighborlistParameters
     from kups.core.result import as_result_function
     from kups.observables.stress import _stress_via_virial_theorem
-    from kups.potential.mliap.torch import load_uma, make_torch_mliap_from_state
+    from kups.potential.mliap.torch import load_uma
 
     task_name = "omat"
     model_path = _resolve_or_create_uma_checkpoint(tmp_path, task_name=task_name)


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Moved state-binding `make_*_from_state` functions from core potential modules to new `kups.application` subpackage to separate application-layer state handling from reusable core logic, also moved `make_md_step_from_state` and related stress observables to application layer for consistency.