### PR TITLE
perf: Faster logging (JIT-compile leaf stacking, zstd, default chunk size to 4 MiB)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "nanoargs>=0.1.1",
     "slub>=0.1.1",
     "matplotlib>=3.10.5",   # python 3.14 support - ASE depends on matplotlib
+    "hdf5plugin>=6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/src/kups/core/storage.py
+++ b/src/kups/core/storage.py
@@ -32,7 +32,9 @@ from types import EllipsisType
 from typing import Any, Literal, Protocol, Self, cast, overload, override
 
 import h5py
+import hdf5plugin  # registers the zstd (and other) HDF5 filters on import
 import jax
+import jax.numpy as jnp
 import numpy as np
 
 from kups.core.lens import View
@@ -122,7 +124,7 @@ class EveryNStep(LoggingFrequency):
         return step // self.n
 
 
-_DEFAULT_CHUNK_BYTES = 1 << 20  # ~1 MiB; chunk- and batch-sizing target
+_DEFAULT_CHUNK_BYTES = 1 << 22  # ~4 MiB; chunk- and batch-sizing target
 _MAX_AUTO_BATCH = 128  # cap so cheap (small-frame) groups still flush periodically
 
 
@@ -137,15 +139,19 @@ class Compression:
     bloat). Scalar datasets are stored uncompressed.
 
     Args:
-        codec: HDF5 compression filter, ``"gzip"`` or ``"lzf"``.
-        level: gzip level (0-9); ignored for lzf.
+        codec: HDF5 compression filter: ``"zstd"`` (via hdf5plugin), ``"gzip"``,
+            or ``"lzf"``. zstd is several times faster than gzip at a comparable
+            (often better) ratio on trajectory data, but its files require the
+            hdf5plugin filter to be importable to read.
+        level: Compression level, ``1``-``22`` for zstd and ``0``-``9`` for gzip;
+            ignored for lzf.
         shuffle: Enable the byte-shuffle filter. Helps float arrays; may slightly
             reduce the ratio on highly repetitive data.
         target_chunk_bytes: Approximate per-chunk size in bytes.
     """
 
-    codec: Literal["gzip", "lzf"] = "gzip"
-    level: int = 4
+    codec: Literal["zstd", "gzip", "lzf"] = "zstd"
+    level: int = 1
     shuffle: bool = True
     target_chunk_bytes: int = _DEFAULT_CHUNK_BYTES
 
@@ -168,10 +174,14 @@ class Compression:
         kwargs: dict[str, Any] = {
             "chunks": self._chunk_shape(leading_dims, shape, itemsize),
             "shuffle": self.shuffle,
-            "compression": self.codec,
         }
-        if self.codec == "gzip":
+        if self.codec == "zstd":
+            kwargs.update(hdf5plugin.Zstd(clevel=self.level))
+        elif self.codec == "gzip":
+            kwargs["compression"] = "gzip"
             kwargs["compression_opts"] = self.level
+        else:  # lzf
+            kwargs["compression"] = "lzf"
         return kwargs
 
     def _chunk_shape(
@@ -474,10 +484,16 @@ class Hdf5ObjWriter[Storage]:
             states: Per-step values to stack and write, in order.
             start: Leading-axis index of the first state.
         """
-        leaves = [jax.tree.leaves(s) for s in states]
         stop = start + len(states)
+        stacked = _stack_leaves(states)
         for j, dataset in enumerate(self.datasets):
-            dataset[start:stop] = np.stack([np.asarray(step[j]) for step in leaves])
+            dataset[start:stop] = np.asarray(stacked[j])
+
+
+@jit
+def _stack_leaves(states: list[Any]) -> list[jax.Array]:
+    leaves = [jax.tree.leaves(s) for s in states]
+    return [jnp.stack([step[j] for step in leaves]) for j in range(len(leaves[0]))]
 
 
 @dataclass
@@ -702,7 +718,7 @@ class BackgroundWriter[State, WriterConfig]:
         logging.info("Writer thread started")
         while self.running.is_set():
             try:
-                to_log = self.data_queue.get(timeout=1.0)
+                to_log = self.data_queue.get(timeout=0.1)
             except queue.Empty:
                 continue
             try:

--- a/test/core/test_storage.py
+++ b/test/core/test_storage.py
@@ -6,6 +6,7 @@
 import tempfile
 
 import h5py
+import hdf5plugin
 import jax
 import jax.numpy as jnp
 import numpy.testing as npt
@@ -348,6 +349,12 @@ def _array_dataset(group: h5py.Group) -> h5py.Dataset:
     return group[name]  # type: ignore[return-value]
 
 
+def _filter_ids(ds: h5py.Dataset) -> list[int]:
+    """HDF5 filter ids applied to ``ds`` (e.g. ``1`` shuffle, ``32015`` zstd)."""
+    dcpl = ds.id.get_create_plist()
+    return [dcpl.get_filter(i)[0] for i in range(dcpl.get_nfilters())]
+
+
 class TestCompression:
     def test_dataset_kwargs_sizing(self):
         """Per-leaf chunk sizing: time-axis target, scalars uncompressed."""
@@ -355,12 +362,10 @@ class TestCompression:
         # Large per-frame array: chunk holds target_bytes // frame_bytes frames.
         kw = c.dataset_kwargs((1000,), (1326, 3), itemsize=8)
         assert kw["chunks"] == ((1 << 20) // (1326 * 3 * 8), 1326, 3)
-        assert kw == {
-            **kw,
-            "compression": "gzip",
-            "compression_opts": 4,
-            "shuffle": True,
-        }
+        # Default codec is zstd (via hdf5plugin) + byte-shuffle.
+        assert kw["shuffle"] is True
+        assert kw["compression"] == hdf5plugin.Zstd.filter_id
+        assert kw["compression_opts"] == (1,)
         # Scalar-per-step: single chunk spanning the whole time axis.
         assert c.dataset_kwargs((1000,), (), itemsize=8)["chunks"] == (1000,)
         # Logged once (no time axis): one chunk spanning the whole array.
@@ -368,20 +373,25 @@ class TestCompression:
         # Rank-0 scalar: cannot chunk, so uncompressed.
         assert c.dataset_kwargs((), (), itemsize=8) == {}
 
+    def test_gzip_has_level(self):
+        kw = Compression(codec="gzip", level=4).dataset_kwargs((10,), (5,), itemsize=8)
+        assert kw["compression"] == "gzip"
+        assert kw["compression_opts"] == 4
+
     def test_lzf_has_no_level(self):
         kw = Compression(codec="lzf").dataset_kwargs((10,), (5,), itemsize=8)
         assert kw["compression"] == "lzf"
         assert "compression_opts" not in kw
 
     def test_roundtrip_and_filters_applied(self, temp_file: str):
-        """Default compression round-trips and lands gzip+shuffle+chunks on datasets."""
+        """Default compression round-trips and lands zstd+shuffle+chunks on datasets."""
         state = SimpleState(
             position=jnp.zeros((64, 3)), velocity=jnp.zeros((64, 3)), energy=1.0
         )
         config = WriterGroupConfig(
             view=view(lambda s: {"pos": s.position}),
             logging_frequency=EveryNStep(1),
-        )  # default compression == Compression() (gzip + shuffle)
+        )  # default compression == Compression() (zstd + shuffle)
         writer = HDF5StorageWriter(temp_file, config, state, total_steps=20)
         with writer:
             for i in range(20):
@@ -394,7 +404,7 @@ class TestCompression:
 
         with h5py.File(temp_file, "r") as f:
             ds = _array_dataset(f["group"])  # type: ignore[arg-type]
-            assert ds.compression == "gzip"
+            assert hdf5plugin.Zstd.filter_id in _filter_ids(ds)
             assert ds.shuffle is True
             assert ds.chunks is not None and ds.chunks[0] >= 1
 
@@ -420,12 +430,14 @@ class TestCompression:
 class TestAutoBatching:
     def test_auto_batch_size_property(self, temp_file: str):
         """GroupWriters.batch_size derives from datasets + compression."""
-        from kups.core.storage import _MAX_AUTO_BATCH
+        from kups.core.storage import _DEFAULT_CHUNK_BYTES, _MAX_AUTO_BATCH
 
+        # Frame large enough that the chunk-fitting formula binds below the cap.
+        n = 20_000
         state = SimpleState(
-            position=jnp.zeros((3000,)), velocity=jnp.zeros((1,)), energy=0.0
+            position=jnp.zeros((n,)), velocity=jnp.zeros((1,)), energy=0.0
         )
-        expected = (1 << 20) // (state.position.dtype.itemsize * 3000)
+        expected = _DEFAULT_CHUNK_BYTES // (state.position.dtype.itemsize * n)
         assert 1 < expected < _MAX_AUTO_BATCH
 
         # Large per-frame leaf: the chunk-fitting formula binds.

--- a/uv.lock
+++ b/uv.lock
@@ -1362,6 +1362,22 @@ wheels = [
 ]
 
 [[package]]
+name = "hdf5plugin"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h5py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/4f/9130151e3aa475b3e4e9a611bf608107fe5c72d277d74c4cf36f164b7c81/hdf5plugin-6.0.0.tar.gz", hash = "sha256:847ed9e96b451367a110f0ba64a3b260d38d64bbf3f25751858d3b56e094cfe0", size = 66372085, upload-time = "2025-10-08T18:16:28.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/13/15017f6210bfea843316d62f0f121e364e17bb129444ed803a256a213036/hdf5plugin-6.0.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:a59fbd5d4290a8a5334d82ccb4c6b9bfc7aaf586de7fedb88762e8601bc05fd4", size = 13339413, upload-time = "2025-10-08T18:16:10.656Z" },
+    { url = "https://files.pythonhosted.org/packages/40/bf/d1f3765fb879820d7331e30e860b684f5b78d3ec17324e8f54130cbe560b/hdf5plugin-6.0.0-py3-none-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d301f4b9295872bacf277c70628d4c5e965ee47db762d8fde2d4849f201b9897", size = 42858563, upload-time = "2025-10-08T18:16:14.106Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/67/37d0b84fbbf26bf0d6a99a8f98bcd82bb6d437dc8cabee259fb3d7506ec7/hdf5plugin-6.0.0-py3-none-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:78b082ea355fe46bf5b396024de1fb662a1aaf9a5e11861ad61a5a2a6316d59d", size = 45126124, upload-time = "2025-10-08T18:16:17.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/2f/1046d464ad1db29a4f6c70ba4e19b39baa8a6542c719eaa4e765108f07f1/hdf5plugin-6.0.0-py3-none-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:79e0524d18ddc41c0cf2e1bb2e529d4e154c286f6a1bd85f3d44019d2a17574a", size = 44857273, upload-time = "2025-10-08T18:16:22.007Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/75478bdfee85533777de4204373f563aa7a1074355300743c3aedc33cac5/hdf5plugin-6.0.0-py3-none-win_amd64.whl", hash = "sha256:99866f90be1ceac5519e6e038669564be326c233618d59ba1f38c9dd8c32099e", size = 3379316, upload-time = "2025-10-08T18:16:25.007Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2126,6 +2142,7 @@ dependencies = [
     { name = "etils" },
     { name = "flatbuffers" },
     { name = "h5py" },
+    { name = "hdf5plugin" },
     { name = "jax" },
     { name = "jsonargparse" },
     { name = "matplotlib" },
@@ -2192,6 +2209,7 @@ requires-dist = [
     { name = "fairchem-core", marker = "python_full_version < '3.15' and extra == 'uma'", specifier = ">=2.20.0" },
     { name = "flatbuffers", specifier = ">=25.2.10" },
     { name = "h5py", specifier = ">=3.15.0" },
+    { name = "hdf5plugin", specifier = ">=6.0.0" },
     { name = "huggingface-hub", marker = "extra == 'hf'", specifier = ">=1.11.0" },
     { name = "jax", specifier = ">=0.7.2" },
     { name = "jax", extras = ["cuda"], marker = "sys_platform == 'linux' and extra == 'cuda'", specifier = ">=0.7.2" },


### PR DESCRIPTION
Stacks leaf arrays using `jnp.stack` via a JIT-compiled helper (`_stack_leaves`) instead of individually converting each leaf with `np.stack`/`np.asarray` per step. This batches the stacking work on the accelerator before a single `np.asarray` transfer to the host, reducing overhead when flushing buffered states to HDF5.

Furthermore we default to zstd instead of gzip for higher throughput at lower file sizes.

The default chunk/batch size target is also increased from 1 MiB to 4 MiB to better amortize I/O and JIT dispatch costs.