### PR TITLE
refactor(lens): naming + docstring cleanups (issue #176)

### DIFF
--- a/src/kups/application/mcmc/data.py
+++ b/src/kups/application/mcmc/data.py
@@ -382,7 +382,7 @@ def mcmc_state_from_config(
     n_host = len(hp.keys)
     if host.cell_replication is not None:
         pos_lens = lens(lambda x: x.positions, cls=Particles)
-        p = pos_lens.apply(p, cell.wrap)
+        p = pos_lens.modify(p, cell.wrap)
         cell, p = make_supercell(cell, host.cell_replication, p, pos_lens)
         n_host = len(p.positions)
     n_ads = len(adsorbates)

--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -110,7 +110,7 @@ def relax_state_from_ase(
     # cell_factor = atom count (ASE's exp_cell_factor) balances the extensive
     # cell-virial gradient against the per-atom forces in the joint optimiser.
     n_atoms = float(p.data.positions.shape[0])
-    cell = bind(cell, lambda x: x.frame).apply(
+    cell = bind(cell, lambda x: x.frame).modify(
         lambda f: FrechetFrame.from_frame(f, cell_factor=n_atoms)
     )
     cell = cell[None]

--- a/src/kups/application/simulations/mcmc_rigid.py
+++ b/src/kups/application/simulations/mcmc_rigid.py
@@ -190,7 +190,7 @@ class MCMCState:
 
     @property
     def guest_only(self) -> MCMCState:
-        return bind(self, lambda x: x.particles.data).apply(MCMCParticles.guest_only)
+        return bind(self, lambda x: x.particles.data).modify(MCMCParticles.guest_only)
 
     def blocking_spheres_neighborlist(
         self, cutoffs: Table[SystemId, Array]

--- a/src/kups/application/simulations/mcmc_widom.py
+++ b/src/kups/application/simulations/mcmc_widom.py
@@ -348,7 +348,7 @@ def run(config: Config) -> WidomState:
     state = run_warmup_cycles(
         next(chain), cycle_fn, state, config.run.num_warmup_cycles
     )
-    state = bind(state, lambda x: x.widom_statistics.data).apply(WidomStatistics.reset)
+    state = bind(state, lambda x: x.widom_statistics.data).modify(WidomStatistics.reset)
 
     logged_data = make_widom_logged_data(state)
     logger = CompositeLogger(

--- a/src/kups/core/assertion.py
+++ b/src/kups/core/assertion.py
@@ -414,7 +414,7 @@ class AssertionContext:
         return (
             bind(self)
             .focus(lambda ctx: ctx.assertions)
-            .apply(lambda assertions: assertions + (assertion,))
+            .modify(lambda assertions: assertions + (assertion,))
         )
 
     def check_assertions(self) -> Array:
@@ -601,11 +601,11 @@ def scan_handler(
         """Initialize all assertions to be true."""
 
         def initialize(a: RuntimeAssertion[Any, Any]) -> RuntimeAssertion[Any, Any]:
-            a = bind(a).focus(lambda a: a.predicate).apply(jnp.ones_like)
+            a = bind(a).focus(lambda a: a.predicate).modify(jnp.ones_like)
             a = (
                 bind(a)
                 .focus(lambda a: (a.fix_args, a.fmt_args))
-                .apply(partial(jax.tree.map, jnp.empty_like))
+                .modify(partial(jax.tree.map, jnp.empty_like))
             )
             return a
 
@@ -657,11 +657,11 @@ def while_handler(
             return jnp.full_like(x, fill_value=-jnp.inf)
 
         def initialize(a: RuntimeAssertion[Any, Any]) -> RuntimeAssertion[Any, Any]:
-            a = bind(a).focus(lambda a: a.predicate).apply(jnp.ones_like)
+            a = bind(a).focus(lambda a: a.predicate).modify(jnp.ones_like)
             a = (
                 bind(a)
                 .focus(lambda a: (a.fix_args, a.fmt_args))
-                .apply(partial(jax.tree.map, _sentinel_like))
+                .modify(partial(jax.tree.map, _sentinel_like))
             )
             return a
 

--- a/src/kups/core/cell.py
+++ b/src/kups/core/cell.py
@@ -1020,7 +1020,7 @@ def make_supercell[T, T2, C: Cell[Any]](
         lambda x: jnp.repeat(x[None], n_reps, axis=0).reshape(-1, *x.shape[1:]),
         to_replicate,
     )
-    replicated = to_shift.apply(
+    replicated = to_shift.modify(
         replicated,
         lambda y: jax.tree.map(
             lambda x: new_cell.wrap(

--- a/src/kups/core/lens.py
+++ b/src/kups/core/lens.py
@@ -121,10 +121,10 @@ type Modifier[R] = Callable[[R], R]
 
 
 class _NOT_SET_TYPE(enum.Enum):
-    OBJ = enum.auto()
+    NOT_SET = enum.auto()
 
 
-_NOT_SET = _NOT_SET_TYPE.OBJ
+_NOT_SET = _NOT_SET_TYPE.NOT_SET
 
 
 S = TypeVar("S", covariant=True)
@@ -209,8 +209,8 @@ class Lens(Protocol[S, R]):
         """
         ...
 
-    def apply[S2, R2](self: Lens[S2, R2], state: S2, /, modifier: Modifier[R2]) -> S2:
-        """Apply a modifier function to the focused value.
+    def modify[S2, R2](self: Lens[S2, R2], state: S2, /, modifier: Modifier[R2]) -> S2:
+        """Apply a modifier function to the focused value and return the updated state.
 
         Args:
             state: The data structure to modify
@@ -345,7 +345,7 @@ class BoundLens(Protocol[S, R]):
         """
         ...
 
-    def apply[R2](self: BoundLens[S, R2], modifier: Modifier[R2]) -> S:
+    def modify[R2](self: BoundLens[S, R2], modifier: Modifier[R2]) -> S:
         """Apply a modifier function to the focused value in the bound data structure.
 
         Args:
@@ -410,7 +410,7 @@ class BaseLens(Lens[S, R], abc.ABC):
         return NestedLens(self, SimpleLens(view(where)))
 
     @override
-    def apply[S2](self: BaseLens[S2, R], state: S2, modifier: Modifier[R]) -> S2:
+    def modify[S2](self: BaseLens[S2, R], state: S2, modifier: Modifier[R]) -> S2:
         """Apply a modifier function to the focused value."""
         return self.set(state, modifier(self.get(state)))
 
@@ -586,7 +586,7 @@ class SimpleBoundLens(BoundLens[S, R]):
         return self.lens.set(self.target, value)
 
     @override
-    def apply(self, modifier: Modifier[R]) -> S:
+    def modify(self, modifier: Modifier[R]) -> S:
         """Apply a modifier to the focused value in the bound target."""
         return self.lens.set(self.target, modifier(self.lens.get(self.target)))
 
@@ -625,7 +625,7 @@ class SimpleBoundLens(BoundLens[S, R]):
 
 
 @dataclass
-class LambdaLens(BaseLens[S, R]):
+class ExplicitLens(BaseLens[S, R]):
     """A lens that uses custom getter and setter functions.
 
     This allows for more complex lens behavior that cannot be expressed
@@ -636,12 +636,12 @@ class LambdaLens(BaseLens[S, R]):
     _set: Update[S, R] = field(static=True)
 
     @override
-    def get[S2](self: LambdaLens[S2, R], state: S2) -> R:
+    def get[S2](self: ExplicitLens[S2, R], state: S2) -> R:
         """Get the focused value using the custom getter function."""
         return self._get(state)
 
     @override
-    def set[S2, R2](self: LambdaLens[S2, R2], state: S2, value: R2) -> S2:
+    def set[S2, R2](self: ExplicitLens[S2, R2], state: S2, value: R2) -> S2:
         """Set the focused value using the custom setter function."""
         return self._set(state, value)
 
@@ -724,7 +724,7 @@ class TreePathView:
 
 def all_where_lens[S, Target](
     obj: S,
-    conditional: Callable[[Any], bool],
+    predicate: Callable[[Any], bool],
     *,
     target_cls: type[Target] | None = None,
 ) -> Lens[S, tuple[Target, ...]]:
@@ -732,14 +732,17 @@ def all_where_lens[S, Target](
 
     Args:
         obj: An instance of the state type to infer the pytree structure
-        conditional: A predicate function that tests each element
-        target_cls: Optional type hint for the target type (currently unused)
+        predicate: A boolean predicate that tests each element
+        target_cls: Type-inference only; discarded at runtime. Binds the
+            ``Target`` typevar so callers like ``all_isinstance_lens`` get a
+            correctly typed ``Lens[S, tuple[cls, ...]]`` return type.
 
     Returns:
         A lens that focuses on all elements satisfying the condition as a tuple.
     """
-    leaves = jax.tree.leaves_with_path(obj, is_leaf=conditional)
-    paths = [p for p, obj in leaves if conditional(obj)]
+    _ = target_cls
+    leaves = jax.tree.leaves_with_path(obj, is_leaf=predicate)
+    paths = [p for p, obj in leaves if predicate(obj)]
 
     def getter(state: S) -> tuple[Target, ...]:
         return tuple(f(state) for f in map(TreePathView, paths))
@@ -777,7 +780,7 @@ def _traversal_lens[S, R](
             lifted(_PathTraversal(obj=state))
         ).set(state, value)
 
-    return LambdaLens(getter, setter)
+    return ExplicitLens(getter, setter)
 
 
 def lens[S, R](where: Callable[[S], R], /, *, cls: type[S] | None = None) -> Lens[S, R]:
@@ -861,7 +864,7 @@ def bind[S, R](obj: S, where: Callable[[S], R] | None = None) -> BoundLens[S, R]
         A BoundLens that operates on the given object
     """
     if where is None:
-        return SimpleBoundLens(lens(lambda x: x), obj)  # type: ignore[return-value]
+        return SimpleBoundLens(lens(identity), obj)  # type: ignore[return-value]
     return SimpleBoundLens(lens(where), obj)
 
 

--- a/src/kups/core/neighborlist/pipeline.py
+++ b/src/kups/core/neighborlist/pipeline.py
@@ -97,10 +97,10 @@ def _prepare(
     )
     frames = systems.map_data(lambda s: s.cell.frame.materialize())
     keys_frame = frames[keys.data.system]
-    keys = bind(keys, lambda x: x.data.positions).apply(keys_frame.to_fractional)
+    keys = bind(keys, lambda x: x.data.positions).modify(keys_frame.to_fractional)
     if queries is not None:
         queries_frame = frames[queries.data.system]
-        queries = bind(queries, lambda x: x.data.positions).apply(
+        queries = bind(queries, lambda x: x.data.positions).modify(
             queries_frame.to_fractional
         )
 

--- a/src/kups/core/potential.py
+++ b/src/kups/core/potential.py
@@ -322,7 +322,7 @@ class ScaledPotential[State, Gradients, Hessians, StatePatch: Patch[Any]](
             Scaled potential output with original patch
         """
         out = self.potential(state, patch)
-        out = bind(out).focus(lambda x: x.data).apply(lambda x: x * self.scale)
+        out = bind(out).focus(lambda x: x.data).modify(lambda x: x * self.scale)
         return out
 
 

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -171,7 +171,7 @@ def _half_time[S: HasIntegratorParams[HasTimeStep]](
     Returns:
         New Indexed system with ``integrator_params.time_step`` halved.
     """
-    return bind(sys, lambda x: x.data.integrator_params.time_step).apply(
+    return bind(sys, lambda x: x.data.integrator_params.time_step).modify(
         lambda x: x / 2
     )
 
@@ -1080,7 +1080,7 @@ class CellPositionStep[State](Propagator[State]):
         # V_old, V_dot both lower-tri ⇒ V_new lower-tri.
         V_new = V_old + (params.time_step[..., None, None] / 2) * V_dot
         # Reconstruct TriclinicFrame so cached volume refreshes.
-        return self.systems.focus(lambda x: x.data.cell.frame).apply(
+        return self.systems.focus(lambda x: x.data.cell.frame).modify(
             state, lambda frame: frame.from_matrix(V_new)
         )
 

--- a/src/kups/observables/stress.py
+++ b/src/kups/observables/stress.py
@@ -223,7 +223,7 @@ def total_lattice_gradient[C: Cell[AnyPeriodicity]](
         # so its row carries no atoms -- drop the coupling there.
         coupling = coupling * jnp.array(cell.periodic)[:, None]
         coupling_gradient = cell.frame.parameter_gradient(coupling)
-        return bind(partial, lambda c: c.frame).apply(
+        return bind(partial, lambda c: c.frame).modify(
             lambda f: tree_map(jnp.add, f, coupling_gradient)
         )
 

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -146,7 +146,7 @@ class EwaldCachePatch[State, Gradient, Hessian](Patch[State]):
     def __call__(self, state: State, accept: Accept) -> State:
         mask = accept[self.system_idx]
         new_sf = self.new_structure_factor
-        return self.lens.apply(
+        return self.lens.modify(
             state,
             lambda cache: EwaldCache(
                 structure_factor=where_broadcast_last(

--- a/src/kups/potential/mliap/local.py
+++ b/src/kups/potential/mliap/local.py
@@ -311,7 +311,7 @@ class LocalMLIAPPatch[State](Patch[State]):
         """
         new_cache = self.cache
         mask = accept[self.system_idx]
-        return self.lens.apply(
+        return self.lens.modify(
             state,
             lambda cache: tree_map(
                 lambda a, b: where_broadcast_last(mask, a, b), new_cache, cache
@@ -395,7 +395,7 @@ def local_mliap_energy_update[
     changes = inp.point_cloud_changes
     change_indices = changes.indices
     change_raw = change_indices.indices_in(old_point_cloud.particles.keys)
-    new_point_cloud = bind(old_point_cloud, lambda x: x.particles).apply(
+    new_point_cloud = bind(old_point_cloud, lambda x: x.particles).modify(
         lambda p: p.update(change_indices, changes.data)
     )
     n = old_point_cloud.particles.size
@@ -711,7 +711,7 @@ def make_local_mliap_from_state(
         out_idx_view = state.focus(
             lambda x: bind(
                 x.local_mliap_model.cache, lambda x: x.total_energies.data
-            ).apply(lambda x: jnp.arange(x.size, dtype=int))
+            ).modify(lambda x: jnp.arange(x.size, dtype=int))
         )
 
     model_lens = state.focus(lambda x: x.local_mliap_model.data)

--- a/test/core/test_lens.py
+++ b/test/core/test_lens.py
@@ -16,7 +16,7 @@ from kups.core.data import Table
 from kups.core.lens import (
     HasLensFields,
     IndexLens,
-    LambdaLens,
+    ExplicitLens,
     Lens,
     LensField,
     MergedLens,
@@ -82,7 +82,7 @@ def company():
     )
 
 
-@pytest.fixture(params=[SimpleLens, LambdaLens])
+@pytest.fixture(params=[SimpleLens, ExplicitLens])
 def direct_lens(request):
     return request.param
 
@@ -97,12 +97,12 @@ def name_lens(direct_lens):
 
     if direct_lens is SimpleLens:
         return lens(get_name)
-    elif direct_lens is LambdaLens:
+    elif direct_lens is ExplicitLens:
 
         def set_name(state: Person, value: str) -> Person:
             return Person(name=value, age=state.age, address=state.address)
 
-        return LambdaLens(view(get_name), set_name)
+        return ExplicitLens(view(get_name), set_name)
 
 
 @pytest.fixture
@@ -114,12 +114,12 @@ def age_lens(direct_lens):
 
     if direct_lens is SimpleLens:
         return lens(get_age)
-    elif direct_lens is LambdaLens:
+    elif direct_lens is ExplicitLens:
 
         def set_age(state: Person, value: int) -> Person:
             return Person(name=state.name, age=value, address=state.address)
 
-        return LambdaLens(view(get_age), set_age)
+        return ExplicitLens(view(get_age), set_age)
 
 
 @pytest.fixture(params=[("age_lens", 30), ("name_lens", "John Doe")])
@@ -130,7 +130,7 @@ def person_lens_and_target(request, direct_lens):
     return lens, target
 
 
-@pytest.fixture(params=[SimpleLens, LambdaLens])
+@pytest.fixture(params=[SimpleLens, ExplicitLens])
 def scores_lens(request):
     """Factory for creating scores lenses of different types."""
 
@@ -139,12 +139,12 @@ def scores_lens(request):
 
     if request.param is SimpleLens:
         return lens(get_scores)
-    elif request.param is LambdaLens:
+    elif request.param is ExplicitLens:
 
         def set_scores(state: Company, value: jax.Array) -> Company:
             return Company(name=state.name, employees=state.employees, scores=value)
 
-        return LambdaLens(view(get_scores), set_scores)
+        return ExplicitLens(view(get_scores), set_scores)
 
 
 class TestView:
@@ -207,7 +207,7 @@ class TestLensOperations:
         lens, val = person_lens_and_target
 
         # Apply modifier to increment age
-        modified_person = lens.apply(person, lambda age: age * 2)
+        modified_person = lens.modify(person, lambda age: age * 2)
         assert lens.get(modified_person) == val * 2
 
     def test_lens_focus(self, person):
@@ -308,7 +308,7 @@ class TestNestedLens:
             return replace(a, street=value, city="")
 
         outer = lens(get_address)
-        inner = LambdaLens(view(get_street), set_street_and_clear_city)
+        inner = ExplicitLens(view(get_street), set_street_and_clear_city)
 
         result = outer.nest(inner).set(person, "456 Oak Ave")
 
@@ -371,7 +371,7 @@ class TestBoundLens:
         assert person.name == "John Doe"  # Original unchanged
 
         # Test apply
-        new_person = bound_lens.apply(lambda name: name.upper())
+        new_person = bound_lens.modify(lambda name: name.upper())
         assert new_person.name == "JOHN DOE"
 
         # Test focus
@@ -431,8 +431,8 @@ class TestIndexLens:
             index_lens.at(jnp.array([0]))
 
 
-class TestLambdaLensSpecific:
-    """Tests specific to LambdaLens functionality that differs from SimpleLens."""
+class TestExplicitLensSpecific:
+    """Tests specific to ExplicitLens functionality that differs from SimpleLens."""
 
     def test_lambda_lens_custom_transformation(self, person):
         """Test lambda lens with custom transformation on get."""
@@ -443,7 +443,7 @@ class TestLambdaLensSpecific:
         def set_name(state: Person, value: str) -> Person:
             return Person(name=value, age=state.age, address=state.address)
 
-        upper_name_lens = LambdaLens(view(get_upper_name), set_name)
+        upper_name_lens = ExplicitLens(view(get_upper_name), set_name)
 
         # Test get with transformation
         assert upper_name_lens.get(person) == "JOHN DOE"
@@ -702,7 +702,7 @@ class TestMergedLens:
     def test_merged_lens_apply(self, person, merged_lens):
         """Test applying a modifier to merged lens values."""
         # Apply a modifier that uppercases the name and doubles the age
-        result = merged_lens.apply(person, lambda vals: (vals[0].upper(), vals[1] * 2))
+        result = merged_lens.modify(person, lambda vals: (vals[0].upper(), vals[1] * 2))
         assert result.name == "JOHN DOE"
         assert result.age == 60  # 30 * 2
 
@@ -784,14 +784,14 @@ class TestMergedLens:
         assert new_person.age == 30  # unchanged
 
     def test_merged_lens_with_lambda_lens(self, person):
-        """Test merging with a LambdaLens."""
+        """Test merging with a ExplicitLens."""
         name_lens = lens(lambda p: p.name, cls=Person)
 
         # Create a lambda lens for age
         def set_age(state: Person, value: int) -> Person:
             return Person(name=state.name, age=value, address=state.address)
 
-        age_lambda_lens = LambdaLens(view(lambda p: p.age), set_age)
+        age_lambda_lens = ExplicitLens(view(lambda p: p.age), set_age)
 
         merged = name_lens.merge(age_lambda_lens)
 
@@ -809,7 +809,7 @@ class TestMergedLens:
 
         # Perform various operations
         merged_lens.get(person)
-        merged_lens.apply(person, lambda x: (x[0].upper(), x[1] + 10))
+        merged_lens.modify(person, lambda x: (x[0].upper(), x[1] + 10))
 
         # Original should be unchanged
         assert person.name == original_name
@@ -1369,7 +1369,7 @@ class TestLensField:
         counter = Counter(count=5)
 
         count_lens = Counter.count
-        new_counter = count_lens.apply(counter, lambda x: x + 10)
+        new_counter = count_lens.modify(counter, lambda x: x + 10)
 
         assert new_counter.count == 15
         assert counter.count == 5  # Original unchanged
@@ -1741,7 +1741,7 @@ class TestMethodInvocationInLenses:
         x = Table(tuple(range(5)), jnp.arange(5))
 
         # Use apply for transformations as suggested by jonkhler
-        result = bind(x).apply(lambda s: s.map_data(lambda x: x * 2))
+        result = bind(x).modify(lambda s: s.map_data(lambda x: x * 2))
 
         assert isinstance(result, Table)
         assert jnp.array_equal(result.data, jnp.arange(5) * 2)
@@ -2433,7 +2433,7 @@ class TestIndexingAndSlicingInTraversal:
         npt.assert_array_equal(result[1], jnp.arange(4))
 
         # Apply transformation to the sliced portion
-        new_x = slice_lens.apply(
+        new_x = slice_lens.modify(
             x, lambda sliced: jax.tree.map(lambda y: y * 10, sliced)
         )
         assert len(new_x) == 3


### PR DESCRIPTION
## Summary

Addresses all items from #176. Each change is independent and motivated by that issue.

### Changes

| Item | Change |
|------|--------|
| `apply` → `modify` | Rename on all four `Lens`/`BoundLens` protocol methods and ~20 call sites across `src/`. Matches python-lenses convention (`modify` / `over`); `apply` read ambiguously as "invoke the lens". |
| `LambdaLens` → `ExplicitLens` | The class wraps explicit named getter+setter functions — it is not specifically about lambdas. Rename is local to `lens.py` and `test/core/test_lens.py`. |
| `all_where_lens` docstring | `target_cls` was documented as `(currently unused)` and pyright flagged it. It is not dead: it binds the `Target` typevar for type inference (same pattern as `_cls` in `lens()` at :766). Fixed docstring to say "type-inference only, discarded at runtime" and added `_ = target_cls`. |
| `conditional` → `predicate` | Renamed in `all_where_lens` signature and body. The parameter is a boolean predicate; `where` already means "getter" elsewhere in the module. |
| `_NOT_SET_TYPE.OBJ` → `NOT_SET` | Member name `OBJ` was meaningless in context. |
| `bind()` no-`where` branch | Replaced `lambda x: x` with `identity`, which is already imported from `kups.core.utils.functools`. |

## Out of scope (per #176)

- `SimpleLens` rename (15+ call sites in `src/`)
- Lens variance fix (separate issue #175)

## Test plan

- [x] `python3.12 -c "import ast; ast.parse(...)"` — syntax valid
- [x] All 20 `apply` call sites renamed; `grep` confirms zero residual `.apply(` in `src/` and `test/`