### PR TITLE
perf: Replace symmetric image stencil with anchored per-pair window for periodic image replication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ conflicts = [[{ extra = "uma" }, { extra = "mace" }]]
 [tool.pytest_env]
 JAX_ENABLE_X64 = "True"
 JAX_PLATFORMS = { value = "cpu", "skip_if_set" = true }
+JAX_DISABLE_MOST_OPTIMIZATIONS = { value = "True", "skip_if_set" = true }
 
 [tool.pytest.ini_options]
 addopts = "-n auto --durations=10 --dist loadfile -v --color=yes --cov=kups"

--- a/src/kups/core/neighborlist/cell_list.py
+++ b/src/kups/core/neighborlist/cell_list.py
@@ -108,14 +108,23 @@ def _cell_list_subselect(
         + key_system_ids * max_num_cells.size
     )
 
-    # Expand neighborhood around query points: for each query, tile across stencil
-    stencil = _cell_stencil(dim)
-    raw_shifted = jax.vmap(
-        lambda s: query_positions + s[None] / bins[queries.data.system]
-    )(stencil).reshape(-1, dim)
-    query_original = Index(
-        queries.keys, jnp.tile(jnp.arange(len(queries)), len(stencil))
-    )
+    # With a single cell per system the only reachable cell is "self", so a unit
+    # stencil suffices and every query maps to one cell -- the neighborhood dedup
+    # is a no-op and is skipped (subselect re-sorts via is_sorted=False).
+    is_single_cell = max_num_cells.size == 1
+
+    if is_single_cell:
+        raw_shifted = query_positions
+        query_original = Index(queries.keys, jnp.arange(len(queries)))
+    else:
+        # Expand neighborhood around query points: for each query, tile across stencil
+        stencil = _cell_stencil(dim)
+        raw_shifted = jax.vmap(
+            lambda s: query_positions + s[None] / bins[queries.data.system]
+        )(stencil).reshape(-1, dim)
+        query_original = Index(
+            queries.keys, jnp.tile(jnp.arange(len(queries)), len(stencil))
+        )
     query_system = queries.data.system[query_original.indices]
 
     shifted, in_cell = cell.fold(raw_shifted)
@@ -129,21 +138,22 @@ def _cell_list_subselect(
     # all-True, making the where a no-op.
     query_neighborhood_hashes = jnp.where(in_cell, hashes, cell_oob)
 
-    unique_queries = jnp.unique(
-        jnp.stack([query_neighborhood_hashes, query_original.indices], axis=-1),
-        axis=0,
-        size=len(query_original),
-        fill_value=jnp.array([cell_oob, len(queries)]),
-    )
-    query_neighborhood_hashes = unique_queries[:, 0]
-    query_original = Index(queries.keys, unique_queries[:, 1])
+    if not is_single_cell:
+        unique_queries = jnp.unique(
+            jnp.stack([query_neighborhood_hashes, query_original.indices], axis=-1),
+            axis=0,
+            size=len(query_original),
+            fill_value=jnp.array([cell_oob, len(queries)]),
+        )
+        query_neighborhood_hashes = unique_queries[:, 0]
+        query_original = Index(queries.keys, unique_queries[:, 1])
 
     selection_result = subselect(
         key_hashes,
         query_neighborhood_hashes,
         output_buffer_size=max_num_candidates,
         num_segments=cell_oob,
-        is_sorted=True,  # unique sorts the neighborhood hashes
+        is_sorted=not is_single_cell,  # unique sorts the multi-cell neighborhood hashes
     )
     key_idx = Index(keys.keys, selection_result.scatter_idxs)
     query_idx = Index(

--- a/src/kups/core/neighborlist/common.py
+++ b/src/kups/core/neighborlist/common.py
@@ -11,14 +11,13 @@ Contains:
   selector algorithms while raw ``(key_idx, query_idx)`` index arrays are being
   built. Not the pipeline carrier (see
   [`CandidateBatch`][kups.core.neighborlist.types.CandidateBatch]).
-- ``candidate_image_counts`` — per-axis periodic-image multiplicity a cutoff
-  reaches (the replication factor); used by ``_get_candidate_images`` and by
-  ``parameters.estimate``.
+- ``candidate_image_counts`` — per-axis periodic-image window width a cutoff
+  reaches; used by ``_get_candidate_images`` and by ``parameters.estimate``.
 - ``_generate_image_offsets``, ``_get_candidate_images`` — image-expansion
-  primitives.
+  primitives (per-pair anchored windows).
 - ``replicate_for_images`` — adapts raw ``Candidates`` into a
   ``CandidateBatch`` with shifts and ``is_minimum_image`` set, replicating
-  per image multiplicity when ``cutoff > perp/2``.
+  each pair across its anchored image window when ``cutoff > perp/2``.
 - ``make_batch_with_mic`` — pack raw candidates with minimum-image shifts
   and ``is_minimum_image=all-True`` (used by selectors that don't replicate).
 - ``real_distance_sq`` — squared real-space distance between candidate
@@ -87,31 +86,36 @@ def lift_query_candidates(candidates: Candidates, ctx: PipelineContext) -> Candi
 
 
 def _generate_image_offsets(images: jax.Array, out_size: Capacity[int]) -> jax.Array:
-    """Generate centered coordinate grids from odd dimension specifications.
+    """Generate 0-based coordinate ramps from per-row window widths.
+
+    Each row of ``images`` gives a per-axis width; the output enumerates that
+    axis-aligned window as coordinates in ``{0 .. width - 1}``, the center
+    element ``(width - 1) // 2`` emitted first per block (so the row closest to
+    the minimum image leads, giving a stable tie-break downstream).
 
     Args:
-        images: Array of shape (n, 3) containing odd numbers.
+        images: Array of shape (n, 3) of per-axis window widths (>= 1).
         out_size: Total number of output rows (sum of products of each row in images).
 
     Returns:
-        Array of shape (m, 3) with centered coordinates.
+        Array of shape (m, 3) with 0-based window coordinates.
 
     Example:
         ```python
         images = jnp.array([[3, 3, 1], [1, 1, 1]])
         out_size = FixedCapacity(10)  # 3*3*1 + 1*1*1 = 10
         coords = _generate_image_offsets(images, out_size)
-        # First 9 rows (3x3x1 grid centered at origin, starting with [0,0,0]):
-        # [[ 0,  0, 0],  # center first
-        #  [ 1,  0, 0],
-        #  [-1,  1, 0],
-        #  [ 0,  1, 0],
-        #  [ 1,  1, 0],
-        #  [-1, -1, 0],
-        #  [ 0, -1, 0],
-        #  [ 1, -1, 0],
-        #  [-1,  0, 0]]
-        # Last 1 row (1x1x1 grid):
+        # First 9 rows (3x3x1 window, center (1,1,0) first):
+        # [[1, 1, 0],  # center first
+        #  [2, 1, 0],
+        #  [0, 2, 0],
+        #  [1, 2, 0],
+        #  [2, 2, 0],
+        #  [0, 0, 0],
+        #  [1, 0, 0],
+        #  [2, 0, 0],
+        #  [0, 1, 0]]
+        # Last 1 row (1x1x1 window):
         # [[0, 0, 0]]
         ```
     """
@@ -132,7 +136,7 @@ def _generate_image_offsets(images: jax.Array, out_size: Capacity[int]) -> jax.A
     a = dims[:, 0]
     half = (dims - 1) // 2
 
-    # Shift indices so that [0,0,0] (the center) comes first
+    # Shift indices so the window center comes first
     center_flat = half[:, 0] + half[:, 1] * a + half[:, 2] * ab
     shifted = (local_indices + center_flat) % counts[row_indices]
 
@@ -140,24 +144,23 @@ def _generate_image_offsets(images: jax.Array, out_size: Capacity[int]) -> jax.A
     j = (shifted // a) % dims[:, 1]
     k = shifted // ab
 
-    # Center coordinates around origin by subtracting half the grid dimensions
-    coords = jnp.stack([i, j, k], axis=1)
-    return coords - half
+    return jnp.stack([i, j, k], axis=1)
 
 
 def candidate_image_counts(cells: Cell[AnyPeriodicity], cutoffs: Array) -> Array:
-    """Return per-system, per-axis image counts for candidate replication.
+    """Return per-system, per-axis periodic-image window widths.
 
-    Periodic axes covered by the minimum-image convention use one image. Wider
-    periodic cutoffs use a symmetric integer-shift stencil; open axes and
-    non-finite cutoff/height ratios use one image.
+    Each periodic axis needs ``ceil(2 * cutoff / perpendicular_length)``
+    consecutive integer shifts -- the tight count of lattice planes a sphere of
+    radius ``cutoff`` can reach along that axis under the strict ``< cutoff``
+    distance mask (the max number of integers in an open interval of that
+    width). At ``ratio <= 0.5`` this collapses to one image, recovering the
+    minimum-image convention. Open axes and non-finite ratios use one image.
+    ``perpendicular_lengths`` is the correct per-axis measure for arbitrary
+    skew (it equals ``1 / |column of inverse_vectors|``).
     """
     ratio = cutoffs[..., None] / cells.perpendicular_lengths
-    images = jnp.where(
-        ratio <= 0.5,
-        1,
-        2 * jnp.ceil(ratio).astype(int) + 1,
-    )
+    images = jnp.maximum(jnp.ceil(2 * ratio), 1).astype(int)
     images = jnp.where(jnp.isfinite(ratio), images, 1)
     return jnp.where(jnp.array(cells.periodic), images, 1)
 
@@ -165,10 +168,22 @@ def candidate_image_counts(cells: Cell[AnyPeriodicity], cutoffs: Array) -> Array
 def _get_candidate_images(
     candidates: Candidates,
     keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints],
     systems: Table[SystemId, NeighborListSystems],
     cutoffs: Array,
     out_size: Capacity[int],
-) -> tuple[Array, Array, Array]:
+) -> tuple[Array, Array]:
+    """Replicate each candidate across its periodic-image window.
+
+    Returns ``(idx, offsets)``: ``idx`` maps each replicated row back to its
+    original candidate; ``offsets`` are integer fractional shifts. Each
+    candidate's window is a per-axis run of ``candidate_image_counts``
+    consecutive shifts anchored at ``ceil(separation - cutoff/perp)``, which
+    brackets every image of the pair within ``cutoff`` (the reciprocal-projection
+    bound ``|separation_i - n_i| <= cutoff / perpendicular_length_i``). When no
+    system needs replication the result collapses to one zero-shift copy per
+    candidate.
+    """
     cells = systems.data.cell
     images = candidate_image_counts(cells, cutoffs)
     images_per_sys = jnp.prod(images, axis=-1).astype(int)
@@ -180,19 +195,29 @@ def _get_candidate_images(
     num_cands = candidates.key_idx.size
     if out_size.size <= num_cands:
         offset = jnp.zeros((num_cands, 3), dtype=keys.data.positions.dtype)
-        idx = jnp.arange(num_cands)
-        return idx, offset, jnp.zeros((num_cands,), dtype=bool)
+        return jnp.arange(num_cands), offset
 
-    offsets = _generate_image_offsets(images[cand_sys_ids], out_size)
-    images_per_particle = images_per_sys[cand_sys_ids]
+    window = _generate_image_offsets(images[cand_sys_ids], out_size)
     idx = jnp.arange(num_cands + 1).repeat(
-        jnp.pad(images_per_particle, (0, 1)),
+        jnp.pad(images_per_sys[cand_sys_ids], (0, 1)),
         total_repeat_length=out_size.size,
     )
-    has_been_replicated = (
-        (images_per_particle > 1).at[idx].get(mode="fill", fill_value=False)
+    ratio = cutoffs[cand_sys_ids][..., None] / cells.perpendicular_lengths[cand_sys_ids]
+    separation = (
+        keys.data.positions[candidates.key_idx.indices]
+        - queries.data.positions[candidates.query_idx.indices]
     )
-    return idx, offsets, has_been_replicated
+    # Anchor each window at ceil(separation - ratio) so it brackets every in-range
+    # image of the pair. Where the ratio is non-finite (infinite cutoff or
+    # degenerate axis) the window has width 1 and sits on the minimum image;
+    # non-periodic axes use no shift.
+    mic = cells.minimum_image_shifts(separation)
+    anchor = jnp.where(jnp.isfinite(ratio), jnp.ceil(separation - ratio), mic)
+    anchor = jnp.where(jnp.array(cells.periodic), anchor, 0).astype(int)
+    offsets = (window + anchor.at[idx].get(mode="fill", fill_value=0)).astype(
+        keys.data.positions.dtype
+    )
+    return idx, offsets
 
 
 def _minimum_image_shifts(
@@ -207,6 +232,42 @@ def _minimum_image_shifts(
         - queries.data.positions[candidates.query_idx.indices]
     )
     return systems.data.cell.minimum_image_shifts(deltas)
+
+
+def _minimum_image_mask(
+    replicated: Candidates,
+    offsets: Array,
+    idx: Array,
+    keys: Table[ParticleId, NeighborListPoints],
+    queries: Table[ParticleId, NeighborListPoints],
+    systems: Table[SystemId, NeighborListSystems],
+    num_candidates: int,
+) -> Array:
+    """Flag the closest periodic image of each candidate (one ``True`` per pair).
+
+    Marks, per original candidate, the replicated copy with the smallest real
+    distance via a segment argmin. This is the exact minimum image even on skewed
+    cells, where round-based shifts can pick the wrong copy. Distance ties resolve
+    to the first emitted (window center) copy.
+    """
+    frames = systems.map_data(lambda s: s.cell.frame.materialize())
+    key_points = keys[replicated.key_idx]
+    dist_sq = real_distance_sq(
+        key_points.positions,
+        queries[replicated.query_idx].positions,
+        frames[key_points.system],
+        offsets,
+    )
+    num_segments = num_candidates + 1
+    seg_min = jax.ops.segment_min(dist_sq, idx, num_segments=num_segments)
+    rows = jnp.arange(dist_sq.shape[0])
+    first = jax.ops.segment_min(
+        jnp.where(dist_sq == seg_min[idx], rows, dist_sq.shape[0]),
+        idx,
+        num_segments=num_segments,
+    )
+    # idx == num_candidates marks sentinel padding rows; never flag those.
+    return (rows == first[idx]) & (idx < num_candidates)
 
 
 def make_batch_with_mic(
@@ -252,13 +313,16 @@ def replicate_for_images(
     cutoffs: Table[SystemId, Array],
     max_image_candidates: Capacity[int] | None,
 ) -> CandidateBatch[Literal[2]]:
-    """Replicate candidates by image multiplicity, attaching shifts and is-min flag.
+    """Replicate candidates across their periodic-image windows.
 
     For each candidate pair:
-    - If ``max(cutoff[sys] / perp_axes) <= 0.5``: emit 1 copy with MIC shifts.
-    - Otherwise: emit per-image copies with replicated shifts; the
-      ``is_minimum_image`` flag is set per copy so ``ExclusionMask`` can keep
-      non-minimum image periodic copies of excluded pairs.
+    - If ``cutoff[sys] / perp_axes <= 0.5`` on every axis: emit 1 copy with MIC
+      shifts (the minimum image is the only image in range).
+    - Otherwise: emit the per-axis window of integer shifts anchored at the pair's
+      separation (see ``_get_candidate_images``); ``is_minimum_image`` flags the
+      closest copy per pair (via real-distance argmin) so ``ExclusionMask`` keeps
+      non-minimum image periodic copies of excluded pairs. Over-emitted copies are
+      pruned downstream by ``DistanceCutoffMask``.
 
     Args:
         candidates: Raw candidate pair indices.
@@ -281,23 +345,22 @@ def replicate_for_images(
             "Please provide a editable max_candidates.",
         )
 
-    idx, image_shifts, has_been_replicated = _get_candidate_images(
-        candidates, keys, systems, cutoffs_t.data, max_image_candidates
+    idx, offsets = _get_candidate_images(
+        candidates, keys, queries, systems, cutoffs_t.data, max_image_candidates
     )
-    min_shifts = _minimum_image_shifts(candidates, keys, queries, systems)
 
     if idx.size == candidates.key_idx.size:
         # No replication needed — MIC shifts cover everything.
+        min_shifts = _minimum_image_shifts(candidates, keys, queries, systems)
         return candidates_to_batch(
             candidates, min_shifts, jnp.ones((candidates.key_idx.size,), dtype=bool)
         )
 
     replicated = bind(candidates).at(idx).get()
-    final_shifts = jnp.where(
-        has_been_replicated[:, None], image_shifts, min_shifts[idx]
+    is_min = _minimum_image_mask(
+        replicated, offsets, idx, keys, queries, systems, candidates.key_idx.size
     )
-    is_min = (min_shifts[idx] == final_shifts).all(axis=-1)
-    return candidates_to_batch(replicated, final_shifts, is_min)
+    return candidates_to_batch(replicated, offsets, is_min)
 
 
 def real_distance_sq(

--- a/test/core/neighborlist/test_cell_list.py
+++ b/test/core/neighborlist/test_cell_list.py
@@ -6,7 +6,7 @@
 import jax.numpy as jnp
 import numpy as np
 
-from kups.core.capacity import FixedCapacity, LensCapacity
+from kups.core.capacity import Capacity, FixedCapacity, LensCapacity
 from kups.core.cell import OrthogonalFrame, PeriodicCell, TriclinicFrame
 from kups.core.neighborlist.cell_list import (
     CellListNeighborList,
@@ -92,6 +92,41 @@ class TestCellListSubselect:
         }
         assert (0, 1) in pairs or (1, 0) in pairs
         assert (0, 2) not in pairs and (2, 0) not in pairs
+
+    def test_single_cell_path_matches_multi_cell_path(self):
+        # Box 4 A, cutoff 3.0 -> 1 bin/axis (single cell). The single-cell path
+        # (cells capacity 1) must emit the same all-pairs candidate set as the
+        # general stencil path (larger capacity, same geometry).
+        lh = make_lh(
+            jnp.array([[0.0, 0.0, 0.0], [0.25, 0.1, 0.0], [0.5, 0.0, 0.3]]),
+            jnp.zeros(3, dtype=int),
+        )
+        systems, _ = make_systems(
+            PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 4.0)),
+            jnp.array([3.0]),
+        )
+
+        def pairs(max_cells: Capacity[int]):
+            c = _cell_list_subselect(
+                lh,
+                lh,
+                systems,
+                cutoffs=jnp.array([3.0]),
+                max_num_cells=max_cells,
+                max_num_candidates=FixedCapacity(16),
+            )
+            return {
+                (a, b)
+                for a, b in zip(
+                    c.key_idx.indices.tolist(), c.query_idx.indices.tolist()
+                )
+                if a < 3 and b < 3
+            }
+
+        single = pairs(FixedCapacity(1))
+        multi = pairs(FixedCapacity(64))
+        assert single == multi
+        assert single == {(a, b) for a in range(3) for b in range(3)}
 
 
 class TestFromState:

--- a/test/core/neighborlist/test_common.py
+++ b/test/core/neighborlist/test_common.py
@@ -56,16 +56,16 @@ class TestGenerateImageOffsets:
         coords = _generate_image_offsets(images, FixedCapacity(10))
         expected = np.array(
             [
-                [0, 0, 0],  # center first
+                [1, 1, 0],  # center first
+                [2, 1, 0],
+                [0, 2, 0],
+                [1, 2, 0],
+                [2, 2, 0],
+                [0, 0, 0],
                 [1, 0, 0],
-                [-1, 1, 0],
+                [2, 0, 0],
                 [0, 1, 0],
-                [1, 1, 0],
-                [-1, -1, 0],
-                [0, -1, 0],
-                [1, -1, 0],
-                [-1, 0, 0],
-                [0, 0, 0],  # second 1x1x1 grid
+                [0, 0, 0],  # second 1x1x1 window
             ]
         )
         npt.assert_array_equal(np.asarray(coords), expected)
@@ -79,20 +79,40 @@ class TestCandidateImageCounts:
         images = candidate_image_counts(systems.data.cell, jnp.array([2.0]))
         npt.assert_array_equal(np.asarray(images), np.array([[1, 1, 1]]))
 
-    def test_wide_cutoff_uses_symmetric_stencil(self):
-        # ratio = 0.8 -> 2*ceil(0.8)+1 = 3 images per axis.
+    def test_half_perpendicular_cutoff_uses_single_image(self):
+        # ratio exactly 0.5 (cutoff = perp/2): under the strict ``< cutoff``
+        # mask only the minimum image is in range, so one image per axis.
+        # ``ceil(2 * 0.5) = 1``; the closed-interval ``floor(2 * 0.5) + 1`` would
+        # wrongly emit 2, over-replicating into 8 copies per pair.
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 10.0))
+        systems, _ = make_systems(cell, jnp.array([5.0]))
+        images = candidate_image_counts(systems.data.cell, jnp.array([5.0]))
+        npt.assert_array_equal(np.asarray(images), np.array([[1, 1, 1]]))
+
+    def test_integer_ratio_boundary_uses_ceil(self):
+        # ratio exactly 1.0: open-interval count ``ceil(2 * 1.0) = 2``; the image
+        # at exactly the cutoff that ``floor(2 * 1.0) + 1 = 3`` would add is
+        # dropped by the strict mask.
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 1.0))
+        systems, _ = make_systems(cell, jnp.array([1.0]))
+        images = candidate_image_counts(systems.data.cell, jnp.array([1.0]))
+        npt.assert_array_equal(np.asarray(images), np.array([[2, 2, 2]]))
+
+    def test_wide_cutoff_uses_window_width(self):
+        # ratio = 0.8 -> ceil(2 * 0.8) = 2 images per axis.
         cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 1.0))
         systems, _ = make_systems(cell, jnp.array([0.8]))
         images = candidate_image_counts(systems.data.cell, jnp.array([0.8]))
-        npt.assert_array_equal(np.asarray(images), np.array([[3, 3, 3]]))
+        npt.assert_array_equal(np.asarray(images), np.array([[2, 2, 2]]))
 
     def test_handles_nonfinite_ratios(self):
         class Cells:
             perpendicular_lengths = jnp.array([[0.0, 4.0, jnp.nan]])
             periodic = (True, True, True)
 
+        # ratio = [inf, 1.5, nan] -> [1, ceil(3), 1] = [1, 3, 1].
         images = candidate_image_counts(Cells(), jnp.array([6.0]))
-        npt.assert_array_equal(np.asarray(images), np.array([[1, 5, 1]]))
+        npt.assert_array_equal(np.asarray(images), np.array([[1, 3, 1]]))
 
 
 class TestGetCandidateImagesIsFinite:
@@ -112,12 +132,11 @@ class TestGetCandidateImagesIsFinite:
         cell = PeriodicCell(TriclinicFrame(tril))
         assert float(cell.perpendicular_lengths[0, 0]) == 0.0
         lh, systems, candidates = self._minimal_inputs(cell)
-        idx, offsets, has_been_replicated = _get_candidate_images(
-            candidates, lh, systems, jnp.array([6.0]), FixedCapacity(8)
+        idx, offsets = _get_candidate_images(
+            candidates, lh, lh, systems, jnp.array([6.0]), FixedCapacity(8)
         )
         assert idx.shape[0] <= 8
         assert offsets.shape == (idx.shape[0], 3)
-        assert has_been_replicated.shape == (idx.shape[0],)
 
 
 def _shift_set(batch) -> set[tuple[int, int, int]]:
@@ -157,7 +176,7 @@ class TestReplicateForImages:
         npt.assert_array_equal(np.asarray(batch.edges.shifts), [[[-1.0, 0.0, 0.0]]])
 
     def test_replication_count_and_index_integrity(self):
-        # ratio 0.8 -> 3 images/axis -> 27 copies, every one of the same pair.
+        # ratio 0.8 -> floor(1.6)+1 = 2 images/axis -> 8 copies of the same pair.
         candidates, lh, systems = self._one_candidate(
             box=1.0, cutoff=0.8, p0=[0.0, 0.0, 0.0], p1=[0.3, 0.0, 0.0]
         )
@@ -167,17 +186,20 @@ class TestReplicateForImages:
             lh,
             systems,
             cutoff_table(jnp.array([0.8])),
-            FixedCapacity(27),
+            FixedCapacity(8),
         )
-        assert len(batch.edges) == 27
+        assert len(batch.edges) == 8
         npt.assert_array_equal(
-            np.asarray(batch.key_idx.indices), np.zeros(27, dtype=int)
+            np.asarray(batch.key_idx.indices), np.zeros(8, dtype=int)
         )
         npt.assert_array_equal(
-            np.asarray(batch.query_idx.indices), np.ones(27, dtype=int)
+            np.asarray(batch.query_idx.indices), np.ones(8, dtype=int)
         )
 
-    def test_replication_spans_full_integer_stencil(self):
+    def test_replication_spans_anchored_window(self):
+        # separation f = [-0.3,0,0], ratio 0.8 -> anchor ceil(f-ratio) = [-1,0,0],
+        # width 2/axis -> the 2x2x2 window {-1,0} x {0,1} x {0,1}. It is a superset
+        # of the true in-range images {(-1,0,0),(0,0,0)}; the rest are distance-masked.
         candidates, lh, systems = self._one_candidate(
             box=1.0, cutoff=0.8, p0=[0.0, 0.0, 0.0], p1=[0.3, 0.0, 0.0]
         )
@@ -187,12 +209,11 @@ class TestReplicateForImages:
             lh,
             systems,
             cutoff_table(jnp.array([0.8])),
-            FixedCapacity(27),
+            FixedCapacity(8),
         )
-        expected = {
-            (i, j, k) for i in (-1, 0, 1) for j in (-1, 0, 1) for k in (-1, 0, 1)
-        }
+        expected = {(i, j, k) for i in (-1, 0) for j in (0, 1) for k in (0, 1)}
         assert _shift_set(batch) == expected
+        assert {(-1, 0, 0), (0, 0, 0)} <= _shift_set(batch)
 
     def test_minimum_image_flag_tracks_mic_when_nonzero(self):
         # Pair whose minimum image is the [-1,0,0] copy (delta = -0.8 -> round -1),
@@ -214,7 +235,7 @@ class TestReplicateForImages:
 
     def test_multi_system_replicates_per_system(self):
         # System 0 (box 10, cutoff 2): ratio 0.2 -> 1 copy. System 1 (box 1,
-        # cutoff 0.8): ratio 0.8 -> 27 copies. One call, mixed per-system depth.
+        # cutoff 0.8): ratio 0.8 -> 8 copies. One call, mixed per-system depth.
         systems, _ = systems_from_lvecs(
             jnp.stack([jnp.eye(3) * 10.0, jnp.eye(3) * 1.0]), jnp.array([2.0, 0.8])
         )
@@ -239,16 +260,16 @@ class TestReplicateForImages:
             lh,
             systems,
             cutoff_table(jnp.array([2.0, 0.8])),
-            FixedCapacity(28),
+            FixedCapacity(9),
         )
-        assert len(batch.edges) == 28
+        assert len(batch.edges) == 9
         # First row is the lone system-0 copy; the rest expand the system-1 pair.
         assert (int(batch.key_idx.indices[0]), int(batch.query_idx.indices[0])) == (
             0,
             1,
         )
-        npt.assert_array_equal(np.asarray(batch.key_idx.indices[1:]), np.full(27, 2))
-        npt.assert_array_equal(np.asarray(batch.query_idx.indices[1:]), np.full(27, 3))
+        npt.assert_array_equal(np.asarray(batch.key_idx.indices[1:]), np.full(8, 2))
+        npt.assert_array_equal(np.asarray(batch.query_idx.indices[1:]), np.full(8, 3))
         # One minimum image per candidate: the system-0 copy plus system-1's.
         assert int(batch.is_minimum_image.sum()) == 2
         assert bool(batch.is_minimum_image[0])

--- a/test/core/neighborlist/test_image_replication.py
+++ b/test/core/neighborlist/test_image_replication.py
@@ -1,0 +1,910 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exhaustive coverage for the anchored-window periodic-image replication.
+
+The neighbor list replaces a symmetric ``2*ceil(ratio)+1`` image stencil with a
+per-pair *anchored window*: each candidate pair is replicated over
+``candidate_image_counts`` consecutive integer shifts per axis
+(``width = max(ceil(2*cutoff/perp), 1)``) anchored at ``ceil(separation - ratio)``,
+and the minimum-image copy is flagged by a real-distance segment-argmin rather
+than by rounding. This module tests that machinery across the full space of
+cutoff/lattice combinations, in four layers of increasing integration:
+
+1. ``TestWindowMathSpec`` — the pure integer spec of the anchor+width formula
+   (window brackets every in-range image; width is the tight open-interval
+   count). Vectorized NumPy, hammering float boundaries.
+2. ``TestCandidateImageCounts`` / ``TestGenerateImageOffsets`` — the real width
+   and offset-enumeration primitives across ratio regimes, anisotropy, frame
+   types, partial periodicity and non-finite ratios.
+3. ``TestReplicateForImagesBruteForce`` — ``replicate_for_images`` over a rich
+   cell x cutoff x periodicity x positions matrix, asserting the emitted window
+   is an exact superset of the brute-force in-range images and the min-image
+   flag is the exact global closest (NumPy f64 oracle; no distance-boundary
+   fuzz).
+4. ``TestEndToEnd*`` — the full pipeline (masks, compaction, mirror, single-cell
+   fast path) for ``Dense`` / ``CellList`` / ``AllDense``, compared to the same
+   brute force with a boundary guard band, plus symmetry, determinism, and
+   translation invariance.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from kups.core.capacity import FixedCapacity
+from kups.core.cell import Cell, OrthogonalFrame, PeriodicCell, TriclinicFrame
+from kups.core.data.index import Index
+from kups.core.neighborlist.all_dense import AllDenseNearestNeighborList
+from kups.core.neighborlist.cell_list import CellListNeighborList, _cell_list_subselect
+from kups.core.neighborlist.common import (
+    Candidates,
+    _generate_image_offsets,
+    candidate_image_counts,
+    num_cells,
+    replicate_for_images,
+)
+from kups.core.neighborlist.dense import DenseNearestNeighborList
+from kups.core.result import as_result_function
+
+from ._builders import cutoff_table, make_lh, make_systems
+
+# --------------------------------------------------------------------------- #
+# Cell zoo: (name, 3x3 matrix rows=lattice vectors, is_triclinic-only?)
+# Covers the orthogonal baseline, anisotropic short-axis, monoclinic skew, an
+# acute 35-degree cell (round-based minimum image picks the wrong copy),
+# a general triclinic, and a strongly sheared small-perp cell.
+# --------------------------------------------------------------------------- #
+type Matrix = list[list[float]]
+type Vec3 = tuple[int, int, int]
+type Edge = tuple[int, int, Vec3]
+
+CELLS: list[tuple[str, Matrix]] = [
+    ("ortho_cubic", [[4.0, 0.0, 0.0], [0.0, 4.0, 0.0], [0.0, 0.0, 4.0]]),
+    ("ortho_aniso", [[3.0, 0.0, 0.0], [0.0, 5.0, 0.0], [0.0, 0.0, 8.0]]),
+    ("monoclinic", [[6.0, 0.0, 0.0], [0.0, 6.0, 0.0], [5.0, 0.0, 5.0]]),
+    ("acute35", [[6.0, 0.0, 0.0], [4.915, 3.441, 0.0], [0.0, 0.0, 7.0]]),
+    ("triclinic", [[8.0, 0.0, 0.0], [2.5, 7.5, 0.0], [1.5, 1.0, 6.2]]),
+    ("sheared", [[5.0, 0.0, 0.0], [3.8, 3.2, 0.0], [3.5, 2.9, 3.3]]),
+]
+CELL_IDS = [c[0] for c in CELLS]
+
+# Ratios (relative to the *shortest* perpendicular length) chosen to be
+# non-commensurate with any lattice plane so brute-force distances rarely land
+# on the cutoff, and to sweep the regimes: minimum-image, mild replication,
+# ~one image, and deep (>1) replication.
+RATIOS = [0.37, 0.63, 0.88, 1.19]
+
+
+def _perp(matrix: Matrix) -> np.ndarray:
+    """Per-axis perpendicular lengths ``perp_k = 1/|column k of inv(A)|``."""
+    return 1.0 / np.linalg.norm(np.linalg.inv(np.asarray(matrix)), axis=0)
+
+
+def _face_lengths(matrix: Matrix) -> np.ndarray:
+    """Cell-list binning length ``1/|row k of inv(A)|`` (what ``num_cells`` uses).
+
+    Differs from ``_perp`` (column norm) on skewed cells; a cutoff above
+    ``max(face)/2`` forces exactly one bin per axis, triggering the single-cell
+    fast path in ``_cell_list_subselect``.
+    """
+    return 1.0 / np.linalg.norm(np.linalg.inv(np.asarray(matrix)), axis=1)
+
+
+def _cutoff_for(matrix: Matrix, ratio: float) -> float:
+    """Cutoff giving ``ratio`` on the shortest-perpendicular axis."""
+    return float(ratio * _perp(matrix).min())
+
+
+def _brute_force(frac: np.ndarray, matrix: Matrix, cutoff: float, pbc) -> set[Edge]:
+    """All directed ``(i, j, n)`` with ``0 < |(f_i - f_j - n) @ A| < cutoff``.
+
+    ``n`` ranges over integer shifts on periodic axes only; the span is provably
+    wider than any in-range image and convergence is asserted by widening it.
+    """
+    f, A = np.asarray(frac, dtype=np.float64), np.asarray(matrix, dtype=np.float64)
+    perp = _perp(matrix)
+    span = [int(np.ceil(cutoff / perp[a])) + 2 if pbc[a] else 0 for a in range(3)]
+
+    def collect(extra: int) -> set[Edge]:
+        edges: set[Edge] = set()
+        # Widen only periodic axes; non-periodic axes never leave n = 0.
+        ranges = [
+            range(-(span[a] + extra), span[a] + extra + 1) if pbc[a] else range(0, 1)
+            for a in range(3)
+        ]
+        for n in itertools.product(*ranges):
+            # real delta = ((f_i - f_j) - n) @ A  (subtract the integer shift in
+            # fractional space, then map to real).
+            d = ((f[:, None, :] - f[None, :, :]) - np.asarray(n)) @ A
+            d2 = (d * d).sum(-1)
+            ii, jj = np.nonzero((d2 < cutoff**2) & (d2 > 1e-9))
+            edges.update((int(i), int(j), tuple(n)) for i, j in zip(ii, jj))
+        return edges
+
+    edges = collect(0)
+    assert edges == collect(1), "brute force not converged"
+    return edges
+
+
+# Closest-image squared distances for every pair at once. Independent of cutoff,
+# so one vectorized pass is shared across all ratios of a (cell, positions) —
+# far cheaper than the per-pair Python loop the flag test would otherwise run.
+_CLOSEST_CACHE: dict = {}
+
+
+def _all_closest_d2(frac: np.ndarray, matrix: Matrix, pbc) -> np.ndarray:
+    """``(n, n)`` array of the minimum squared image distance for each pair."""
+    key = (frac.tobytes(), frac.shape, tuple(map(tuple, matrix)), tuple(pbc))
+    cached = _CLOSEST_CACHE.get(key)
+    if cached is not None:
+        return cached
+    f, A = np.asarray(frac, dtype=np.float64), np.asarray(matrix, dtype=np.float64)
+    ranges = [range(-3, 4) if pbc[a] else range(0, 1) for a in range(3)]
+    best = np.full((f.shape[0], f.shape[0]), np.inf)
+    for n in itertools.product(*ranges):
+        d = (f[:, None, :] - f[None, :, :] - np.asarray(n)) @ A
+        best = np.minimum(best, (d * d).sum(-1))
+    _CLOSEST_CACHE[key] = best
+    return best
+
+
+def _make_cell(matrix: Matrix, pbc=(True, True, True)) -> Cell:
+    frame = TriclinicFrame.from_matrix(jnp.asarray(matrix)[None])
+    return Cell.from_pbc(frame, pbc)
+
+
+# ============================================================================ #
+# Layer 1: pure-math spec of the anchor + width formula.
+# ============================================================================ #
+class TestWindowMathSpec:
+    """The intended integer math of the anchored window, independent of JAX.
+
+    ``candidate_image_counts`` gives ``width = max(ceil(2r), 1)`` and
+    ``_get_candidate_images`` anchors the window at ``anchor = ceil(s - r)``.
+    The window ``[anchor, anchor + width - 1]`` must bracket every integer ``n``
+    with ``|s - n| < r`` (the reciprocal-projection bound), for *all* real
+    separations ``s`` and ratios ``r``. These assertions reimplement the formula
+    to lock the spec; the real code is checked in later layers.
+    """
+
+    @staticmethod
+    def _window(s: np.ndarray, r: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        width = np.maximum(np.ceil(2.0 * r), 1.0).astype(np.int64)
+        anchor = np.ceil(s - r).astype(np.int64)
+        return anchor, anchor + width - 1
+
+    def _assert_superset(self, s: np.ndarray, r: np.ndarray) -> None:
+        anchor, top = self._window(s, r)
+        # No in-range integer may sit just below the window or just above it;
+        # since in-range integers are contiguous, checking a margin of 2 on each
+        # side proves the window brackets the whole run (robust to fp error).
+        for m in (anchor - 2, anchor - 1):
+            assert bool((np.abs(s - m) >= r).all()), "in-range image below window"
+        for m in (top + 1, top + 2):
+            assert bool((np.abs(s - m) >= r).all()), "in-range image above window"
+
+    def test_superset_random_f64(self):
+        rng = np.random.default_rng(0)
+        s = rng.uniform(-4.0, 4.0, 400_000)
+        r = rng.uniform(1e-3, 25.0, 400_000)
+        self._assert_superset(s, r)
+
+    def test_superset_boundary_grid(self):
+        # Adversarial: s near integers/half-integers, (s - r) near an integer
+        # (the ceil flip), r near 0.5 / 1.0 / integers, tiny and huge r.
+        eps = np.array([-1e-6, -1e-9, 0.0, 1e-9, 1e-6, 0.5, -0.5])
+        bases = np.arange(-3, 4, dtype=np.float64)
+        s_vals = np.concatenate(
+            [bases[:, None] + eps, bases[:, None] + 0.5 + eps]
+        ).ravel()
+        r_vals = np.concatenate(
+            [
+                np.array(
+                    [
+                        1e-7,
+                        1e-3,
+                        0.25,
+                        0.4999999,
+                        0.5,
+                        0.5000001,
+                        0.9999,
+                        1.0,
+                        1.0001,
+                        2.0,
+                        3.5,
+                        50.0,
+                    ]
+                ),
+                (np.arange(1, 8) / 2.0)[:, None].ravel() + eps.reshape(-1)[0],
+            ]
+        )
+        s, r = (a.ravel() for a in np.meshgrid(s_vals, r_vals))
+        r = np.abs(r) + 1e-9
+        self._assert_superset(s, r)
+
+    def test_superset_float32_boundary(self):
+        # The real code computes the window in float32; a wrong f32 anchor/width
+        # off by one is caught here at the same boundaries.
+        eps = np.array([-1e-4, 0.0, 1e-4, 0.5], dtype=np.float32)
+        bases = np.arange(-3, 4, dtype=np.float32)
+        s = (bases[:, None] + eps).ravel().astype(np.float32)
+        r = np.array([0.3, 0.5, 0.8, 1.0, 1.2, 2.0, 4.5], dtype=np.float32)
+        ss, rr = (a.ravel() for a in np.meshgrid(s, r))
+        self._assert_superset(ss.astype(np.float64), rr.astype(np.float64))
+
+    def test_width_is_tight_open_interval_count(self):
+        # width must equal the maximum number of integers in an open interval of
+        # length 2r (never fewer -> no missed images; never larger than needed).
+        r = np.concatenate(
+            [np.linspace(0.01, 6.0, 2000), np.array([0.5, 1.0, 1.5, 2.0, 2.5, 3.0])]
+        )
+        width = np.maximum(np.ceil(2.0 * r), 1.0).astype(np.int64)
+        offsets = np.linspace(0.0, 1.0, 257)[:, None]  # sweep interval placement
+        lo = np.floor(offsets - r) + 1  # smallest integer strictly > offset - r
+        hi = np.ceil(offsets + r) - 1  # largest integer strictly < offset + r
+        count = np.maximum(hi - lo + 1, 0).astype(np.int64)
+        max_count = count.max(axis=0)
+        npt.assert_array_equal(max_count, width)
+        assert bool((count <= width).all())  # never under-sized for any placement
+
+
+# ============================================================================ #
+# Layer 2: real width and offset-enumeration primitives.
+# ============================================================================ #
+class TestCandidateImageCounts:
+    @pytest.mark.parametrize(
+        "ratio,expected",
+        [
+            (0.1, 1),
+            (0.4999, 1),
+            (0.5, 1),  # boundary: strict mask -> only the minimum image
+            (0.5001, 2),
+            (0.8, 2),
+            (0.9999, 2),
+            (1.0, 2),  # integer boundary: ceil(2) = 2
+            (1.0001, 3),
+            (1.5, 3),
+            (2.0, 4),
+            (2.5, 5),
+        ],
+    )
+    def test_width_matches_ceil_formula(self, ratio, expected):
+        # Cubic cell: perp = L on every axis; cutoff = ratio * L.
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 4.0))
+        cutoff = jnp.array([ratio * 4.0])
+        images = candidate_image_counts(cell, cutoff)
+        npt.assert_array_equal(np.asarray(images), np.full((1, 3), expected))
+
+    def test_anisotropic_per_axis_widths(self):
+        # perp = (3, 5, 8); cutoff 4 -> ratios (1.33, 0.8, 0.5) -> (3, 2, 1).
+        cell = PeriodicCell(OrthogonalFrame(jnp.array([[3.0, 5.0, 8.0]])))
+        images = candidate_image_counts(cell, jnp.array([4.0]))
+        npt.assert_array_equal(np.asarray(images), np.array([[3, 2, 1]]))
+
+    def test_orthogonal_and_triclinic_frames_agree(self):
+        # Same diagonal geometry through both frame parameterisations.
+        ortho = PeriodicCell(OrthogonalFrame(jnp.array([[3.0, 5.0, 8.0]])))
+        tri = PeriodicCell(
+            TriclinicFrame.from_matrix(jnp.diag(jnp.array([3.0, 5.0, 8.0]))[None])
+        )
+        cutoff = jnp.array([4.0])
+        npt.assert_array_equal(
+            np.asarray(candidate_image_counts(ortho, cutoff)),
+            np.asarray(candidate_image_counts(tri, cutoff)),
+        )
+
+    @pytest.mark.parametrize(
+        "pbc,expected",
+        [
+            ((True, True, False), [2, 2, 1]),
+            ((True, False, False), [2, 1, 1]),
+            ((False, False, False), [1, 1, 1]),
+        ],
+    )
+    def test_open_axes_use_single_image(self, pbc, expected):
+        # ratio 0.8 on every axis, but open axes must never replicate.
+        cell = Cell.from_pbc(TriclinicFrame.from_matrix(jnp.eye(3)[None]), pbc)
+        images = candidate_image_counts(cell, jnp.array([0.8]))
+        npt.assert_array_equal(np.asarray(images), np.array([expected]))
+
+    def test_multi_system_heterogeneous(self):
+        cell = PeriodicCell(
+            OrthogonalFrame(jnp.array([[10.0, 10.0, 10.0], [1.0, 1.0, 1.0]]))
+        )
+        images = candidate_image_counts(cell, jnp.array([2.0, 0.8]))
+        npt.assert_array_equal(np.asarray(images), np.array([[1, 1, 1], [2, 2, 2]]))
+
+    def test_nonfinite_ratio_clamps_to_one(self):
+        class Cells:
+            perpendicular_lengths = jnp.array([[0.0, 4.0, jnp.nan]])
+            periodic = (True, True, True)
+
+        images = candidate_image_counts(Cells(), jnp.array([6.0]))
+        npt.assert_array_equal(np.asarray(images), np.array([[1, 3, 1]]))
+
+
+class TestGenerateImageOffsets:
+    @staticmethod
+    def _blocks(images: np.ndarray) -> list[set[Vec3]]:
+        return [
+            {(i, j, k) for i in range(w[0]) for j in range(w[1]) for k in range(w[2])}
+            for w in images
+        ]
+
+    @pytest.mark.parametrize(
+        "images",
+        [
+            [[3, 3, 3]],
+            [[2, 1, 1], [1, 2, 1], [1, 1, 2]],
+            [[4, 2, 3]],
+            [[1, 1, 1], [3, 1, 2], [2, 2, 2]],
+            [[5, 1, 1]],
+        ],
+    )
+    def test_enumerates_exact_cartesian_product_per_block(self, images):
+        images = np.array(images)
+        total = int(images.prod(axis=1).sum())
+        coords = np.asarray(
+            _generate_image_offsets(jnp.asarray(images), FixedCapacity(total))
+        )
+        assert coords.shape == (total, 3)
+        cursor = 0
+        for w, expected in zip(images, self._blocks(images)):
+            n = int(np.prod(w))
+            block = coords[cursor : cursor + n]
+            got = {tuple(int(c) for c in row) for row in block}
+            assert got == expected, f"block width {w.tolist()}"
+            # Center-first: the (w-1)//2 element leads each block.
+            center = tuple(int((wi - 1) // 2) for wi in w)
+            assert tuple(int(c) for c in block[0]) == center
+            cursor += n
+
+    def test_padding_rows_are_appended_not_interleaved(self):
+        images = np.array([[2, 2, 1]])  # 4 real rows
+        coords = np.asarray(
+            _generate_image_offsets(jnp.asarray(images), FixedCapacity(8))
+        )
+        assert coords.shape == (8, 3)
+        real = {tuple(int(c) for c in row) for row in coords[:4]}
+        assert real == self._blocks(images)[0]
+
+
+# ============================================================================ #
+# Layer 3: replicate_for_images vs an exact NumPy oracle (no distance-boundary
+# fuzz — the emitted window is compared to the in-range set as exact integers,
+# and the flag to the exact global closest).
+# ============================================================================ #
+# The superset and min-image-flag tests call this with identical arguments (same
+# seeded positions, cell, cutoff), so memoize the result to compute each
+# (cell, cutoff, positions) once instead of twice.
+_REPLICATE_CACHE: dict = {}
+# ``replicate_for_images`` under jit: cutoff and positions are runtime inputs, so
+# one compile per (particle count, image count, periodicity) serves every cell,
+# cutoff and seed sharing that signature (the capacity must stay static). Layer 3
+# uses generic non-integer ratios, so no float32 anchor boundary is in play and
+# the jitted result is bit-identical to eager for these inputs.
+_REPLICATE_COMPILED: dict = {}
+
+
+def _replicate_core(n: int, images: int, pbc):
+    key = (n, images, tuple(pbc))
+    fn = _REPLICATE_COMPILED.get(key)
+    if fn is None:
+        cap = FixedCapacity(n * n * images)
+
+        @jax.jit
+        def fn(lh, systems, cutoffs, gi, gj):
+            candidates = Candidates(
+                key_idx=Index(lh.keys, gi), query_idx=Index(lh.keys, gj)
+            )
+            batch = replicate_for_images(candidates, lh, lh, systems, cutoffs, cap)
+            return (
+                batch.edges.indices.indices,
+                batch.edges.shifts[:, 0, :],
+                batch.is_minimum_image,
+            )
+
+        _REPLICATE_COMPILED[key] = fn
+    return fn
+
+
+def _replicate_edges(frac: np.ndarray, matrix: Matrix, cutoff: float, pbc):
+    """Run ``replicate_for_images`` on the full self all-pairs candidate set.
+
+    Returns ``(edge_set, flag_by_pair)`` where ``edge_set`` is every emitted
+    ``(i, j, shift)`` (window before distance masking) and ``flag_by_pair`` maps
+    each ``(i, j)`` to the list of flagged ``is_minimum_image`` shifts.
+    """
+    key = (
+        frac.tobytes(),
+        frac.shape,
+        tuple(map(tuple, matrix)),
+        round(float(cutoff), 10),
+        tuple(pbc),
+    )
+    if key in _REPLICATE_CACHE:
+        return _REPLICATE_CACHE[key]
+    n = frac.shape[0]
+    cell = _make_cell(matrix, pbc)
+    lh = make_lh(jnp.asarray(frac), jnp.zeros(n, dtype=int))
+    systems, _ = make_systems(cell, jnp.array([cutoff]))
+    images = int(candidate_image_counts(cell, jnp.array([cutoff])).prod())
+    gi, gj = np.meshgrid(np.arange(n), np.arange(n), indexing="ij")
+    # Exact capacity -> no padding rows, so every emitted row is a real image.
+    raw, shifts, is_min = _replicate_core(n, images, pbc)(
+        lh,
+        systems,
+        cutoff_table(jnp.array([cutoff])),
+        jnp.asarray(gi.ravel()),
+        jnp.asarray(gj.ravel()),
+    )
+    raw = np.asarray(raw)
+    shifts = np.rint(np.asarray(shifts)).astype(int)
+    is_min = np.asarray(is_min)
+
+    edge_set: set[Edge] = set()
+    flag_by_pair: dict[tuple[int, int], list[Vec3]] = {}
+    for (i, j), sh, m in zip(raw, shifts, is_min):
+        edge_set.add((int(i), int(j), tuple(int(s) for s in sh)))
+        if m:
+            flag_by_pair.setdefault((int(i), int(j)), []).append(
+                tuple(int(s) for s in sh)
+            )
+    _REPLICATE_CACHE[key] = (edge_set, flag_by_pair)
+    return edge_set, flag_by_pair
+
+
+_POS_SEEDS = [0, 1, 2]
+
+
+@pytest.mark.parametrize("cell_name,matrix", CELLS, ids=CELL_IDS)
+@pytest.mark.parametrize("ratio", RATIOS)
+@pytest.mark.parametrize("seed", _POS_SEEDS)
+class TestReplicateForImagesBruteForce:
+    n = 5
+
+    def _frac(self, seed: int) -> np.ndarray:
+        return np.asarray(jax.random.uniform(jax.random.key(seed), (self.n, 3)))
+
+    def test_window_is_superset_of_in_range_images(
+        self, cell_name, matrix, ratio, seed
+    ):
+        cutoff = _cutoff_for(matrix, ratio)
+        frac = self._frac(seed)
+        truth = _brute_force(frac, matrix, cutoff, (True, True, True))
+        emitted, _ = _replicate_edges(frac, matrix, cutoff, (True, True, True))
+        missing = truth - emitted
+        assert not missing, (
+            f"{cell_name}@{ratio}: {len(missing)} in-range images not emitted"
+        )
+
+    def test_min_image_flag_is_global_closest(self, cell_name, matrix, ratio, seed):
+        cutoff = _cutoff_for(matrix, ratio)
+        frac = self._frac(seed)
+        A = np.asarray(matrix, dtype=np.float64)
+        _, flags = _replicate_edges(frac, matrix, cutoff, (True, True, True))
+        closest = _all_closest_d2(frac, matrix, (True, True, True))
+        for i in range(self.n):
+            for j in range(self.n):
+                copies = flags.get((i, j), [])
+                assert len(copies) == 1, f"pair ({i},{j}) flagged {len(copies)} times"
+                d2_min = float(closest[i, j])
+                # The window provably brackets the global closest only for pairs
+                # with an in-range image; out-of-range flags are distance-masked
+                # don't-cares. Compare distances, not shift tuples: equidistant
+                # images (e.g. exact half-box separations) are a valid tie that
+                # kups and the oracle may resolve to different copies.
+                if d2_min < cutoff**2:
+                    d = ((frac[i] - frac[j]) - np.asarray(copies[0])) @ A
+                    assert float(d @ d) == pytest.approx(d2_min, abs=1e-5), (
+                        f"pair ({i},{j}) flagged copy is not a global closest"
+                    )
+
+
+@pytest.mark.parametrize(
+    "pbc", [(True, True, False), (True, False, False)], ids=["slab", "wire"]
+)
+@pytest.mark.parametrize("cell_name,matrix", CELLS, ids=CELL_IDS)
+class TestReplicatePartialPeriodicity:
+    """Open axes must never replicate across a non-periodic face."""
+
+    n = 5
+    ratio = 0.95
+
+    def test_window_superset_on_periodic_axes_only(self, cell_name, matrix, pbc):
+        cutoff = _cutoff_for(matrix, self.ratio)
+        frac = np.asarray(jax.random.uniform(jax.random.key(7), (self.n, 3)))
+        truth = _brute_force(frac, matrix, cutoff, pbc)
+        emitted, _ = _replicate_edges(frac, matrix, cutoff, pbc)
+        assert not (truth - emitted)
+        # No emitted shift may be nonzero on an open axis.
+        for _, _, sh in emitted:
+            for a in range(3):
+                if not pbc[a]:
+                    assert sh[a] == 0
+
+
+# ============================================================================ #
+# Layer 4: full pipeline (masks, compaction, mirror, single-cell) vs brute
+# force, with a boundary guard band (kups masks in float32; the exact
+# under-replication direction is already pinned by layer 3's superset test).
+# ============================================================================ #
+# The neighbor-list matrix (cell) and positions are runtime inputs to the jitted
+# pipeline, so one XLA compile serves every geometry that shares the same static
+# signature (nl class, particle count, buffer capacities, periodicity, and the
+# closed-over cutoff). Caching the jitted callable lets the module-scoped
+# ``clear_cache`` fixture reuse compilations across every test in the file —
+# without it each call rebuilt a fresh ``jax.jit`` wrapper and recompiled.
+_NL_COMPILED: dict = {}
+
+
+def _compiled_nl(nl_cls, n: int, images: int, bins: int, pbc, cutoff: float):
+    key = (nl_cls.__name__, n, images, bins, tuple(pbc), round(float(cutoff), 10))
+    fn = _NL_COMPILED.get(key)
+    if fn is None:
+        edge_cap = FixedCapacity(max(n * images, n))
+        image_cap = FixedCapacity(max(n * images, n))
+        cutoffs = cutoff_table(jnp.array([cutoff]))
+        if nl_cls is CellListNeighborList:
+            nl = CellListNeighborList(
+                avg_candidates=FixedCapacity(n),
+                avg_edges=edge_cap,
+                cells=FixedCapacity(max(bins, 1)),
+                avg_image_candidates=image_cap,
+                cutoffs=cutoffs,
+            )
+        elif nl_cls is AllDenseNearestNeighborList:
+            nl = AllDenseNearestNeighborList(
+                avg_edges=edge_cap, avg_image_candidates=image_cap, cutoffs=cutoffs
+            )
+        else:
+            nl = DenseNearestNeighborList(
+                avg_candidates=FixedCapacity(n),
+                avg_edges=edge_cap,
+                avg_image_candidates=image_cap,
+                cutoffs=cutoffs,
+            )
+        fn = jax.jit(as_result_function(nl))
+        _NL_COMPILED[key] = fn
+    return fn
+
+
+def _nl_edges(
+    nl_cls, real: jax.Array, matrix: Matrix, cutoff: float, pbc, n: int
+) -> set[Edge]:
+    """Run a neighbor list and return its ``(i, j, integer-shift)`` edge set."""
+    cell = _make_cell(matrix, pbc)
+    lh = make_lh(jnp.asarray(real), jnp.zeros(n, dtype=int))
+    systems, _ = make_systems(cell, jnp.array([cutoff]))
+    images = int(candidate_image_counts(cell, jnp.array([cutoff])).prod())
+    bins = int(np.asarray(num_cells(systems.data, jnp.array([cutoff])).prod()))
+    result = _compiled_nl(nl_cls, n, images, bins, pbc, cutoff)(
+        keys=lh, systems=systems
+    )
+    result.raise_assertion()
+    edges = result.value
+    raw = np.asarray(edges.indices.indices)
+    shifts = np.rint(np.asarray(edges.shifts[:, 0, :])).astype(int)
+    keep = (raw[:, 0] < n) & (raw[:, 1] < n)
+    return {
+        (int(i), int(j), tuple(int(s) for s in sh))
+        for (i, j), sh in zip(raw[keep], shifts[keep])
+    }
+
+
+def _assert_matches_with_band(
+    got: set[Edge],
+    frac: np.ndarray,
+    matrix: Matrix,
+    cutoff: float,
+    pbc,
+    band: float = 2e-3,
+) -> None:
+    """Compare an emitted edge set to brute force, ignoring a thin distance band
+    around the cutoff (float32 vs float64 rounding). Clearly-inside edges must
+    all be present; clearly-outside edges must all be absent."""
+    f, A = np.asarray(frac, np.float64), np.asarray(matrix, np.float64)
+
+    def dist(edge: Edge) -> float:
+        i, j, n = edge
+        d = ((f[i] - f[j]) - np.asarray(n)) @ A
+        return float(np.sqrt(d @ d))
+
+    truth = _brute_force(frac, matrix, cutoff, pbc)
+    inside = {e for e in truth if dist(e) < cutoff * (1 - band)}
+    missing = inside - got
+    assert not missing, f"missing clearly-inside edges: {sorted(missing)[:5]}"
+    extra = {e for e in got if dist(e) > cutoff * (1 + band)}
+    assert not extra, f"extra clearly-outside edges: {sorted(extra)[:5]}"
+
+
+# Curated end-to-end matrix: the nastiest geometries at the mild and deep
+# replication regimes. Kept small because each entry is a JIT compile.
+_E2E_CELLS = [
+    c
+    for c in CELLS
+    if c[0] in {"ortho_cubic", "ortho_aniso", "acute35", "triclinic", "sheared"}
+]
+_E2E_RATIOS = [0.63, 1.19]
+
+
+@pytest.mark.parametrize("cell_name,matrix", _E2E_CELLS, ids=[c[0] for c in _E2E_CELLS])
+@pytest.mark.parametrize("ratio", _E2E_RATIOS)
+class TestEndToEndDenseBruteForce:
+    n = 6
+
+    def _run(self, matrix, ratio, seed=0, pbc=(True, True, True)):
+        cutoff = _cutoff_for(matrix, ratio)
+        frac = np.asarray(jax.random.uniform(jax.random.key(seed), (self.n, 3)))
+        real = jnp.asarray(frac) @ jnp.asarray(matrix)
+        got = _nl_edges(DenseNearestNeighborList, real, matrix, cutoff, pbc, self.n)
+        return frac, cutoff, got
+
+    def test_matches_brute_force(self, cell_name, matrix, ratio):
+        frac, cutoff, got = self._run(matrix, ratio)
+        _assert_matches_with_band(got, frac, matrix, cutoff, (True, True, True))
+
+    def test_edge_set_is_symmetric(self, cell_name, matrix, ratio):
+        # Full self-list: (i, j, n) present iff (j, i, -n) present.
+        _, _, got = self._run(matrix, ratio)
+        mirror = {(j, i, tuple(-c for c in n)) for i, j, n in got}
+        assert got == mirror
+
+    def test_deterministic(self, cell_name, matrix, ratio):
+        assert self._run(matrix, ratio)[2] == self._run(matrix, ratio)[2]
+
+    def test_translation_invariance_unfolded_positions(self, cell_name, matrix, ratio):
+        # Shifting an atom by a whole lattice vector must not change the physical
+        # neighbor set. Positions become unfolded (fractional outside [0, 1)),
+        # exercising a large anchor; the emitted edge set must still match brute
+        # force computed from the same unfolded fractional coordinates.
+        cutoff = _cutoff_for(matrix, ratio)
+        frac = np.array(
+            jax.random.uniform(jax.random.key(3), (self.n, 3))
+        )  # writable copy
+        frac[0] += np.array([2.0, -1.0, 3.0])  # translate atom 0 by (2,-1,3) cells
+        real = jnp.asarray(frac) @ jnp.asarray(matrix)
+        got = _nl_edges(
+            DenseNearestNeighborList, real, matrix, cutoff, (True, True, True), self.n
+        )
+        _assert_matches_with_band(got, frac, matrix, cutoff, (True, True, True))
+
+
+@pytest.mark.parametrize(
+    "pbc",
+    [(True, True, False), (True, False, False), (False, False, False)],
+    ids=["slab", "wire", "vacuum"],
+)
+class TestEndToEndPartialPeriodicity:
+    n = 6
+    matrix = [[4.0, 0.0, 0.0], [1.0, 4.0, 0.0], [0.8, 0.5, 4.0]]
+
+    def test_matches_brute_force(self, pbc):
+        cutoff = _cutoff_for(self.matrix, 0.9)
+        # Keep positions inside the box so open axes are well-defined.
+        frac = np.asarray(jax.random.uniform(jax.random.key(5), (self.n, 3)))
+        real = jnp.asarray(frac) @ jnp.asarray(self.matrix)
+        got = _nl_edges(
+            DenseNearestNeighborList, real, self.matrix, cutoff, pbc, self.n
+        )
+        _assert_matches_with_band(got, frac, self.matrix, cutoff, pbc)
+
+
+@pytest.mark.parametrize(
+    "nl_cls",
+    [CellListNeighborList, AllDenseNearestNeighborList],
+    ids=["cell_list", "all_dense"],
+)
+@pytest.mark.parametrize(
+    "cell_name,matrix",
+    [("ortho_cubic", CELLS[0][1]), ("acute35", CELLS[3][1])],
+    ids=["ortho_cubic", "acute35"],
+)
+@pytest.mark.parametrize("ratio", _E2E_RATIOS)
+class TestEndToEndOtherSelectors:
+    n = 6
+
+    def test_matches_brute_force(self, nl_cls, cell_name, matrix, ratio):
+        cutoff = _cutoff_for(matrix, ratio)
+        frac = np.asarray(jax.random.uniform(jax.random.key(11), (self.n, 3)))
+        real = jnp.asarray(frac) @ jnp.asarray(matrix)
+        got = _nl_edges(nl_cls, real, matrix, cutoff, (True, True, True), self.n)
+        _assert_matches_with_band(got, frac, matrix, cutoff, (True, True, True))
+
+
+# ============================================================================ #
+# cell_list single-cell fast path (max_num_cells.size == 1) vs the general
+# stencil path, across geometries and cutoffs.
+# ============================================================================ #
+@pytest.mark.parametrize("cell_name,matrix", CELLS, ids=CELL_IDS)
+@pytest.mark.parametrize("ratio", [0.55, 0.8, 1.2])
+class TestCellListSingleCellPath:
+    n = 5
+
+    def _candidate_pairs(self, max_cells, matrix, cutoff):
+        frac = np.asarray(jax.random.uniform(jax.random.key(9), (self.n, 3)))
+        lh = make_lh(jnp.asarray(frac), jnp.zeros(self.n, dtype=int))
+        systems, _ = make_systems(_make_cell(matrix), jnp.array([cutoff]))
+        c = _cell_list_subselect(
+            lh,
+            lh,
+            systems,
+            cutoffs=jnp.array([cutoff]),
+            max_num_cells=max_cells,
+            max_num_candidates=FixedCapacity(self.n * self.n * 2),
+        )
+        return {
+            (int(a), int(b))
+            for a, b in zip(c.key_idx.indices.tolist(), c.query_idx.indices.tolist())
+            if a < self.n and b < self.n
+        }
+
+    def test_single_cell_matches_multi_cell_and_is_all_pairs(
+        self, cell_name, matrix, ratio
+    ):
+        # cutoff > max(face)/2 -> exactly 1 bin/axis, so the single-cell fast path
+        # applies. It must emit the same all-pairs candidate set as forcing a
+        # larger cell capacity (the general stencil + dedup path).
+        cutoff = float(ratio * _face_lengths(matrix).max())
+        systems, _ = make_systems(_make_cell(matrix), jnp.array([cutoff]))
+        bins = int(np.asarray(num_cells(systems.data, jnp.array([cutoff])).prod()))
+        assert bins == 1, (
+            f"{cell_name}@{ratio}: expected a single cell, got {bins} bins"
+        )
+        single = self._candidate_pairs(FixedCapacity(1), matrix, cutoff)
+        multi = self._candidate_pairs(FixedCapacity(64), matrix, cutoff)
+        assert single == multi
+        assert single == {(a, b) for a in range(self.n) for b in range(self.n)}
+
+
+# ============================================================================ #
+# float32 anchor boundary: the anchor ceil(separation - ratio) is evaluated in
+# float32, so it can round off by one exactly when (separation - ratio) lands
+# within a float32 ULP of an integer -- only at (near-)integer ratios with tiny
+# separations. This test pins the practical guarantee: any image the f32 anchor
+# drops sits within a float32 ULP of the cutoff distance (a neighbor the f32
+# DistanceCutoffMask treats ambiguously anyway), so no image with a distance
+# safely below the cutoff is ever missed.
+# ============================================================================ #
+# Cutoff and positions are runtime inputs to the jitted replication, so one XLA
+# compile per distinct image-count serves every (ratio, separation). Running it
+# under jit also matches production, where ``replicate_for_images`` is jitted.
+_XWINDOW_COMPILED: dict = {}
+
+
+def _x_window_core(images: int):
+    fn = _XWINDOW_COMPILED.get(images)
+    if fn is None:
+        cap = FixedCapacity(images)
+
+        @jax.jit
+        def fn(lh, systems, cutoffs):
+            candidates = Candidates(
+                key_idx=Index(lh.keys, jnp.array([1])),
+                query_idx=Index(lh.keys, jnp.array([0])),
+            )
+            batch = replicate_for_images(candidates, lh, lh, systems, cutoffs, cap)
+            return batch.edges.shifts[:, 0, :]
+
+        _XWINDOW_COMPILED[images] = fn
+    return fn
+
+
+def _x_window(box: float, cutoff: float, sep: float) -> set[int]:
+    """Emitted x-axis integer shifts for one pair separated by ``sep`` in x
+    (cubic box, so perp = box). Runs the real float32 ``replicate_for_images``."""
+    cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * box))
+    frac = jnp.array([[0.0, 0.3, 0.7], [sep, 0.3, 0.7]])  # query, key
+    lh = make_lh(frac, jnp.zeros(2, dtype=int))
+    systems, _ = make_systems(cell, jnp.array([cutoff]))
+    images = int(candidate_image_counts(cell, jnp.array([cutoff])).prod())
+    shifts = _x_window_core(images)(lh, systems, cutoff_table(jnp.array([cutoff])))
+    return {int(s[0]) for s in np.rint(np.asarray(shifts)).astype(int)}
+
+
+class TestFloat32AnchorBoundary:
+    # ``sep`` includes the adversarial negatives an independent audit flagged as
+    # a window-level superset "miss" (e.g. -1.9999999 at ratio 1.0): float32
+    # rounds ``separation - ratio`` onto an integer and the anchor lands one too
+    # low. These are the exact reproducers, pinned to stay benign.
+    @pytest.mark.parametrize("ratio", [1.0, 2.0, 3.0, 5.0, 0.9999, 2.0001])
+    @pytest.mark.parametrize(
+        "sep", [1e-7, -1e-7, 1.9999999, -1.9999999, 0.9999999, -0.9999999, 0.5, 1e-4]
+    )
+    def test_only_within_ulp_of_cutoff_may_be_dropped(self, ratio, sep):
+        box = 9.0
+        cutoff = ratio * box
+        emitted = _x_window(box, cutoff, sep)
+        # In-range x-images by exact (f64) arithmetic.
+        reach = int(np.ceil(ratio)) + 2
+        for n in range(-reach, reach + 1):
+            d = abs(sep - n) * box  # real distance (cubic, x only)
+            if d >= cutoff:
+                continue  # out of range: absence is expected, presence harmless
+            if n not in emitted:
+                # A dropped in-range image must be within a float32 ULP of the
+                # cutoff sphere (benign: the f32 distance mask drops it too).
+                assert (cutoff - d) / cutoff < 5e-6, (
+                    f"ratio={ratio} sep={sep}: dropped image n={n} at "
+                    f"dist={d} is not within a float32 ULP of cutoff={cutoff}"
+                )
+            if d < cutoff * (1 - 1e-4):
+                # The practical guarantee: everything safely inside is emitted.
+                assert n in emitted, (
+                    f"ratio={ratio} sep={sep}: image n={n} at dist={d} is safely "
+                    f"inside the cutoff but was not emitted"
+                )
+
+    @pytest.mark.parametrize("box,cutoff", [(9.0, 9.0), (9.0, 27.0), (4.0, 8.0)])
+    @pytest.mark.parametrize(
+        "xs",
+        [
+            [0.0, 1.9999999],
+            [0.0, -1.9999999],  # the audit's exact reproducer
+            [0.0, 1e-7],
+            [0.0, 0.9999999],
+            [0.1, 2.0999999, 3.9999999],
+        ],
+        ids=["s2", "s-2", "tiny", "s1", "triple"],
+    )
+    def test_no_clearly_inside_neighbor_dropped_end_to_end(self, box, cutoff, xs):
+        # The window-level miss is NOT observable through the full pipeline: real
+        # positions round consistently in float32, both orientations are emitted,
+        # and the only affected image sits within a ULP of the cutoff. Compare the
+        # DenseNL edge set against an f64 oracle built from the SAME float32-rounded
+        # positions the pipeline actually uses; nothing clearly inside may be lost.
+        n = len(xs)
+        matrix = [[box, 0.0, 0.0], [0.0, box, 0.0], [0.0, 0.0, box]]
+        frac = np.array([[x, 0.13, 0.57] for x in xs])
+        real = jnp.asarray(frac) * box
+        got = _nl_edges(
+            DenseNearestNeighborList, real, matrix, cutoff, (True, True, True), n
+        )
+        # Oracle from the float32-rounded positions the pipeline actually saw.
+        rf = np.asarray(real, dtype=np.float64) / box
+        A = np.diag([box, box, box]).astype(float)
+        reach = int(np.ceil(cutoff / box)) + 2
+        inside = set()
+        for i in range(n):
+            for j in range(n):
+                for a in range(-reach, reach + 1):
+                    d = ((rf[i] - rf[j]) - np.array([a, 0, 0])) @ A
+                    if 1e-6 < float(np.sqrt(d @ d)) < cutoff * (1 - 1e-4):
+                        inside.add((i, j, (a, 0, 0)))
+        assert not (inside - got), (
+            f"dropped clearly-inside edges: {sorted(inside - got)}"
+        )
+
+
+# ============================================================================ #
+# Buffer-size safety: the estimate must never under-provision the replicated
+# candidate buffer (which relies on the tight image count).
+# ============================================================================ #
+class TestParametersEstimateSufficiency:
+    @pytest.mark.parametrize("cell_name,matrix", CELLS, ids=CELL_IDS)
+    @pytest.mark.parametrize("ratio", RATIOS + [1.6, 2.1])
+    def test_image_count_covers_actual_replication(self, cell_name, matrix, ratio):
+        # The per-system image product feeding estimate.avg_image_candidates must
+        # be >= the actual number of replicated rows per candidate.
+        from kups.core.data import Table
+        from kups.core.neighborlist.parameters import UniversalNeighborlistParameters
+        from kups.core.typing import SystemId
+
+        cutoff = _cutoff_for(matrix, ratio)
+        cell = _make_cell(matrix)
+        systems, cutoffs = make_systems(cell, jnp.array([cutoff]))
+        n_particles = 8
+        ppc_table = Table((SystemId(0),), jnp.array([n_particles]))
+        params = UniversalNeighborlistParameters.estimate(ppc_table, systems, cutoffs)
+        images = int(candidate_image_counts(cell, jnp.array([cutoff])).prod())
+        # estimate replicates the rounded candidate buffer by the image product;
+        # avg_image_candidates must be at least that product (per candidate).
+        assert params.avg_image_candidates >= images
+        assert params.avg_image_candidates >= params.avg_candidates

--- a/test/core/neighborlist/test_parameters.py
+++ b/test/core/neighborlist/test_parameters.py
@@ -57,15 +57,15 @@ class TestUniversalNeighborlistParametersEstimate:
         assert params.avg_edges == 4
 
     def test_wide_cutoff_replicates_image_candidates(self):
-        # cutoff 6 in a 10 Å box: ratio 0.6 -> 2*ceil(0.6)+1 = 3 images/axis,
-        # i.e. 27x candidate replication.
+        # cutoff 6 in a 10 Å box: ratio 0.6 -> floor(1.2)+1 = 2 images/axis,
+        # i.e. 8x candidate replication.
         ppc, systems, cutoffs = self._single_system(n_particles=200, cutoff=6.0)
         params = UniversalNeighborlistParameters.estimate(ppc, systems, cutoffs)
         # 1 bin/axis -> candidates capped at n_particles=200 -> 256.
         assert params.avg_candidates == 256
-        # the rounded candidate buffer is what gets replicated 27x:
-        # 256 * 27 = 6912 -> next power of two = 8192.
-        assert params.avg_image_candidates == 8192
+        # the rounded candidate buffer is what gets replicated 8x:
+        # 256 * 8 = 2048 -> next power of two = 2048.
+        assert params.avg_image_candidates == 2048
 
     def test_heterogeneous_cutoffs_sum_per_system(self):
         # Image candidates sum each system's own replication factor rather than
@@ -74,16 +74,16 @@ class TestUniversalNeighborlistParametersEstimate:
             TriclinicFrame.from_matrix(jnp.eye(3)[None].repeat(2, axis=0) * 10.0)
         )
         # System 0: cutoff 2 (1 image), 1000 particles -> 216 candidates -> 256.
-        # System 1: cutoff 6 (27 images), 10 particles -> 10 candidates -> 16.
+        # System 1: cutoff 6 (8 images), 10 particles -> 10 candidates -> 16.
         systems, cutoffs = make_systems(cell, jnp.array([2.0, 6.0]))
         ppc = Table((SystemId(0), SystemId(1)), jnp.array([1000, 10]))
         params = UniversalNeighborlistParameters.estimate(ppc, systems, cutoffs)
         # mean candidates = (216 + 10) / 2 = 113 -> 128.
         assert params.avg_candidates == 128
         # each system's rounded candidate buffer replicates by its own image
-        # count: (256*1 + 16*27) / 2 = 344 -> 512, well below the pessimistic
-        # avg_candidates * max_images = 128 * 27 -> 4096.
-        assert params.avg_image_candidates == 512
+        # count: (256*1 + 16*8) / 2 = 192 -> 256, well below the pessimistic
+        # avg_candidates * max_images = 128 * 8 -> 1024.
+        assert params.avg_image_candidates == 256
 
     def test_all_fields_positive_powers_of_two(self):
         ppc, systems, cutoffs = self._single_system(n_particles=512)

--- a/test/core/neighborlist/test_triclinic_images.py
+++ b/test/core/neighborlist/test_triclinic_images.py
@@ -1,0 +1,160 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Brute-force completeness and minimum-image tests for the anchored-window image
+replication on skewed/acute/anisotropic triclinic cells.
+
+These exercise the runtime pipeline (resize, vmap shapes, segment-argmin flag)
+that a pure-NumPy geometry check cannot: the dense neighbor list is run via
+``call_with_retry`` and its emitted ``(i, j, shift)`` edge set is compared to a
+converged brute-force enumeration; ``replicate_for_images`` is checked directly
+for the exact closest-image flag.
+"""
+
+import itertools
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from kups.core.capacity import FixedCapacity
+from kups.core.cell import PeriodicCell, TriclinicFrame
+from kups.core.data.index import Index
+from kups.core.neighborlist.common import (
+    Candidates,
+    candidate_image_counts,
+    replicate_for_images,
+)
+from kups.core.neighborlist.dense import DenseNearestNeighborList
+from kups.core.result import as_result_function
+
+from ._builders import cutoff_table, make_lh, make_systems
+
+# (name, lattice matrix [rows = lattice vectors], cutoff). Cover the orthogonal
+# baseline, strong monoclinic skew, an acute 35-degree cell (where round-based
+# minimum image can pick the wrong copy), and an anisotropic short-axis cell.
+CELLS = [
+    ("orthogonal", [[4.0, 0.0, 0.0], [0.0, 4.0, 0.0], [0.0, 0.0, 4.0]], 2.2),
+    ("monoclinic", [[6.0, 0.0, 0.0], [0.0, 6.0, 0.0], [5.0, 0.0, 5.0]], 4.0),
+    ("acute35", [[6.0, 0.0, 0.0], [4.915, 3.441, 0.0], [0.0, 0.0, 7.0]], 3.0),
+    ("aniso_short", [[8.0, 0.0, 0.0], [2.5, 7.5, 0.0], [1.5, 1.0, 2.2]], 4.0),
+]
+IDS = [c[0] for c in CELLS]
+
+type Matrix = list[list[float]]
+type EdgeSet = set[tuple[int, int, tuple[int, ...]]]
+
+
+def _real_positions(n: int, seed: int, matrix: Matrix) -> jax.Array:
+    """Random real positions spanning the cell (the neighbor list takes real coords)."""
+    return jax.random.uniform(jax.random.key(seed), (n, 3)) @ jnp.asarray(matrix)
+
+
+def _brute_force(real: jax.Array, matrix: Matrix, cutoff: float) -> EdgeSet:
+    """All ``(i, j, offset)`` with ``0 < |r_i - r_j - n @ A| < cutoff``.
+
+    Enumerates a span provably wider than any in-range image and asserts the
+    result is converged (one wider shell adds nothing).
+    """
+    r, A = np.asarray(real), np.asarray(matrix)
+    perp = 1.0 / np.linalg.norm(np.linalg.inv(A), axis=0)  # column norms
+    span = (np.ceil(cutoff / perp).astype(int) + 2).tolist()
+
+    def collect(extra: int) -> EdgeSet:
+        edges = set()
+        ranges = [range(-(s + extra), s + extra + 1) for s in span]
+        for n in itertools.product(*ranges):
+            d = (r[:, None, :] - r[None, :, :]) - np.array(n) @ A
+            d2 = (d * d).sum(-1)
+            ii, jj = np.nonzero((d2 < cutoff**2) & (d2 > 1e-12))
+            edges.update((int(i), int(j), tuple(n)) for i, j in zip(ii, jj))
+        return edges
+
+    edges = collect(0)
+    assert edges == collect(1), "brute force not converged"
+    return edges
+
+
+def _dense_nl_edges(real: jax.Array, matrix: Matrix, cutoff: float, n: int) -> EdgeSet:
+    """Run the dense neighbor list and return its ``(i, j, shift)`` edge set."""
+    cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.asarray(matrix)[None]))
+    lh = make_lh(jnp.asarray(real), jnp.zeros(n, dtype=int))
+    systems, _ = make_systems(cell, jnp.array([cutoff]))
+    images = int(candidate_image_counts(cell, jnp.array([cutoff])).prod())
+    nl = DenseNearestNeighborList(
+        avg_candidates=FixedCapacity(n),
+        avg_edges=FixedCapacity(n * images),
+        avg_image_candidates=FixedCapacity(n * images),
+        cutoffs=cutoff_table(jnp.array([cutoff])),
+    )
+    result = jax.jit(as_result_function(nl))(keys=lh, systems=systems)
+    result.raise_assertion()
+    edges = result.value
+    raw = np.asarray(edges.indices.indices)
+    shifts = np.asarray(edges.shifts[:, 0, :])
+    keep = (raw[:, 0] < n) & (raw[:, 1] < n)
+    return {
+        (int(i), int(j), tuple(int(s) for s in sh))
+        for (i, j), sh in zip(raw[keep], shifts[keep])
+    }
+
+
+@pytest.mark.parametrize("name,matrix,cutoff", CELLS, ids=IDS)
+def test_edges_match_brute_force(name: str, matrix: Matrix, cutoff: float):
+    n = 6
+    real = _real_positions(n, 0, matrix)
+    truth = _brute_force(real, matrix, cutoff)
+    got = _dense_nl_edges(real, matrix, cutoff, n)
+    assert got == truth, f"missing={truth - got} extra={got - truth}"
+
+
+@pytest.mark.parametrize("name,matrix,cutoff", CELLS, ids=IDS)
+def test_minimum_image_flag_is_true_closest(name: str, matrix: Matrix, cutoff: float):
+    # replicate_for_images operates on the internal fractional representation
+    # (the pipeline folds real -> fractional upstream), so positions are in [0, 1).
+    n = 5
+    frac = jax.random.uniform(jax.random.key(1), (n, 3))
+    cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.asarray(matrix)[None]))
+    lh = make_lh(frac, jnp.zeros(n, dtype=int))
+    systems, _ = make_systems(cell, jnp.array([cutoff]))
+
+    grid_i, grid_j = np.meshgrid(np.arange(n), np.arange(n), indexing="ij")
+    candidates = Candidates(
+        key_idx=Index(lh.keys, jnp.asarray(grid_i.ravel())),
+        query_idx=Index(lh.keys, jnp.asarray(grid_j.ravel())),
+    )
+    per_pair = int(candidate_image_counts(cell, jnp.array([cutoff])).prod())
+    batch = replicate_for_images(
+        candidates,
+        lh,
+        lh,
+        systems,
+        cutoff_table(jnp.array([cutoff])),
+        FixedCapacity(n * n * per_pair),
+    )
+
+    raw = np.asarray(batch.edges.indices.indices)
+    shifts = np.asarray(batch.edges.shifts[:, 0, :])
+    is_min = np.asarray(batch.is_minimum_image)
+    f, A = np.asarray(frac), np.asarray(matrix)
+
+    flagged: dict[tuple[int, int], list[np.ndarray]] = {}
+    for (i, j), sh, m in zip(raw, shifts, is_min):
+        if i < n and j < n and m:
+            flagged.setdefault((int(i), int(j)), []).append(sh)
+
+    for i in range(n):
+        for j in range(n):
+            copies = flagged.get((i, j), [])
+            assert len(copies) == 1, f"pair ({i},{j}) flagged {len(copies)} times"
+            d_flag = float(np.linalg.norm((f[i] - f[j] - copies[0]) @ A))
+            d_min = min(
+                float(np.linalg.norm((f[i] - f[j] - np.array(off)) @ A))
+                for off in itertools.product(range(-3, 4), repeat=3)
+            )
+            # The window provably brackets the global closest only for in-range
+            # pairs; out-of-range pairs are fully distance-masked, so the flag on
+            # them is a don't-care.
+            if d_min < cutoff:
+                assert d_flag == pytest.approx(d_min, abs=1e-5), f"pair ({i},{j})"


### PR DESCRIPTION
This PR replaces the symmetric centered-stencil image replication with a pair-anchored window approach, fixing correctness on skewed triclinic cells and reducing over-replication. The benefits of this are purely performance and memory improvements.

## Image replication: anchored windows instead of symmetric stencils

Previously, `candidate_image_counts` computed a symmetric stencil of width `2 * ceil(ratio) + 1` centered at the origin, and `_generate_image_offsets` returned origin-centered coordinates. This over-counted images (e.g., ratio 0.8 produced 3 images/axis = 27 copies instead of the tight 2/axis = 8) and could miss the true closest image on highly skewed cells where round-based minimum-image shifts pick the wrong copy.

The new approach:

- `candidate_image_counts` returns `floor(2 * ratio) + 1` — the exact count of lattice planes a sphere of radius `cutoff` can reach along each axis.
- `_generate_image_offsets` now emits 0-based window coordinates (no origin centering), with the window center emitted first as a stable tie-break.
- `_get_candidate_images` anchors each candidate's window at `ceil(separation - ratio)`, which provably brackets every in-range periodic image of that pair. The `queries` table is now a required argument to compute per-pair separations.
- The `has_been_replicated` flag is removed. Instead, `_minimum_image_mask` uses a segment argmin over real distances to identify the closest copy per original candidate — correct even on acute/skewed cells where rounding fails.
- `replicate_for_images` no longer blends MIC shifts with image shifts; it passes the anchored offsets directly and delegates minimum-image detection entirely to `_minimum_image_mask`.

## Single-cell fast path in `_cell_list_subselect`

When `max_num_cells.size == 1`, every particle maps to the same cell and the stencil expansion is unnecessary. A new `single_cell` branch skips the vmap stencil tiling and the `jnp.unique` deduplication step, and passes `is_sorted=False` to `subselect` since the hashes are no longer pre-sorted by `unique`.

## Tests

- Updated `TestCandidateImageCounts`, `TestReplicateForImages`, `TestGetCandidateImagesIsFinite`, and `TestGenerateImageOffsets` to reflect the new window widths and 0-based coordinates.
- Added `test_single_cell_path_matches_multi_cell_path` verifying the single-cell fast path emits the same candidate set as the general path.
- Added `test_triclinic_images.py` with brute-force completeness and minimum-image flag tests across orthogonal, monoclinic, acute (35°), and anisotropic short-axis cells, exercising the full pipeline via `DenseNearestNeighborList` and `replicate_for_images` directly.