### PR TITLE
feat: selective + chunked reading in HDF5 storage

### DIFF
--- a/docs/notebooks/logging.ipynb
+++ b/docs/notebooks/logging.ipynb
@@ -269,7 +269,7 @@
     "\n",
     "On `__enter__` the writer opens the file, sizes every dataset against the total step count (so the HDF5 layout is known at file creation time), and starts a background thread that drains a queue. On every `log` call the main thread extracts the view from the state synchronously, hands the small host-side copy to the background thread, and returns. The heavy write-to-disk work happens out of band and does not block the next step. On `__exit__` the writer flushes, records the actual number of steps that ran (for runs that stopped early), and closes the file.\n",
     "\n",
-    "The cell below writes a two-group trajectory (one scalar logged once, the energy logged every step) to a temporary HDF5 file, then reads it back with [HDF5StorageReader][kups.core.storage.HDF5StorageReader]."
+    "The cell below writes a two-group trajectory (one scalar logged once, the energy and step index logged every step) to a temporary HDF5 file, then reads it straight back to confirm the stored trajectory matches the live run. The reader API itself is the subject of the next section."
    ]
   },
   {
@@ -298,7 +298,7 @@
     "        logging_frequency=Once(),\n",
     "    ),\n",
     "    frames=WriterGroupConfig(\n",
-    "        view=view(lambda s: {\"energy\": s.energy}),\n",
+    "        view=view(lambda s: {\"energy\": s.energy, \"step\": s.step}),\n",
     "        logging_frequency=EveryNStep(1),\n",
     "    ),\n",
     ")\n",
@@ -318,6 +318,93 @@
     "print(\"first logged energy: \", float(frames[\"energy\"][0]))\n",
     "print(\"last  logged energy: \", float(frames[\"energy\"][-1]))\n",
     "print(\"live final energy:   \", float(final.energy))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d44430a9",
+   "metadata": {},
+   "source": [
+    "## `HDF5StorageReader`: reading a run back\n",
+    "\n",
+    "A file written this way is self-describing: it stores the schema's pytree structure and each group's array layout alongside the data, so reading needs nothing but the path. [HDF5StorageReader][kups.core.storage.HDF5StorageReader] is a context manager that opens the file for the duration of a `with` block and closes it on exit, and `list_groups` enumerates what was recorded.\n",
+    "\n",
+    "`focus_group` selects one group and returns a [GroupReader][kups.core.storage.GroupReader]. It accepts either a [View][kups.core.lens.View] into the schema (the same lens vocabulary used to write, so `lambda s: s.frames` resolves to the `frames` group) or a raw group-name string. The reader reconstructs the stored value's pytree on each read, so what comes back has the shape the view produced when writing, with a leading time axis stacked across the logged steps.\n",
+    "\n",
+    "A `GroupReader` is array-like along that time axis. An integer index reads one frame, a slice reads a contiguous span, `[:]` reads the whole trajectory, and `[...]` reads a once-logged group that has no time axis. Each index pulls only the requested frames off disk rather than materialising the entire dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bac8ebd5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with HDF5StorageReader(out_file) as reader:\n",
+    "    print(\"groups:\", reader.list_groups())\n",
+    "\n",
+    "    frames = reader.focus_group(lambda s: s.frames)\n",
+    "    print(\"whole trajectory:\", frames[:][\"energy\"].shape)\n",
+    "    print(\"first frame:     \", float(frames[0][\"energy\"]))\n",
+    "    print(\"last frame:      \", float(frames[-1][\"energy\"]))\n",
+    "    print(\"every 10th frame:\", frames[::10][\"energy\"].shape)\n",
+    "\n",
+    "    # A once-logged group has no time axis; read it with `...`.\n",
+    "    initial = reader.focus_group(lambda s: s.initial)[...]\n",
+    "    print(\"start_energy:    \", float(initial[\"start_energy\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3e03389",
+   "metadata": {},
+   "source": [
+    "### Reading only the fields you need\n",
+    "\n",
+    "A group usually holds several fields, and `[:]` reads every one. When an analysis touches only a few, pass a `select` lens to `read`: it is the same lens vocabulary `focus_group` uses, applied one level deeper — to a field of the stored value rather than to a group. Only the datasets backing that field are pulled off disk; the rest stay put. This is what keeps post-processing of a long run cheap — read the one column a statistic needs, not the whole per-step record."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba29bb17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with HDF5StorageReader(out_file) as reader:\n",
+    "    frames = reader.focus_group(lambda s: s.frames)\n",
+    "    # Read just the energy column; the step column is never touched.\n",
+    "    energy = frames.read(select=lambda d: d[\"energy\"])\n",
+    "    print(\"energy column only:\", energy.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f641913",
+   "metadata": {},
+   "source": [
+    "### Streaming long trajectories in chunks\n",
+    "\n",
+    "`[:]` is convenient but pulls the entire group into memory at once. For a long run whose trajectory does not fit comfortably in RAM, `read_chunked` walks the time axis in fixed-size blocks, yielding one block per step (the last is shorter when the length is not a multiple of the chunk size). This is the natural shape for a streaming reduction: accumulate a running statistic, downsample, or re-encode frame by frame without ever holding the whole trajectory at once. It takes the same `select` lens as `read`, so a reduction over one field reads neither the other fields nor the whole time axis at once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6564d469",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with HDF5StorageReader(out_file) as reader:\n",
+    "    frames = reader.focus_group(lambda s: s.frames)\n",
+    "    total, count = 0.0, 0\n",
+    "    # `select` streams just the energy column, one block at a time.\n",
+    "    for energies in frames.read_chunked(16, select=lambda d: d[\"energy\"]):\n",
+    "        total += float(energies.sum())\n",
+    "        count += energies.shape[0]\n",
+    "        print(f\"  chunk of {energies.shape[0]} frames\")\n",
+    "    print(f\"mean energy over {count} frames: {total / count:.4f}\")"
    ]
   },
   {
@@ -415,7 +502,7 @@
    "source": [
     "## Where to go next\n",
     "\n",
-    "The simulation drivers in `kups.application.utils.propagate` show how the pieces fit together: warmup with no logger, production with a composite logger, both wrapping the same propagator from the [Propagators](propagators.md) notebook. For application-level logging schemas that cover a full GCMC or MD run (which fields, at which frequencies, in which groups) see `kups.application.mcmc.logging` and its MD counterpart. For the HDF5 reader side and the reading-back-a-run workflow, see [HDF5StorageReader][kups.core.storage.HDF5StorageReader] in the storage module."
+    "The simulation drivers in `kups.application.utils.propagate` show how the pieces fit together: warmup with no logger, production with a composite logger, both wrapping the same propagator from the [Propagators](propagators.md) notebook. For application-level logging schemas that cover a full GCMC or MD run (which fields, at which frequencies, in which groups) see `kups.application.mcmc.logging` and its MD counterpart."
    ]
   }
  ],
@@ -480,13 +567,13 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_ebcc2fd1b5b84f7d98f5450a9584e370",
-       "max": 30.0,
-       "min": 0.0,
+       "max": 30,
+       "min": 0,
        "orientation": "horizontal",
        "style": "IPY_MODEL_a48f0db0c8bd416887fde0aa062f44d5",
        "tabbable": null,
        "tooltip": null,
-       "value": 30.0
+       "value": 30
       }
      },
      "180ece58690e4bbfab8d95fadca0f5f3": {
@@ -618,13 +705,13 @@
        "description": "",
        "description_allow_html": false,
        "layout": "IPY_MODEL_e7afa1fb91324c2783a056f79332a120",
-       "max": 10.0,
-       "min": 0.0,
+       "max": 10,
+       "min": 0,
        "orientation": "horizontal",
        "style": "IPY_MODEL_a8c9658f80d448c7b847f5f2a7fbf7a1",
        "tabbable": null,
        "tooltip": null,
-       "value": 10.0
+       "value": 10
       }
      },
      "7ebd6c706ff14df087192a6166b92e86": {

--- a/src/kups/application/mcmc/analysis.py
+++ b/src/kups/application/mcmc/analysis.py
@@ -108,17 +108,16 @@ def _analyze_single_system(
     """
     if n_blocks is None:
         energy_result = optimal_block_average(energy)
-        n_blocks_used = int(energy_result.n_blocks)
+        n_blocks = int(energy_result.n_blocks)
     else:
         energy_result = block_average(energy, n_blocks=n_blocks)
-        n_blocks_used = n_blocks
 
-    loading = block_average(counts, n_blocks=n_blocks_used, axis=0)
+    loading = block_average(counts, n_blocks=n_blocks, axis=0)
 
-    U_blocks = compute_block_means(energy, n_blocks_used)
-    N_blocks = compute_block_means(counts, n_blocks_used)
-    UN_blocks = compute_block_means(energy[:, None] * counts, n_blocks_used)
-    NN_blocks = compute_block_means(counts[..., None] * counts[:, None], n_blocks_used)
+    U_blocks = compute_block_means(energy, n_blocks)
+    N_blocks = compute_block_means(counts, n_blocks)
+    UN_blocks = compute_block_means(energy[:, None] * counts, n_blocks)
+    NN_blocks = compute_block_means(counts[..., None] * counts[:, None], n_blocks)
 
     cov = NN_blocks - N_blocks[..., None] * N_blocks[:, None, :]
     cov_inv = jnp.linalg.inv(cov)
@@ -137,8 +136,8 @@ def _analyze_single_system(
         if s is None:
             return None, None
         return (
-            block_average(s, n_blocks=n_blocks_used),
-            block_average(jnp.trace(s, axis1=-2, axis2=-1) / 3, n_blocks=n_blocks_used),
+            block_average(s, n_blocks=n_blocks),
+            block_average(jnp.trace(s, axis1=-2, axis2=-1) / 3, n_blocks=n_blocks),
         )
 
     stress_result, pressure_result = _stress_and_pressure(stress)
@@ -163,6 +162,55 @@ def _analyze_single_system(
 
 
 @no_jax_tracing
+def _analyze_mcmc(
+    system_keys: tuple[SystemId, ...],
+    temperatures: Array,
+    count_keys: tuple[tuple[SystemId, MotifId], ...],
+    count_data: Array,
+    all_energy: Array,
+    guest_stress: StressResult,
+    n_blocks: int | None,
+) -> dict[SystemId, MCMCAnalysisResult]:
+    """Run per-system block averaging from extracted per-step arrays.
+
+    Args:
+        system_keys: System identifiers, one per energy/stress column.
+        temperatures: Per-system temperature (K), shape ``(n_systems,)``.
+        count_keys: ``(system, motif)`` key per particle-count column.
+        count_data: Particle counts, shape ``(n_steps, n_columns)``.
+        all_energy: Potential energy, shape ``(n_steps, n_systems)``.
+        guest_stress: Per-step stress components, each shape
+            ``(n_steps, n_systems, 3, 3)``.
+        n_blocks: Number of blocks, or ``None`` for automatic selection.
+
+    Returns:
+        Per-system analysis results keyed by ``SystemId``.
+    """
+    stress_potential = guest_stress.potential
+    stress_tail = guest_stress.tail_correction
+    stress_ideal = guest_stress.ideal_gas
+    all_stress = stress_potential + stress_tail + stress_ideal
+
+    results: dict[SystemId, MCMCAnalysisResult] = {}
+    for i, sys_id in enumerate(system_keys):
+        motif_cols = [j for j, label in enumerate(count_keys) if label[0] == sys_id]
+        s = all_stress[:, i]
+        has_stress = bool(jnp.any(s != 0))
+        results[sys_id] = _analyze_single_system(
+            energy=all_energy[:, i].reshape(-1),
+            counts=count_data[:, motif_cols].reshape(-1, len(motif_cols)),
+            temperature=float(temperatures[i]),
+            n_blocks=n_blocks,
+            stress=s if has_stress else None,
+            stress_potential=stress_potential[:, i] if has_stress else None,
+            stress_tail_correction=stress_tail[:, i] if has_stress else None,
+            stress_ideal_gas=stress_ideal[:, i] if has_stress else None,
+        )
+
+    return results
+
+
+@no_jax_tracing
 def analyze_mcmc(
     fixed: IsMCMCFixedData,
     per_step: IsMCMCStepData,
@@ -183,43 +231,15 @@ def analyze_mcmc(
     Returns:
         Per-system analysis results keyed by ``SystemId``.
     """
-    system_keys = fixed.systems.keys
-    count_keys = per_step.particle_count.keys
-    count_data = per_step.particle_count.data
-    temperatures = fixed.systems.data.temperature
-    all_energy = per_step.systems.data.potential_energy
-    guest_stress = per_step.systems.data.guest_stress
-    stress_potential = guest_stress.potential
-    stress_tail = guest_stress.tail_correction
-    stress_ideal = guest_stress.ideal_gas
-    all_stress = stress_potential + stress_tail + stress_ideal
-
-    results: dict[SystemId, MCMCAnalysisResult] = {}
-    for i, sys_id in enumerate(system_keys):
-        motif_cols = [j for j, label in enumerate(count_keys) if label[0] == sys_id]
-        counts = count_data[:, motif_cols].reshape(-1, len(motif_cols))
-        energy = all_energy[:, i].reshape(-1)
-        s = all_stress[:, i]
-        has_stress = bool(jnp.any(s != 0))
-        temperature = float(temperatures[i])
-        results[sys_id] = _analyze_single_system(
-            energy,
-            counts,
-            temperature,
-            n_blocks,
-            stress=s if has_stress else None,
-            stress_potential=stress_potential[:, i]
-            if has_stress and stress_potential is not None
-            else None,
-            stress_tail_correction=stress_tail[:, i]
-            if has_stress and stress_tail is not None
-            else None,
-            stress_ideal_gas=stress_ideal[:, i]
-            if has_stress and stress_ideal is not None
-            else None,
-        )
-
-    return results
+    return _analyze_mcmc(
+        fixed.systems.keys,
+        fixed.systems.data.temperature,
+        per_step.particle_count.keys,
+        per_step.particle_count.data,
+        per_step.systems.data.potential_energy,
+        per_step.systems.data.guest_stress,
+        n_blocks,
+    )
 
 
 @plain_dataclass
@@ -275,13 +295,12 @@ def _analyze_single_widom_system(
     """
     if n_blocks is None:
         w_result = optimal_block_average(mean_w_per_cycle)
-        n_used = int(w_result.n_blocks)
+        n_blocks = int(w_result.n_blocks)
     else:
         w_result = block_average(mean_w_per_cycle, n_blocks=n_blocks)
-        n_used = n_blocks
 
-    block_w = compute_block_means(mean_w_per_cycle, n_used)
-    block_du_w = compute_block_means(mean_du_w_per_cycle, n_used)
+    block_w = compute_block_means(mean_w_per_cycle, n_blocks)
+    block_du_w = compute_block_means(mean_du_w_per_cycle, n_blocks)
 
     mean_w = jnp.mean(block_w)
     mean_du_w = jnp.mean(block_du_w)
@@ -289,7 +308,9 @@ def _analyze_single_widom_system(
     var_du_w = jnp.var(block_du_w, ddof=1)
     # Block-level covariance for the ratio's delta-method SE.
     cov_w_du_w = (
-        jnp.mean((block_w - mean_w) * (block_du_w - mean_du_w)) * n_used / (n_used - 1)
+        jnp.mean((block_w - mean_w) * (block_du_w - mean_du_w))
+        * n_blocks
+        / (n_blocks - 1)
     )
 
     kT = temperature * BOLTZMANN_CONSTANT
@@ -308,17 +329,50 @@ def _analyze_single_widom_system(
         inv_w**2 * var_du_w
         + ratio**2 * inv_w**2 * var_w
         - 2 * ratio * inv_w**2 * cov_w_du_w
-    ) / n_used
+    ) / n_blocks
     se_q_st = jnp.sqrt(jnp.maximum(var_q_st, 0.0))
 
     return WidomAnalysisResult(
-        excess_chemical_potential=BlockAverageResult(mu_ex, se_mu_ex, n_used),
-        henry_coefficient=BlockAverageResult(k_h, se_k_h, n_used),
-        heat_of_adsorption=BlockAverageResult(q_st, se_q_st, n_used),
+        excess_chemical_potential=BlockAverageResult(mu_ex, se_mu_ex, n_blocks),
+        henry_coefficient=BlockAverageResult(k_h, se_k_h, n_blocks),
+        heat_of_adsorption=BlockAverageResult(q_st, se_q_st, n_blocks),
     )
 
 
 @no_jax_tracing
+@no_jax_tracing
+def _analyze_widom(
+    per_step: Table[SystemId, WidomStatistics],
+    system_keys: tuple[SystemId, ...],
+    temperatures: Array,
+    volumes: Array,
+    n_blocks: int | None,
+) -> dict[SystemId, WidomAnalysisResult]:
+    """Block-average per-system Widom statistics into μ_ex / K_H / q_st.
+
+    Args:
+        per_step: Cumulative ``WidomStatistics`` time series.
+        system_keys: System identifiers, one per column.
+        temperatures: Per-system temperature (K), shape ``(n_systems,)``.
+        volumes: Per-system cell volume (Å³), shape ``(n_systems,)``.
+        n_blocks: Number of blocks; ``None`` uses ``optimal_block_average``.
+
+    Returns:
+        Per-system Widom results keyed by ``SystemId``.
+    """
+    mean_w, mean_du_w = _per_cycle_widom_means(per_step)
+    results: dict[SystemId, WidomAnalysisResult] = {}
+    for i, sys_id in enumerate(system_keys):
+        results[sys_id] = _analyze_single_widom_system(
+            mean_w[:, i],
+            mean_du_w[:, i],
+            float(temperatures[i]),
+            float(volumes[i]),
+            n_blocks,
+        )
+    return results
+
+
 def analyze_widom(
     fixed: WidomFixedData,
     per_step: Table[SystemId, WidomStatistics],
@@ -330,21 +384,17 @@ def analyze_widom(
         fixed: Fixed-group data carrying per-system temperature and cell.
         per_step: Cumulative ``WidomStatistics`` time series.
         n_blocks: Number of blocks; ``None`` uses ``optimal_block_average``.
-    """
-    mean_w, mean_du_w = _per_cycle_widom_means(per_step)
-    temperatures = fixed.systems.data.temperature
-    volumes = fixed.systems.data.cell.volume
 
-    results: dict[SystemId, WidomAnalysisResult] = {}
-    for i, sys_id in enumerate(fixed.systems.keys):
-        results[sys_id] = _analyze_single_widom_system(
-            mean_w[:, i],
-            mean_du_w[:, i],
-            float(temperatures[i]),
-            float(volumes[i]),
-            n_blocks,
-        )
-    return results
+    Returns:
+        Per-system Widom results keyed by ``SystemId``.
+    """
+    return _analyze_widom(
+        per_step,
+        fixed.systems.keys,
+        fixed.systems.data.temperature,
+        fixed.systems.data.cell.volume,
+        n_blocks,
+    )
 
 
 @no_jax_tracing
@@ -352,11 +402,18 @@ def analyze_widom_file(
     hdf5_path: str | Path,
     n_blocks: int | None = None,
 ) -> dict[SystemId, WidomAnalysisResult]:
-    """Analyze a ``kups_mcmc_widom`` HDF5 output."""
+    """Analyze a ``kups_mcmc_widom`` HDF5 output, reading only system metadata
+    and the per-cycle Widom statistics."""
     with HDF5StorageReader[WidomLoggedData[Any]](hdf5_path) as reader:
-        fixed = reader.focus_group(lambda s: s.fixed)[...]
+        systems = reader.focus_group(lambda s: s.fixed).read(select=lambda d: d.systems)
         per_step = reader.focus_group(lambda s: s.per_step)[...]
-    return analyze_widom(fixed, per_step, n_blocks)
+    return _analyze_widom(
+        per_step,
+        systems.keys,
+        systems.data.temperature,
+        systems.data.cell.volume,
+        n_blocks,
+    )
 
 
 @no_jax_tracing
@@ -366,8 +423,9 @@ def analyze_mcmc_file(
 ) -> dict[SystemId, MCMCAnalysisResult]:
     """Analyze MCMC simulation results from an HDF5 file.
 
-    Convenience wrapper that reads the HDF5 file and delegates to
-    :func:`analyze_mcmc`.
+    Reads only the fields the analysis needs — per-system metadata, particle
+    counts, potential energy, and guest stress — leaving the per-step particle
+    and group tables on disk.
 
     Args:
         hdf5_path: Path to HDF5 output file from
@@ -379,7 +437,22 @@ def analyze_mcmc_file(
         Per-system analysis results keyed by ``SystemId``.
     """
     with HDF5StorageReader[MCMCLoggedData[Any]](hdf5_path) as reader:
-        fixed = reader.focus_group(lambda s: s.fixed)[...]
-        per_step = reader.focus_group(lambda s: s.per_step)[...]
+        systems = reader.focus_group(lambda s: s.fixed).read(select=lambda d: d.systems)
+        per_step = reader.focus_group(lambda s: s.per_step)
+        particle_count = per_step.read(select=lambda d: d.particle_count)
+        all_energy, guest_stress = per_step.read(
+            select=lambda d: (
+                d.systems.data.potential_energy,
+                d.systems.data.guest_stress,
+            )
+        )
 
-    return analyze_mcmc(fixed, per_step, n_blocks)
+    return _analyze_mcmc(
+        systems.keys,
+        systems.data.temperature,
+        particle_count.keys,
+        particle_count.data,
+        all_energy,
+        guest_stress,
+        n_blocks,
+    )

--- a/src/kups/application/md/analysis.py
+++ b/src/kups/application/md/analysis.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass as plain_dataclass
 from pathlib import Path
 from typing import Protocol
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
@@ -18,49 +17,34 @@ from kups.application.md.logging import MDLoggedData
 from kups.core.constants import BOLTZMANN_CONSTANT
 from kups.core.data import Index, Table
 from kups.core.storage import HDF5StorageReader
-from kups.core.typing import (
-    HasMasses,
-    HasMomenta,
-    HasPositions,
-    HasPotentialEnergy,
-    HasStressTensor,
-    ParticleId,
-    SystemId,
-)
+from kups.core.typing import HasPotentialEnergy, HasStressTensor, ParticleId, SystemId
 from kups.core.utils.block_average import (
     BlockAverageResult,
     block_average,
     optimal_block_average,
 )
-from kups.md.observables import (
-    particle_kinetic_energy,
-    remove_center_of_mass_momentum,
-)
 
 
-class _IsMDAtoms(HasPositions, Protocol):
+class _IsMDInitAtoms(Protocol):
     @property
     def system(self) -> Index[SystemId]: ...
-
-
-class _IsMDStepAtoms(HasMomenta, HasMasses, Protocol): ...
 
 
 class IsMDInitData(Protocol):
     """Contract for the init reader group."""
 
     @property
-    def atoms(self) -> Table[ParticleId, _IsMDAtoms]: ...
+    def atoms(self) -> Table[ParticleId, _IsMDInitAtoms]: ...
 
 
 class IsMDStepData(HasPotentialEnergy, HasStressTensor, Protocol):
     """Contract for the step reader group."""
 
     @property
-    def atoms(self) -> Table[ParticleId, _IsMDStepAtoms]: ...
+    def kinetic_energy(self) -> Array: ...
 
     @property
-    def kinetic_energy(self) -> Array: ...
+    def internal_kinetic_energy(self) -> Array: ...
 
     @property
     def volume(self) -> Array: ...
@@ -98,80 +82,91 @@ class MDAnalysisResult:
 def _analyze_single_system(
     potential_energy: Array,
     kinetic_energy: Array,
+    internal_kinetic_energy: Array,
     stress_tensor: Array,
     volume: Array,
     n_atoms: int,
     n_blocks: int | None,
-    internal_kinetic_energy: Array,
 ) -> MDAnalysisResult:
-    """Run block-averaging analysis for one system.
+    """Block-average one system's time series into thermodynamic averages.
 
     Args:
-        potential_energy: Potential energy time series, shape ``(n_steps,)``.
-        kinetic_energy: Kinetic energy time series, shape ``(n_steps,)``.
-        stress_tensor: Stress tensor time series, shape ``(n_steps, 3, 3)``.
-        volume: Cell volume time series, shape ``(n_steps,)``.
-        n_atoms: Number of atoms in this system.
-        n_blocks: Number of blocks, or ``None`` for automatic selection.
-        internal_kinetic_energy: Center-of-mass-projected kinetic energy time
-            series to use when computing internal temperature. The logged
-            ``kinetic_energy`` and ``total_energy`` are left unchanged.
-    """
-    degrees_of_freedom = 3 * n_atoms - 3
-    total_energy = potential_energy + kinetic_energy
-    n_steps = len(total_energy)
+        potential_energy: Potential energy, shape ``(n_steps,)``.
+        kinetic_energy: Total kinetic energy, shape ``(n_steps,)``.
+        internal_kinetic_energy: Center-of-mass-projected kinetic energy used for
+            the temperature, shape ``(n_steps,)``.
+        stress_tensor: Stress tensor, shape ``(n_steps, 3, 3)``.
+        volume: Cell volume, shape ``(n_steps,)``.
+        n_atoms: Number of atoms in the system.
+        n_blocks: Number of blocks, or ``None`` to auto-select from the pressure.
 
-    temperature = (
-        2 * internal_kinetic_energy / (BOLTZMANN_CONSTANT * degrees_of_freedom)
-    )
+    Returns:
+        Block-averaged thermodynamic results for the system.
+    """
+    total_energy = potential_energy + kinetic_energy
+    dof = 3 * n_atoms - 3
+    temperature = 2 * internal_kinetic_energy / (BOLTZMANN_CONSTANT * dof)
     pressure = jnp.trace(stress_tensor, axis1=-2, axis2=-1) / 3
 
     if n_blocks is None:
         pressure_result = optimal_block_average(pressure)
-        n_blocks_used = int(pressure_result.n_blocks)
+        n_blocks = int(pressure_result.n_blocks)
     else:
         pressure_result = block_average(pressure, n_blocks=n_blocks)
-        n_blocks_used = n_blocks
 
-    pe_result = block_average(potential_energy, n_blocks=n_blocks_used)
-    ke_result = block_average(kinetic_energy, n_blocks=n_blocks_used)
-    te_result = block_average(total_energy, n_blocks=n_blocks_used)
-    temp_result = block_average(temperature, n_blocks=n_blocks_used)
-    volume_result = block_average(volume, n_blocks=n_blocks_used)
-
-    steps = np.arange(n_steps)
-    slope, _ = np.polyfit(steps, np.asarray(total_energy), 1)
+    slope, _ = np.polyfit(np.arange(len(total_energy)), np.asarray(total_energy), 1)
 
     return MDAnalysisResult(
-        potential_energy=pe_result,
-        kinetic_energy=ke_result,
-        total_energy=te_result,
-        temperature=temp_result,
+        potential_energy=block_average(potential_energy, n_blocks=n_blocks),
+        kinetic_energy=block_average(kinetic_energy, n_blocks=n_blocks),
+        total_energy=block_average(total_energy, n_blocks=n_blocks),
+        temperature=block_average(temperature, n_blocks=n_blocks),
         energy_drift=float(slope),
         energy_drift_per_atom=float(slope) / n_atoms,
         pressure=pressure_result,
-        volume=volume_result,
+        volume=block_average(volume, n_blocks=n_blocks),
         n_atoms=n_atoms,
-        n_steps=n_steps,
+        n_steps=len(total_energy),
     )
 
 
-def _internal_kinetic_energy(
-    atoms: Table[ParticleId, _IsMDStepAtoms],
+def _analyze_md_systems(
     system: Index[SystemId],
-    system_number: int,
-) -> Array:
-    """Compute per-step internal kinetic energy for one system."""
-    mask = system.indices == system_number
-    momenta = atoms.data.momenta[:, mask, :]
-    masses = atoms.data.masses[:, mask]
-    local_system = Index.zeros(momenta.shape[1], label=SystemId)
-    projected_momenta = jax.vmap(
-        remove_center_of_mass_momentum,
-        in_axes=(0, 0, None),
-    )(momenta, masses, local_system)
+    potential_energy: Array,
+    kinetic_energy: Array,
+    internal_kinetic_energy: Array,
+    stress_tensor: Array,
+    volume: Array,
+    n_blocks: int | None,
+) -> dict[SystemId, MDAnalysisResult]:
+    """Block-average each system independently.
 
-    return jnp.sum(particle_kinetic_energy(projected_momenta, masses), axis=-1)
+    Args:
+        system: Per-atom system index supplying keys and atom counts.
+        potential_energy: Potential energy, shape ``(n_steps, n_systems)``.
+        kinetic_energy: Total kinetic energy, shape ``(n_steps, n_systems)``.
+        internal_kinetic_energy: Center-of-mass-projected kinetic energy, shape
+            ``(n_steps, n_systems)``.
+        stress_tensor: Stress tensor, shape ``(n_steps, n_systems, 3, 3)``.
+        volume: Cell volume, shape ``(n_steps, n_systems)``.
+        n_blocks: Number of blocks, or ``None`` for automatic selection.
+
+    Returns:
+        Per-system analysis results keyed by ``SystemId``.
+    """
+    n_atoms_per_system = system.counts.data
+    return {
+        sys_id: _analyze_single_system(
+            potential_energy[:, i],
+            kinetic_energy[:, i],
+            internal_kinetic_energy[:, i],
+            stress_tensor[:, i],
+            volume[:, i],
+            int(n_atoms_per_system[i]),
+            n_blocks,
+        )
+        for i, sys_id in enumerate(system.keys)
+    }
 
 
 def analyze_md(
@@ -185,54 +180,64 @@ def analyze_md(
     independently for each system.
 
     Args:
-        init_data: Initial simulation state with atom positions and system index.
+        init_data: Initial simulation state providing the per-atom system index.
         step_data: Per-step thermodynamic data with shape ``(n_steps, n_systems)``.
-        n_blocks: Number of blocks for error estimation. If None, uses
-            optimal_block_average to auto-select.
+        n_blocks: Number of blocks for error estimation. ``None`` auto-selects via
+            ``optimal_block_average``.
 
     Returns:
         Per-system analysis results keyed by ``SystemId``.
     """
-    system_index = init_data.atoms.data.system
-    n_atoms_per_system = system_index.counts.data
-
-    results: dict[SystemId, MDAnalysisResult] = {}
-    for i, sys_id in enumerate(system_index.keys):
-        kinetic_energy = step_data.kinetic_energy[:, i]
-        internal_ke = kinetic_energy
-        internal_ke = _internal_kinetic_energy(step_data.atoms, system_index, i)
-        results[sys_id] = _analyze_single_system(
-            potential_energy=step_data.potential_energy[:, i],
-            kinetic_energy=kinetic_energy,
-            stress_tensor=step_data.stress_tensor[:, i],
-            volume=step_data.volume[:, i],
-            n_atoms=int(n_atoms_per_system[i]),
-            n_blocks=n_blocks,
-            internal_kinetic_energy=internal_ke,
-        )
-
-    return results
+    return _analyze_md_systems(
+        init_data.atoms.data.system,
+        step_data.potential_energy,
+        step_data.kinetic_energy,
+        step_data.internal_kinetic_energy,
+        step_data.stress_tensor,
+        step_data.volume,
+        n_blocks,
+    )
 
 
 def analyze_md_file(
     hdf5_path: str | Path,
     n_blocks: int | None = None,
 ) -> dict[SystemId, MDAnalysisResult]:
-    """Analyze MD simulation results from HDF5 file.
+    """Analyze MD simulation results from an HDF5 file.
 
-    Convenience wrapper that reads HDF5 and delegates to ``analyze_md``.
+    Reads only the per-step thermodynamic scalars (energies, stress, volume) and
+    the initial system index, leaving the per-atom trajectory on disk. Internal
+    kinetic energy is logged per step, so no momenta are read here.
 
     Args:
         hdf5_path: Path to HDF5 file from MD simulation.
-        n_blocks: Number of blocks for error estimation. If None, uses
-            optimal_block_average to auto-select.
+        n_blocks: Number of blocks for error estimation. ``None`` auto-selects via
+            ``optimal_block_average``.
 
     Returns:
         Per-system analysis results keyed by ``SystemId``.
     """
-
     with HDF5StorageReader[MDLoggedData](hdf5_path) as reader:
-        init_data = reader.focus_group(lambda state: state.init)[...]
-        step_data = reader.focus_group(lambda state: state.step)[...]
-
-    return analyze_md(init_data, step_data, n_blocks=n_blocks)
+        system = reader.focus_group(lambda s: s.init).read(
+            select=lambda d: d.atoms.data.system
+        )
+        potential_energy, kinetic_energy, internal_kinetic_energy, stress, volume = (
+            reader.focus_group(lambda s: s.step).read(
+                select=lambda d: (
+                    d.potential_energy,
+                    d.kinetic_energy,
+                    d.internal_kinetic_energy,
+                    d.stress_tensor,
+                    d.volume,
+                )
+            )
+        )
+    return _analyze_md_systems(
+        system,
+        potential_energy,
+        kinetic_energy,
+        internal_kinetic_energy,
+        stress,
+        volume,
+        n_blocks,
+    )

--- a/src/kups/application/md/logging.py
+++ b/src/kups/application/md/logging.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 from typing import Protocol
 
-import jax
 from jax import Array
 
 from kups.application.md.data import MDParticles, MDSystems
@@ -15,6 +14,7 @@ from kups.core.data import Table
 from kups.core.storage import EveryNStep, Once, WriterGroupConfig
 from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass
+from kups.md.observables import system_kinetic_energy
 from kups.observables.stress import stress_via_virial_theorem
 
 
@@ -49,7 +49,9 @@ class MDStepData:
     Attributes:
         atoms: Indexed particle data.
         potential_energy: Potential energy per system.
-        kinetic_energy: Kinetic energy per system.
+        kinetic_energy: Total kinetic energy per system.
+        internal_kinetic_energy: Kinetic energy per system with center-of-mass
+            motion removed (used for temperature).
         stress_tensor: Virial stress tensor per system.
         volume: Cell volume per system (A^3).
     """
@@ -57,23 +59,23 @@ class MDStepData:
     atoms: Table[ParticleId, MDParticles]
     potential_energy: Array
     kinetic_energy: Array
+    internal_kinetic_energy: Array
     stress_tensor: Array
     volume: Array
 
     @staticmethod
     def from_state(state: HasMDData) -> MDStepData:
-        ke = jax.ops.segment_sum(
-            state.particles.data.kinetic_energy,
-            state.particles.data.system.indices,
-            state.particles.data.system.num_labels,
-        )
+        particles = state.particles
+        system = particles.data.system
+        momenta, masses = particles.data.momenta, particles.data.masses
         return MDStepData(
-            atoms=state.particles,
+            atoms=particles,
             potential_energy=state.systems.data.potential_energy,
-            kinetic_energy=ke,
-            stress_tensor=stress_via_virial_theorem(
-                state.particles, state.systems
-            ).data,
+            kinetic_energy=system_kinetic_energy(momenta, masses, system),
+            internal_kinetic_energy=system_kinetic_energy(
+                momenta, masses, system, remove_com=True
+            ),
+            stress_tensor=stress_via_virial_theorem(particles, state.systems).data,
             volume=state.systems.data.cell.volume,
         )
 

--- a/src/kups/application/relaxation/analysis.py
+++ b/src/kups/application/relaxation/analysis.py
@@ -44,6 +44,23 @@ class _IsRelaxInitData(Protocol):
     def systems(self) -> Table[SystemId, object]: ...
 
 
+def _analyze_relax(
+    system_keys: tuple[SystemId, ...],
+    final_energy: Array,
+    final_max_force: Array,
+    n_steps: int,
+) -> dict[SystemId, RelaxAnalysisResult]:
+    """Build per-system results from the final-step energy and force arrays."""
+    return {
+        sys_id: RelaxAnalysisResult(
+            final_energy=float(final_energy[i]),
+            final_max_force=float(final_max_force[i]),
+            n_steps=n_steps,
+        )
+        for i, sys_id in enumerate(system_keys)
+    }
+
+
 def analyze_relax(
     init_data: _IsRelaxInitData,
     step_data: IsRelaxStepData,
@@ -60,20 +77,22 @@ def analyze_relax(
     Returns:
         Per-system relaxation results keyed by ``SystemId``.
     """
-    results: dict[SystemId, RelaxAnalysisResult] = {}
-    for i, sys_id in enumerate(init_data.systems.keys):
-        results[sys_id] = RelaxAnalysisResult(
-            final_energy=float(step_data.potential_energy[i]),
-            final_max_force=float(step_data.max_force[i]),
-            n_steps=n_steps,
-        )
-    return results
+    return _analyze_relax(
+        init_data.systems.keys,
+        step_data.potential_energy,
+        step_data.max_force,
+        n_steps,
+    )
 
 
 def analyze_relax_file(
     hdf5_path: str | Path,
 ) -> dict[SystemId, RelaxAnalysisResult]:
     """Analyse relaxation results from an HDF5 file.
+
+    Reads only the system keys and the final step's per-system
+    ``potential_energy`` and ``max_force``, leaving the per-atom trajectory on
+    disk.
 
     Args:
         hdf5_path: Path to HDF5 output from a relaxation run.
@@ -84,7 +103,11 @@ def analyze_relax_file(
 
     with HDF5StorageReader[RelaxLoggedData](hdf5_path) as reader:
         n_steps = int(reader.file.attrs.get("actual_steps", -1))
-        init_data = reader.focus_group(lambda s: s.init)[...]
-        step_data = reader.focus_group(lambda s: s.step)[n_steps - 1]
+        system_keys = (
+            reader.focus_group(lambda s: s.init).read(select=lambda d: d.systems).keys
+        )
+        final_energy, final_max_force = reader.focus_group(lambda s: s.step).read(
+            n_steps - 1, select=lambda d: (d.potential_energy, d.max_force)
+        )
 
-    return analyze_relax(init_data, step_data, n_steps)
+    return _analyze_relax(system_keys, final_energy, final_max_force, n_steps)

--- a/src/kups/core/storage.py
+++ b/src/kups/core/storage.py
@@ -3,11 +3,16 @@
 
 """HDF5-backed storage for simulation trajectories.
 
-Provides async-writing :class:`HDF5StorageWriter` (Logger protocol) and
-:class:`HDF5StorageReader` for reading back logged data.  Logging frequency
-is controlled via :class:`LoggingFrequency` implementations (:class:`Once`,
-:class:`EveryNStep`); per-group chunking and compression are controlled via
-:class:`Compression`.
+Writing: :class:`HDF5StorageWriter` (a Logger) extracts per-group :class:`View`
+data from simulation state and writes it asynchronously on a background thread,
+buffering steps into contiguous block writes. Logging frequency is controlled
+via :class:`LoggingFrequency` implementations (:class:`Once`, :class:`EveryNStep`);
+per-group chunking and compression are controlled via :class:`Compression`.
+
+Reading: :class:`HDF5StorageReader` opens a logged file and exposes each group
+through a :class:`GroupReader`, which reconstructs the stored pytree and offers
+array-like indexing (``reader[idx]``) as well as :meth:`GroupReader.read_chunked`
+for streaming a trajectory in fixed-size chunks along the leading (time) axis.
 """
 
 from __future__ import annotations
@@ -19,11 +24,12 @@ import pickle
 import queue
 import threading
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
 from types import EllipsisType
-from typing import Any, Literal, Protocol, Self, cast, override
+from typing import Any, Literal, Protocol, Self, cast, overload, override
 
 import h5py
 import jax
@@ -42,9 +48,38 @@ class LoggingFrequency(Protocol):
     and map simulation steps to dataset indices.
     """
 
-    def should_log(self, step: int) -> bool: ...
-    def leading_shape(self, total_steps: int) -> tuple[int, ...]: ...
-    def dataset_index(self, step: int) -> Index: ...
+    def should_log(self, step: int) -> bool:
+        """Whether to log at this simulation step.
+
+        Args:
+            step: The current simulation step.
+
+        Returns:
+            ``True`` if data should be logged at ``step``.
+        """
+        ...
+
+    def leading_shape(self, total_steps: int) -> tuple[int, ...]:
+        """Leading (time) dimensions of this group's datasets.
+
+        Args:
+            total_steps: Total number of steps in the run.
+
+        Returns:
+            Dimensions prepended to each leaf's shape; empty for once-logged data.
+        """
+        ...
+
+    def dataset_index(self, step: int) -> Index:
+        """Index at which ``step``'s data is stored.
+
+        Args:
+            step: The current simulation step.
+
+        Returns:
+            The leading-axis index, or ``...`` for once-logged data.
+        """
+        ...
 
 
 class Once(LoggingFrequency):
@@ -123,6 +158,10 @@ class Compression:
             leading_dims: Leading (time) dimensions prepended to ``shape``.
             shape: Shape of a single logged value.
             itemsize: Bytes per element.
+
+        Returns:
+            Keyword arguments for ``create_dataset`` (chunks, compression,
+            shuffle); empty for scalar datasets, which are stored uncompressed.
         """
         if not leading_dims + shape:  # scalar: cannot chunk or compress
             return {}
@@ -138,6 +177,17 @@ class Compression:
     def _chunk_shape(
         self, leading_dims: tuple[int, ...], shape: tuple[int, ...], itemsize: int
     ) -> tuple[int, ...]:
+        """Chunk shape for one leaf, sized to roughly ``target_chunk_bytes``.
+
+        Args:
+            leading_dims: Leading (time) dimensions prepended to ``shape``.
+            shape: Shape of a single logged value.
+            itemsize: Bytes per element.
+
+        Returns:
+            ``(frames, *shape)`` along the time axis, or ``shape`` for once-logged
+            data.
+        """
         if not leading_dims:  # logged once: one chunk spanning the whole array
             return shape
         frame_bytes = max(itemsize * math.prod(shape), 1)
@@ -231,6 +281,11 @@ class HDF5StorageWriter[State, WriterConfig]:
     _actual_steps: int = field(init=False, default=0, repr=False)
 
     def __enter__(self) -> Self:
+        """Open the file, create datasets, and start the background writer thread.
+
+        Returns:
+            The writer, for use within the ``with`` block.
+        """
         self._file = h5py.File(self.out_path, "w")
         self._group_writers = _init_group_writers(
             self._file, self.config, self.initial_state, self.total_steps
@@ -244,6 +299,11 @@ class HDF5StorageWriter[State, WriterConfig]:
         return self
 
     def __exit__(self, *exc: object) -> None:
+        """Stop the writer thread, record ``actual_steps``, and close the file.
+
+        Args:
+            *exc: Context-manager exception info; unused.
+        """
         if self._bg_writer is not None:
             self._bg_writer.stop()
         if self._bg_thread is not None:
@@ -256,13 +316,26 @@ class HDF5StorageWriter[State, WriterConfig]:
             self._file = None
 
     def log(self, state: State, step: int) -> None:
-        """Queue state for async background writing."""
+        """Queue state for async background writing.
+
+        Args:
+            state: Full simulation state to extract and log.
+            step: The current simulation step.
+        """
         self._actual_steps = step + 1
         assert self._bg_writer is not None, "Must be used inside a with-block"
         self._bg_writer.write(state, step)
 
     def _prepare_write(self, state: State, step: int) -> list[tuple[int, Index, Any]]:
-        """Extract loggable data on the main thread (before JAX donation)."""
+        """Extract loggable data on the main thread (before JAX donation).
+
+        Args:
+            state: Full simulation state to extract from.
+            step: The current simulation step.
+
+        Returns:
+            ``(group_index, dataset_index, data)`` tuples for groups due to log.
+        """
         to_log: list[tuple[int, Index, Any]] = []
         for i, group in enumerate(self._group_writers):
             if group.logging_frequency.should_log(step):
@@ -271,6 +344,11 @@ class HDF5StorageWriter[State, WriterConfig]:
         return to_log
 
     def _write(self, to_write: list[tuple[int, Index, Any]]) -> None:
+        """Write extracted ``(group, index, data)`` tuples to their datasets.
+
+        Args:
+            to_write: ``(group_index, dataset_index, data)`` tuples to write.
+        """
         for i, idx, data in to_write:
             self._group_writers[i].writer.write(data, idx)
 
@@ -281,7 +359,17 @@ def _init_group_writers[S, WC](
     state: S,
     total_steps: int,
 ) -> list[GroupWriters[S, Any]]:
-    """Shared init logic: create HDF5 groups and datasets from config."""
+    """Create one HDF5 group and its datasets per ``WriterGroupConfig`` leaf.
+
+    Args:
+        hdf5_file: Open file to populate with groups and metadata.
+        config: Pytree of ``WriterGroupConfig`` leaves describing each group.
+        state: Initial state, used to size each group's datasets.
+        total_steps: Total steps in the run, used for the leading dimensions.
+
+    Returns:
+        One ``GroupWriters`` per config leaf, in leaf order.
+    """
     confs_and_paths, conf_structure = jax.tree.flatten_with_path(
         config, is_leaf=lambda x: isinstance(x, WriterGroupConfig)
     )
@@ -329,6 +417,17 @@ class Hdf5ObjWriter[Storage]:
         leading_dims: tuple[int, ...],
         compression: Compression | None = None,
     ) -> Hdf5ObjWriter[S]:
+        """Create one dataset per array leaf of ``state`` and persist its pytree structure.
+
+        Args:
+            hdf5_group: Group to populate with datasets and metadata.
+            state: Sample value whose leaves define dataset shapes and dtypes.
+            leading_dims: Leading (time) dimensions prepended to each leaf shape.
+            compression: Compression/chunking policy, or ``None`` for contiguous datasets.
+
+        Returns:
+            A writer bound to the created datasets.
+        """
         datasets: list[h5py.Dataset] = []
         paths: list[str] = []
         for path, tensor in jax.tree.leaves_with_path(state):
@@ -356,6 +455,12 @@ class Hdf5ObjWriter[Storage]:
         return Hdf5ObjWriter(datasets)
 
     def write(self, state: Storage, index: Index) -> None:
+        """Write a single value's leaves to ``index`` of their datasets.
+
+        Args:
+            state: Value whose leaves are written.
+            index: Dataset index to write each leaf to.
+        """
         for dataset, value in zip(self.datasets, jax.tree.leaves(state)):
             dataset[index] = np.asarray(value)
 
@@ -364,6 +469,10 @@ class Hdf5ObjWriter[Storage]:
 
         Stacks each leaf across ``states`` and writes one slice per dataset,
         amortising the per-call overhead of single-step writes.
+
+        Args:
+            states: Per-step values to stack and write, in order.
+            start: Leading-axis index of the first state.
         """
         leaves = [jax.tree.leaves(s) for s in states]
         stop = start + len(states)
@@ -388,26 +497,41 @@ class HDF5StorageReader[Config]:
     _file: h5py.File | None = field(init=False, default=None, repr=False)
 
     def __enter__(self) -> Self:
+        """Open the HDF5 file for reading.
+
+        Returns:
+            The reader, for use within the ``with`` block.
+        """
         self._file = h5py.File(self.path, "r")
         return self
 
     def __exit__(self, *exc: object) -> None:
+        """Close the file.
+
+        Args:
+            *exc: Context-manager exception info; unused.
+        """
         if self._file is not None:
             self._file.close()
             self._file = None
 
     @property
     def file(self) -> h5py.File:
+        """The open HDF5 file; requires use as a context manager."""
         assert self._file is not None, "File not open; use as context manager"
         return self._file
 
     def focus_group[Storage](
         self, view_or_name: View[Config, WriterGroupConfig[Any, Storage]] | str
     ) -> GroupReader[Storage]:
-        """Returns a reader for a specific logging group.
+        """Return a reader for a specific logging group.
 
         Args:
-            view_or_name: Either a string group name or a View lens.
+            view_or_name: Either a string group name or a ``View`` lens that
+                selects the group from the config pytree.
+
+        Returns:
+            A reader for the focused group.
         """
         if isinstance(view_or_name, str):
             return GroupReader[Storage](self.file[view_or_name])  # type: ignore - h5py is not very good with types
@@ -430,6 +554,11 @@ class HDF5StorageReader[Config]:
         return GroupReader[Storage](group)
 
     def list_groups(self) -> list[str]:
+        """List the names of all logging groups in the file.
+
+        Returns:
+            Group names, in config-pytree leaf order.
+        """
         try:
             group_names = json.loads(self.file.attrs["group_names"])  # type: ignore - h5py is not very good with types
             return group_names
@@ -445,10 +574,12 @@ class GroupReader[Storage]:
 
     @cached_property
     def paths(self) -> list[str]:
+        """Dataset names for this group's array leaves, in pytree-leaf order."""
         return json.loads(self.group.attrs["paths"])  # type: ignore - h5py is not very good with types
 
     @cached_property
     def tree_def(self) -> PyTreeDef[Storage]:
+        """Pytree structure of the stored value, for reassembling reads into Storage."""
         if "tree_def" in self.group:
             raw = bytes(self.group["tree_def"][()])  # type: ignore - h5py typing
         else:
@@ -456,20 +587,96 @@ class GroupReader[Storage]:
         tree_def = pickle.loads(raw)
         return tree_def
 
-    def read(self, index: Index) -> Storage:
-        if index is None:
-            index = slice(None)
+    @cached_property
+    def _names_tree(self) -> Storage:
+        """Group pytree with each array leaf replaced by its dataset name.
 
+        A :class:`~kups.core.lens.View` applied to this tree navigates purely
+        structurally — container keys are static metadata carried by the tree
+        structure — and yields the dataset name(s) for the focused field, so a
+        field read touches only those datasets.
+        """
+        with no_post_init():
+            return self.tree_def.unflatten(self.paths)  # type: ignore - string leaves stand in for arrays
+
+    def _read_leaves(
+        self, leaves: list[str], treedef: PyTreeDef[Any], index: Index
+    ) -> Any:
         def read_dataset(
-            path: str,
+            name: str,
         ) -> np.ndarray[tuple[int, ...], np.dtype[np.generic]]:
-            dataset = self.group["".join(map(str, path))]
-            return dataset[index]  # type: ignore - pylance doesn't understand h5py correctly.
+            return self.group["".join(map(str, name))][index]  # type: ignore - pylance doesn't understand h5py correctly.
 
         with no_post_init():
-            return self.tree_def.unflatten(jax.tree.map(read_dataset, self.paths))
+            return treedef.unflatten(jax.tree.map(read_dataset, leaves))
+
+    @overload
+    def read(self, index: Index = ..., *, select: None = ...) -> Storage: ...
+    @overload
+    def read[Field](
+        self, index: Index = ..., *, select: View[Storage, Field]
+    ) -> Field: ...
+    def read[Field](
+        self, index: Index = slice(None), *, select: View[Storage, Field] | None = None
+    ) -> Storage | Field:
+        """Read ``index`` from each leaf dataset and reassemble the stored pytree.
+
+        Args:
+            index: Index applied to each leaf dataset (int, slice, ellipsis, or
+                tuple thereof). Defaults to the whole leading axis.
+            select: Optional lens focusing a field (or sub-pytree) of the stored
+                value. When given, only the datasets backing that field are read
+                and the focused value is returned; when ``None`` the whole group
+                is read.
+
+        Returns:
+            The stored value (``select=None``) or the focused field, with each
+            leaf sliced by ``index``.
+        """
+        if index is None:
+            index = slice(None)
+        if select is None:
+            return self._read_leaves(self.paths, self.tree_def, index)
+        leaves, treedef = jax.tree.flatten(select(self._names_tree))
+        return self._read_leaves(leaves, treedef, index)
+
+    @overload
+    def read_chunked(
+        self, chunk_size: int, *, select: None = ...
+    ) -> Iterator[Storage]: ...
+    @overload
+    def read_chunked[Field](
+        self, chunk_size: int, *, select: View[Storage, Field]
+    ) -> Iterator[Field]: ...
+    def read_chunked[Field](
+        self, chunk_size: int, *, select: View[Storage, Field] | None = None
+    ) -> Iterator[Storage] | Iterator[Field]:
+        """Yield successive chunks along the leading (time) axis.
+
+        Args:
+            chunk_size: Number of leading-axis frames per chunk; must be positive.
+            select: Optional lens focusing a field of the stored value; when
+                given each chunk reads only that field's datasets (see
+                :meth:`read`).
+
+        Yields:
+            Each chunk as a read of at most ``chunk_size`` frames (the whole
+            value or the focused field); the final chunk may be shorter.
+        """
+        assert chunk_size > 0, "chunk_size must be positive"
+        length = self.group["".join(map(str, self.paths[0]))].shape[0]  # type: ignore - h5py typing
+        for start in range(0, length, chunk_size):
+            yield self.read(slice(start, start + chunk_size), select=select)
 
     def __getitem__(self, index: Index) -> Storage:
+        """Array-like access; equivalent to :meth:`read`.
+
+        Args:
+            index: Index applied to each leaf dataset.
+
+        Returns:
+            The stored value with each leaf sliced by ``index``.
+        """
         return self.read(index)
 
 
@@ -508,10 +715,20 @@ class BackgroundWriter[State, WriterConfig]:
         logging.info("Writer thread stopped")
 
     def write(self, state: State, step: int) -> None:
-        """Queue state data for asynchronous writing to HDF5."""
+        """Queue state data for asynchronous writing to HDF5.
+
+        Args:
+            state: Full simulation state to extract and queue.
+            step: The current simulation step.
+        """
         self.data_queue.put(self.storage_writer._prepare_write(state, step))
 
     def _buffer(self, to_log: list[tuple[int, Index, Any]]) -> None:
+        """Append each group's data to its buffer, flushing when the batch is full.
+
+        Args:
+            to_log: ``(group_index, dataset_index, data)`` tuples to buffer.
+        """
         group_writers = self.storage_writer._group_writers
         for i, index, data in to_log:
             buffer = self._buffers[i]
@@ -520,6 +737,11 @@ class BackgroundWriter[State, WriterConfig]:
                 self._flush_group(i)
 
     def _flush_group(self, i: int) -> None:
+        """Write group ``i``'s buffer as one block if contiguous, else step by step.
+
+        Args:
+            i: Index of the group whose buffer to flush.
+        """
         buffer = self._buffers.get(i)
         if not buffer:
             return
@@ -538,6 +760,7 @@ class BackgroundWriter[State, WriterConfig]:
         buffer.clear()
 
     def _flush_all(self) -> None:
+        """Flush every group's pending buffer."""
         for i in list(self._buffers):
             self._flush_group(i)
 

--- a/src/kups/md/observables.py
+++ b/src/kups/md/observables.py
@@ -63,6 +63,27 @@ def remove_center_of_mass_momentum(
     return momenta - masses[..., None] * com_velocity[system.indices]
 
 
+def system_kinetic_energy(
+    momenta: Array, masses: Array, system: Index[SystemId], *, remove_com: bool = False
+) -> Array:
+    """Total kinetic energy per system.
+
+    Args:
+        momenta: Particle momenta, shape ``(n_atoms, 3)``.
+        masses: Particle masses, shape ``(n_atoms,)``.
+        system: Per-atom system index.
+        remove_com: If ``True``, subtract each system's center-of-mass motion
+            first, yielding the internal (thermal) kinetic energy used for
+            temperature.
+
+    Returns:
+        Kinetic energy per system, shape ``(n_systems,)``.
+    """
+    if remove_com:
+        momenta = remove_center_of_mass_momentum(momenta, masses, system)
+    return system.sum_over(particle_kinetic_energy(momenta, masses)).data
+
+
 @vectorize(signature="(),(3,3),()->()")
 def instantaneous_pressure(
     kinetic_energy: Array,

--- a/test/application/test_mcmc_analysis.py
+++ b/test/application/test_mcmc_analysis.py
@@ -4,7 +4,10 @@
 """Tests for kups.application.mcmc.analysis."""
 
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
+import jax
 import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
@@ -14,10 +17,13 @@ from kups.application.mcmc.analysis import (
     _analyze_single_system,
     _analyze_single_widom_system,
     analyze_mcmc,
+    analyze_mcmc_file,
 )
 from kups.application.mcmc.data import StressResult
 from kups.core.constants import BOLTZMANN_CONSTANT
 from kups.core.data import Table
+from kups.core.lens import view
+from kups.core.storage import EveryNStep, HDF5StorageWriter, Once, WriterGroupConfig
 from kups.core.typing import MotifId, SystemId
 from kups.core.utils.jax import dataclass as jax_dataclass
 from kups.core.utils.jax import no_post_init
@@ -196,3 +202,118 @@ class TestAnalyzeSingleWidomSystem:
         npt.assert_allclose(float(result.excess_chemical_potential.sem), 0.0, atol=1e-9)
         npt.assert_allclose(float(result.henry_coefficient.sem), 0.0, atol=1e-9)
         npt.assert_allclose(float(result.heat_of_adsorption.sem), 0.0, atol=1e-9)
+
+
+jax.tree_util.register_dataclass(_FixedData)
+jax.tree_util.register_dataclass(_SystemStepData)
+jax.tree_util.register_dataclass(_StepData)
+
+
+@jax_dataclass
+class _MCMCFileConfig:
+    """Two-group writer config mirroring the MCMC logging schema shape."""
+
+    fixed: WriterGroupConfig[Any, Any]
+    per_step: WriterGroupConfig[Any, Any]
+
+
+@jax_dataclass
+class _MCMCFileState:
+    """Per-step state the writer extracts ``fixed``/``per_step`` groups from."""
+
+    fixed: _FixedData
+    per_step: _StepData
+
+
+def test_analyze_mcmc_file_matches_in_memory(tmp_path: Path):
+    """analyze_mcmc_file (selective reads) matches analyze_mcmc on identical data."""
+    n_steps, sys0, sys1 = 60, SystemId(0), SystemId(1)
+    count_keys = ((sys0, MotifId(0)), (sys1, MotifId(0)))
+    base = jnp.array([1.0, 2.0])
+
+    def step(t: int) -> _StepData:
+        energy = base + 0.05 * jnp.sin(jnp.array([t, t + 1.0]))
+        counts = jnp.array([4.0, 6.0]) + 0.1 * jnp.cos(jnp.array([t, t + 2.0]))
+        stress = jnp.stack([jnp.eye(3) * (0.3 + 0.01 * t), jnp.eye(3) * 0.5])
+        zero = jnp.zeros_like(stress)
+        with no_post_init():
+            return _StepData(
+                particle_count=Table(count_keys, counts),
+                systems=Table(
+                    (sys0, sys1),
+                    _SystemStepData(
+                        potential_energy=energy,
+                        guest_stress=StressResult(stress, zero, zero),
+                    ),
+                ),
+            )
+
+    with no_post_init():
+        fixed = _FixedData(
+            systems=Table((sys0, sys1), _Temps(temperature=jnp.array([300.0, 400.0])))
+        )
+    # Build the in-memory comparison object from the stacked per-step trajectory.
+    steps = [step(t) for t in range(n_steps)]
+    with no_post_init():
+        per_step_full = _StepData(
+            particle_count=Table(
+                count_keys, jnp.stack([s.particle_count.data for s in steps], axis=0)
+            ),
+            systems=Table(
+                (sys0, sys1),
+                _SystemStepData(
+                    potential_energy=jnp.stack(
+                        [s.systems.data.potential_energy for s in steps], axis=0
+                    ),
+                    guest_stress=StressResult(
+                        jnp.stack(
+                            [s.systems.data.guest_stress.potential for s in steps],
+                            axis=0,
+                        ),
+                        jnp.stack(
+                            [
+                                s.systems.data.guest_stress.tail_correction
+                                for s in steps
+                            ],
+                            axis=0,
+                        ),
+                        jnp.stack(
+                            [s.systems.data.guest_stress.ideal_gas for s in steps],
+                            axis=0,
+                        ),
+                    ),
+                ),
+            ),
+        )
+    expected = analyze_mcmc(fixed, per_step_full, n_blocks=5)
+
+    config = _MCMCFileConfig(
+        fixed=WriterGroupConfig(view=view(lambda s: s.fixed), logging_frequency=Once()),
+        per_step=WriterGroupConfig(
+            view=view(lambda s: s.per_step), logging_frequency=EveryNStep(1)
+        ),
+    )
+    path = tmp_path / "mcmc.h5"
+    writer = HDF5StorageWriter(
+        path, config, _MCMCFileState(fixed, steps[0]), total_steps=n_steps
+    )
+    with writer:
+        for t in range(n_steps):
+            writer.log(_MCMCFileState(fixed, steps[t]), t)
+
+    result = analyze_mcmc_file(path, n_blocks=5)
+
+    assert result.keys() == expected.keys()
+    for sys_id in expected:
+        e, r = expected[sys_id], result[sys_id]
+        npt.assert_allclose(r.energy.mean, e.energy.mean, rtol=1e-6)
+        npt.assert_allclose(r.loading.mean, e.loading.mean, rtol=1e-6)
+        npt.assert_allclose(
+            r.heat_of_adsorption.mean, e.heat_of_adsorption.mean, rtol=1e-6
+        )
+        assert (r.stress is None) == (e.stress is None)
+        if e.stress is not None:
+            assert r.stress is not None
+            assert r.pressure is not None and e.pressure is not None
+            npt.assert_allclose(r.stress.mean, e.stress.mean, rtol=1e-6)
+            npt.assert_allclose(r.pressure.mean, e.pressure.mean, rtol=1e-6)

--- a/test/application/test_md_analysis.py
+++ b/test/application/test_md_analysis.py
@@ -1,40 +1,35 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for kups.application.md.analysis.analyze_md."""
+"""Tests for kups.application.md.analysis."""
 
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
 
 import jax
 import jax.numpy as jnp
 import pytest
 from jax import Array
 
-from kups.application.md.analysis import analyze_md
+from kups.application.md.analysis import analyze_md, analyze_md_file
 from kups.core.constants import BOLTZMANN_CONSTANT
 from kups.core.data import Index, Table
+from kups.core.lens import view
+from kups.core.storage import EveryNStep, HDF5StorageWriter, Once, WriterGroupConfig
 from kups.core.typing import ParticleId, SystemId
-from kups.core.utils.jax import no_post_init
+from kups.core.utils.jax import dataclass as jax_dataclass
 
 
 @dataclass
 class MockAtomData:
-    """Mock satisfying _IsMDAtoms (HasPositions + system index)."""
+    """Mock init atoms providing the per-atom system index."""
 
     positions: Array
     system: Index[SystemId]
 
 
-@dataclass
-class MockStepAtomData:
-    """Mock satisfying per-step atom momenta and masses."""
-
-    momenta: Array
-    masses: Array
-
-
 jax.tree_util.register_dataclass(MockAtomData)
-jax.tree_util.register_dataclass(MockStepAtomData)
 
 
 @dataclass
@@ -46,13 +41,33 @@ class MockInitData:
 
 @dataclass
 class MockStepData:
-    """Mock satisfying IsMDStepData."""
+    """Mock satisfying IsMDStepData (per-step thermodynamic scalars)."""
 
     potential_energy: Array
     kinetic_energy: Array
     stress_tensor: Array
     volume: Array
-    atoms: Table[ParticleId, MockStepAtomData]
+    internal_kinetic_energy: Array
+
+
+jax.tree_util.register_dataclass(MockInitData)
+jax.tree_util.register_dataclass(MockStepData)
+
+
+@jax_dataclass
+class _MDFileConfig:
+    """Two-group writer config mirroring the MD logging schema shape."""
+
+    init: WriterGroupConfig[Any, Any]
+    step: WriterGroupConfig[Any, Any]
+
+
+@jax_dataclass
+class _MDFileState:
+    """Per-step state the writer extracts ``init``/``step`` groups from."""
+
+    init: MockInitData
+    step: MockStepData
 
 
 def _make_init(n_atoms: int = 10, n_systems: int = 1) -> MockInitData:
@@ -66,54 +81,20 @@ def _make_init(n_atoms: int = 10, n_systems: int = 1) -> MockInitData:
     return MockInitData(atoms=Table(keys=keys, data=data))
 
 
-def _make_step_atoms_from_kinetic_energy(
-    ke: Array,
-    n_atoms: int = 10,
-) -> Table[ParticleId, MockStepAtomData]:
-    """Create per-step atoms whose internal kinetic energy matches ``ke``."""
-    n_steps, n_systems = ke.shape
-    dtype = jnp.result_type(ke, jnp.float32)
-    momenta = jnp.zeros((n_steps, n_atoms, 3), dtype=dtype)
-    masses = jnp.ones((n_steps, n_atoms), dtype=dtype)
-
-    for system_number in range(n_systems):
-        atom_indices = [i for i in range(n_atoms) if i % n_systems == system_number]
-        if len(atom_indices) < 2:
-            raise ValueError(
-                "At least two atoms per system are needed for mock momenta"
-            )
-
-        amplitude = jnp.sqrt(ke[:, system_number].astype(dtype))
-        momenta = momenta.at[:, atom_indices[0], 0].set(amplitude)
-        momenta = momenta.at[:, atom_indices[1], 0].set(-amplitude)
-
-    with no_post_init():
-        return Table(
-            keys=tuple(ParticleId(i) for i in range(n_atoms)),
-            data=MockStepAtomData(momenta=momenta, masses=masses),
-        )
-
-
 def _make_step(
     pe: Array,
     ke: Array,
     stress: Array,
     volume: Array | None = None,
-    atoms: Table[ParticleId, MockStepAtomData] | None = None,
-    *,
-    n_atoms: int = 10,
+    internal_ke: Array | None = None,
 ) -> MockStepData:
-    """Create mock step data with per-step atoms."""
-    if volume is None:
-        volume = jnp.ones(pe.shape)
-    if atoms is None:
-        atoms = _make_step_atoms_from_kinetic_energy(ke, n_atoms=n_atoms)
+    """Create mock step data; internal KE defaults to the logged KE."""
     return MockStepData(
         potential_energy=pe,
         kinetic_energy=ke,
         stress_tensor=stress,
-        volume=volume,
-        atoms=atoms,
+        volume=jnp.ones(pe.shape) if volume is None else volume,
+        internal_kinetic_energy=ke if internal_ke is None else internal_ke,
     )
 
 
@@ -138,7 +119,7 @@ class TestAnalyzeMD:
         assert r.energy_drift == pytest.approx(0.0, abs=1e-12)
 
     def test_temperature(self):
-        """Temperature follows T = 2*KE / (k_B * DOF)."""
+        """Temperature follows T = 2*internal_KE / (k_B * DOF)."""
         n_atoms = 10
         n_steps = 100
         ke_val = 0.3
@@ -150,58 +131,33 @@ class TestAnalyzeMD:
         stress = jnp.zeros((n_steps, 1, 3, 3))
 
         results = analyze_md(
-            _make_init(n_atoms),
-            _make_step(pe, ke, stress, n_atoms=n_atoms),
-            n_blocks=10,
+            _make_init(n_atoms), _make_step(pe, ke, stress), n_blocks=10
         )
         r = results[SystemId(0)]
 
         assert r.temperature.mean == pytest.approx(expected_temp, rel=1e-6)
         assert r.n_atoms == n_atoms
 
-    def test_temperature_subtracts_center_of_mass_kinetic_energy(self):
-        """Internal temperature excludes COM drift when per-step momenta are logged."""
-        n_steps = 100
-        n_atoms = 2
+    def test_temperature_uses_internal_kinetic_energy(self):
+        """Temperature is driven by internal KE, independent of the logged KE."""
+        n_atoms, n_steps = 10, 100
         dof = 3 * n_atoms - 3
-        momenta = jnp.tile(
-            jnp.array([[[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]]),
-            (n_steps, 1, 1),
-        )
-        masses = jnp.ones((n_steps, n_atoms))
-        with no_post_init():
-            atoms = Table(
-                keys=tuple(ParticleId(i) for i in range(n_atoms)),
-                data=MockStepAtomData(momenta=momenta, masses=masses),
-            )
         pe = jnp.zeros((n_steps, 1))
-        ke = jnp.full((n_steps, 1), 1.0)
+        ke = jnp.full((n_steps, 1), 5.0)
+        internal_ke = jnp.full((n_steps, 1), 0.3)
         stress = jnp.zeros((n_steps, 1, 3, 3))
 
         results = analyze_md(
-            _make_init(n_atoms), _make_step(pe, ke, stress, atoms=atoms), n_blocks=10
-        )
-
-        expected_temp = 2.0 / (BOLTZMANN_CONSTANT * dof)
-        assert results[SystemId(0)].temperature.mean == pytest.approx(
-            expected_temp, rel=1e-6
-        )
-
-        com_momenta = jnp.tile(
-            jnp.array([[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]]),
-            (n_steps, 1, 1),
-        )
-        with no_post_init():
-            com_atoms = Table(
-                keys=tuple(ParticleId(i) for i in range(n_atoms)),
-                data=MockStepAtomData(momenta=com_momenta, masses=masses),
-            )
-        com_results = analyze_md(
             _make_init(n_atoms),
-            _make_step(pe, ke, stress, atoms=com_atoms),
+            _make_step(pe, ke, stress, internal_ke=internal_ke),
             n_blocks=10,
         )
-        assert com_results[SystemId(0)].temperature.mean == pytest.approx(0.0)
+        r = results[SystemId(0)]
+
+        assert r.kinetic_energy.mean == pytest.approx(5.0)
+        assert r.temperature.mean == pytest.approx(
+            2 * 0.3 / (BOLTZMANN_CONSTANT * dof), rel=1e-6
+        )
 
     def test_pressure(self):
         """Pressure equals trace of diagonal stress / 3."""
@@ -254,3 +210,75 @@ class TestAnalyzeMD:
         assert r1.kinetic_energy.mean == pytest.approx(1.0)
         assert r0.n_atoms == 5
         assert r1.n_atoms == 5
+
+
+def _trajectory(
+    n_steps: int, n_systems: int, n_atoms: int
+) -> tuple[MockInitData, list[MockStepData]]:
+    """Constant init data and a deterministic per-step trajectory."""
+    init = _make_init(n_atoms, n_systems)
+    base = jnp.arange(n_systems, dtype=jnp.float64)
+    steps = [
+        MockStepData(
+            potential_energy=base + 0.1 * t,
+            kinetic_energy=0.5 * base + 0.01 * t + 1.0,
+            stress_tensor=jnp.eye(3) * (0.2 * t + base[:, None, None]),
+            volume=base + 100.0 + t,
+            internal_kinetic_energy=0.4 * base + 0.01 * t + 0.9,
+        )
+        for t in range(n_steps)
+    ]
+    return init, steps
+
+
+def _stack_steps(steps: list[MockStepData]) -> MockStepData:
+    """Stack per-step states into one trajectory object (leading time axis)."""
+    return MockStepData(
+        potential_energy=jnp.stack([s.potential_energy for s in steps]),
+        kinetic_energy=jnp.stack([s.kinetic_energy for s in steps]),
+        stress_tensor=jnp.stack([s.stress_tensor for s in steps]),
+        volume=jnp.stack([s.volume for s in steps]),
+        internal_kinetic_energy=jnp.stack([s.internal_kinetic_energy for s in steps]),
+    )
+
+
+def test_analyze_md_file_matches_in_memory(tmp_path: Path):
+    """analyze_md_file (selective reads) matches analyze_md on identical data."""
+    n_steps, n_systems, n_atoms = 20, 2, 8
+    init, steps = _trajectory(n_steps, n_systems, n_atoms)
+    expected = analyze_md(init, _stack_steps(steps), n_blocks=5)
+
+    config = _MDFileConfig(
+        init=WriterGroupConfig(view=view(lambda s: s.init), logging_frequency=Once()),
+        step=WriterGroupConfig(
+            view=view(lambda s: s.step), logging_frequency=EveryNStep(1)
+        ),
+    )
+    path = tmp_path / "md.h5"
+    writer = HDF5StorageWriter(
+        path, config, _MDFileState(init, steps[0]), total_steps=n_steps
+    )
+    with writer:
+        for t in range(n_steps):
+            writer.log(_MDFileState(init, steps[t]), t)
+
+    result = analyze_md_file(path, n_blocks=5)
+
+    assert result.keys() == expected.keys()
+    fields = (
+        "potential_energy",
+        "kinetic_energy",
+        "total_energy",
+        "temperature",
+        "pressure",
+        "volume",
+    )
+    for sys_id in expected:
+        e, r = expected[sys_id], result[sys_id]
+        assert (r.n_atoms, r.n_steps) == (e.n_atoms, e.n_steps)
+        assert r.energy_drift == pytest.approx(e.energy_drift, rel=1e-6, abs=1e-9)
+        for f in fields:
+            assert getattr(r, f).mean == pytest.approx(getattr(e, f).mean, rel=1e-6)
+            assert getattr(r, f).sem == pytest.approx(
+                getattr(e, f).sem, rel=1e-6, abs=1e-9
+            )

--- a/test/core/test_storage.py
+++ b/test/core/test_storage.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
 
+from kups.core.data import Table
 from kups.core.lens import view
 from kups.core.storage import (
     Compression,
@@ -21,6 +22,7 @@ from kups.core.storage import (
     Once,
     WriterGroupConfig,
 )
+from kups.core.typing import SystemId
 from kups.core.utils.jax import dataclass
 
 
@@ -231,6 +233,35 @@ class TestGroupReader:
             npt.assert_array_equal(group_reader[2]["pos"], simple_state.position + 2)
             npt.assert_array_equal(group_reader[-1]["pos"], simple_state.position + 9)
             assert group_reader[::2]["pos"].shape == (5, 3)
+
+    def test_read_chunked(self, simple_state: SimpleState, temp_file: str):
+        """read_chunked tiles the trajectory into fixed-size chunks with a partial tail."""
+        writer = HDF5StorageWriter(
+            temp_file,
+            WriterGroupConfig(
+                view=view(lambda s: {"pos": s.position}),
+                logging_frequency=EveryNStep(1),
+            ),
+            simple_state,
+            total_steps=10,
+        )
+        with writer:
+            for i in range(10):
+                state = SimpleState(
+                    position=simple_state.position + i,
+                    velocity=simple_state.velocity,
+                    energy=simple_state.energy,
+                )
+                writer.log(state, i)
+
+        with HDF5StorageReader(temp_file) as reader:
+            group_reader = reader.focus_group("group")
+            chunks = list(group_reader.read_chunked(4))
+            assert [c["pos"].shape[0] for c in chunks] == [4, 4, 2]
+            joined = jnp.concatenate([c["pos"] for c in chunks])
+            npt.assert_array_equal(joined, group_reader[:]["pos"])
+            with pytest.raises(AssertionError):
+                list(group_reader.read_chunked(0))
 
 
 class TestIntegration:
@@ -459,3 +490,86 @@ class TestAutoBatching:
             npt.assert_array_equal(traj[6], state.position + 6)
             init = reader.focus_group("group['init']")[...]["pos"]
             npt.assert_array_equal(init, state.position)
+
+
+@dataclass
+class _Row:
+    energy: jax.Array
+    force: jax.Array
+
+
+@dataclass
+class _StepStore:
+    systems: Table[SystemId, _Row]
+    volume: jax.Array
+
+
+@dataclass
+class _SelState:
+    step: _StepStore
+
+
+def _make_sel_state(n_systems: int, i: int) -> _SelState:
+    keys = tuple(SystemId(s) for s in range(n_systems))
+    base = jnp.arange(n_systems, dtype=jnp.float64)
+    systems = Table(keys, _Row(energy=base + i, force=base * 0.1 + i))
+    return _SelState(step=_StepStore(systems=systems, volume=base + 10.0 + i))
+
+
+class TestFieldSelection:
+    """Selective (`select=`) reads of single fields and sub-trees."""
+
+    def test_select_field_and_subtree(self, temp_file: str):
+        """A lens reads only its field; matches the corresponding whole-group read."""
+        n_systems, n_steps = 3, 10
+        config = WriterGroupConfig(
+            view=view(lambda s: s.step), logging_frequency=EveryNStep(1)
+        )
+        writer = HDF5StorageWriter(
+            temp_file, config, _make_sel_state(n_systems, 0), total_steps=n_steps
+        )
+        with writer:
+            for i in range(n_steps):
+                writer.log(_make_sel_state(n_systems, i), i)
+
+        with HDF5StorageReader(temp_file) as reader:
+            g = reader.focus_group("group")
+            full = g[:]
+
+            # Single leaf: returns just that array.
+            energy = g.read(select=lambda d: d.systems.data.energy)
+            assert energy.shape == (n_steps, n_systems)
+            npt.assert_array_equal(energy, full.systems.data.energy)
+
+            # Sub-tree: returns the row struct with only its leaves.
+            row = g.read(select=lambda d: d.systems.data)
+            npt.assert_array_equal(row.force, full.systems.data.force)
+
+            # Selecting a Table preserves its static keys.
+            systems = g.read(select=lambda d: d.systems)
+            assert systems.keys == tuple(SystemId(s) for s in range(n_systems))
+            npt.assert_array_equal(systems.data.energy, full.systems.data.energy)
+
+            # Final-frame field read (relaxation-style access).
+            last = g.read(n_steps - 1, select=lambda d: d.systems.data.energy)
+            npt.assert_array_equal(last, full.systems.data.energy[n_steps - 1])
+
+    def test_select_chunked(self, temp_file: str):
+        """Chunked field reads tile back into the full single-field series."""
+        n_systems, n_steps = 2, 10
+        config = WriterGroupConfig(
+            view=view(lambda s: s.step), logging_frequency=EveryNStep(1)
+        )
+        writer = HDF5StorageWriter(
+            temp_file, config, _make_sel_state(n_systems, 0), total_steps=n_steps
+        )
+        with writer:
+            for i in range(n_steps):
+                writer.log(_make_sel_state(n_systems, i), i)
+
+        with HDF5StorageReader(temp_file) as reader:
+            g = reader.focus_group("group")
+            full_energy = g[:].systems.data.energy
+            chunks = list(g.read_chunked(4, select=lambda d: d.systems.data.energy))
+            assert [c.shape[0] for c in chunks] == [4, 4, 2]
+            npt.assert_array_equal(jnp.concatenate(chunks), full_energy)


### PR DESCRIPTION
This PR extends `GroupReader` with selective and streaming reads, then threads those capabilities through all three analysis pipelines so that file-based analysis reads only the data it actually needs.

## `GroupReader` additions

`GroupReader.read` gains an optional `select` lens parameter. When supplied, the lens is applied to a structural shadow of the stored pytree (leaves replaced by dataset names) to identify which datasets back the requested field; only those datasets are opened and read. The return type narrows to the focused field rather than the full group type.

`GroupReader.read_chunked` is a new method that walks the leading time axis in fixed-size blocks, yielding one chunk per iteration (the final chunk may be shorter). It accepts the same `select` lens as `read`, so a streaming reduction over one field never touches the other datasets or loads the full trajectory into memory.

`GroupReader.__getitem__` is now a thin alias for `read`, and the internal `_read_leaves` / `_names_tree` helpers support both entry points.

## MD logging: `internal_kinetic_energy` logged per step

`MDStepData` gains an `internal_kinetic_energy` field computed by removing center-of-mass momentum before summing kinetic energy per system. A new `system_kinetic_energy` helper in `kups.md.observables` encapsulates both the plain and COM-projected variants behind a `remove_com` flag. The analysis no longer reconstructs momenta from the stored per-atom trajectory; it reads the pre-computed scalar directly.

## Analysis pipelines: selective file reads

`analyze_mcmc_file`, `analyze_widom_file`, and `analyze_relax_file` are rewritten to use `select=` reads instead of loading entire groups. Each function reads only the fields its computation touches — system metadata, particle counts, potential energy, guest stress, or the final-step scalars — leaving per-atom trajectories and unneeded columns on disk.

The public `analyze_mcmc` and `analyze_widom` functions are preserved unchanged. Their logic is extracted into private `_analyze_mcmc` and `_analyze_widom` helpers that accept plain arrays rather than the full logged-data structs, so the file-reading path can call them directly after selective reads without constructing intermediate objects.

A redundant `n_blocks_used` variable is removed throughout `_analyze_single_system` and `_analyze_single_widom_system`; `n_blocks` is reassigned in place when auto-selected.

## Tests

- `TestGroupReader` gains a `test_read_chunked` case covering chunk tiling, partial tail, and the zero-chunk-size guard.
- A new `TestFieldSelection` suite covers single-leaf `select=` reads, sub-tree reads, `Table`-preserving reads, final-frame indexed reads, and chunked field reads.
- `test_analyze_mcmc_file_matches_in_memory` writes a synthetic two-system MCMC trajectory to HDF5 and asserts that `analyze_mcmc_file` produces results identical to `analyze_mcmc` on the same in-memory data.
- `test_analyze_md_file_matches_in_memory` does the same for the MD pipeline, including the `internal_kinetic_energy` field.
- The existing COM-subtraction test is replaced by a simpler `test_temperature_uses_internal_kinetic_energy` that passes `internal_ke` directly rather than constructing mock momenta.

## Notebook

The logging notebook's `HDF5StorageReader` section is expanded into a standalone walkthrough covering `focus_group`, integer/slice/ellipsis indexing, `select=` field reads, and `read_chunked` streaming, with runnable code cells for each. The `frames` group now also logs the step index alongside energy.