### PR TITLE
feat: Union `cond` branch assertions via `jax.lax.switch` instead of requiring matching structures

### DIFF
--- a/src/kups/core/assertion.py
+++ b/src/kups/core/assertion.py
@@ -18,7 +18,6 @@ Key Components:
 
 from __future__ import annotations
 
-import dataclasses
 import traceback
 import typing
 from collections.abc import Callable
@@ -55,12 +54,6 @@ from slub.util import get_bind_params
 from kups.core.lens import bind
 from kups.core.utils.jax import dataclass, field
 
-try:
-    from jax import typeof as get_aval
-except ImportError:
-    # pyrefly: ignore [missing-module-attribute]
-    from jax.core import get_aval  # pyright: ignore[reportAttributeAccessIssue]
-
 # Type alias for fix functions that take a state and fix arguments, returning a new state
 type Fix[State, FixArgs] = Callable[[State, FixArgs], State]
 
@@ -73,12 +66,6 @@ NO_ARGS: Final[_NO_ARGS] = _NO_ARGS()
 """Sentinel instance to distinguish between no arguments and None as an argument."""
 
 _TRACEBACK_MARKER: Final[str] = "\nAssertion created at:\n"
-
-
-def _strip_traceback(message: str) -> str:
-    """Strip the traceback suffix appended by runtime_assert."""
-    idx = message.find(_TRACEBACK_MARKER)
-    return message[:idx] if idx != -1 else message
 
 
 @dataclass
@@ -431,48 +418,6 @@ class AssertionContext:
         return self
 
 
-def _strip_ctx_tracebacks(ctx: AssertionContext, *, note: str = "") -> AssertionContext:
-    """Strip traceback suffixes from all assertion messages in a context."""
-    if not ctx.assertions:
-        return ctx
-
-    def _replace_msg(a: RuntimeAssertion[Any, Any]) -> RuntimeAssertion[Any, Any]:
-        stripped = _strip_traceback(a.message)
-        if note and stripped != a.message:
-            stripped += note
-        return dataclasses.replace(a, message=stripped)
-
-    return AssertionContext(assertions=tuple(map(_replace_msg, ctx.assertions)))
-
-
-def _normalize_ctx_for_comparison(out_info: tuple[Any, ...]) -> tuple[Any, ...]:
-    """Strip traceback suffixes from assertion messages for structural comparison."""
-    outvals, ctx = out_info
-    if not isinstance(ctx, AssertionContext):
-        return out_info
-    return (outvals, _strip_ctx_tracebacks(ctx))
-
-
-def _assert_same_tree[PyTree](old: PyTree, new: PyTree) -> None:
-    """Compare pytree structure and leaf shapes/dtypes."""
-    old_leaves, old_tree_def = jax.tree.flatten(old)
-    new_leaves, new_tree_def = jax.tree.flatten(new)
-    if old_tree_def != new_tree_def:
-        raise ValueError(
-            f"Function modified the tree structure: {new_tree_def} != {old_tree_def}"
-        )
-    leaf_mismatches: list[str] = []
-    for x, y in zip(old_leaves, new_leaves, strict=True):
-        xaval = get_aval(x)
-        yaval = get_aval(y)
-        if any(
-            getattr(xaval, attr) != getattr(yaval, attr) for attr in ["shape", "dtype"]
-        ):
-            leaf_mismatches.append(f"{xaval} != {yaval}")
-    if leaf_mismatches:
-        raise ValueError(f"Function modified the tree values: {leaf_mismatches}")
-
-
 def check_assertion_handler(
     interpreter: Interpreter[AssertionContext],
     ctx: AssertionContext,
@@ -540,52 +485,58 @@ def cond_handler(
     eqn: JaxprEqn,
     invals: list[TracerValue],
 ) -> HandlerResult[AssertionContext]:
-    """Custom cond handler that normalizes traceback strings before branch comparison.
+    """Custom cond handler that unions assertions across branches.
 
-    runtime_assert appends source-location tracebacks to assertion messages. Since
-    messages are static pytree fields, assertions at different source lines produce
-    different treedefs. This handler strips traceback suffixes so that branches with
-    the same base assertion compare as equal.
+    Branches may declare different assertions. The output context holds the
+    incoming assertions followed by every branch's assertions concatenated in
+    branch order. Each branch fills its own slots with real predicates and the
+    slots owned by other branches with passing placeholders (True predicate,
+    zeroed fmt_args/fix_args), so jax.lax.cond observes matching pytree
+    structures across branches. An unchosen branch thus contributes only passing
+    assertions.
     """
     _, bind_params = get_bind_params(eqn)
     branches = bind_params["branches"]
-
-    context_aware_branch_fns = [
-        reinterpret(jaxpr_as_fun(jaxpr), interpreter) for jaxpr in branches
-    ]
-
-    # Check that all branches produce the same context structure by tracing them with a dummy context
-    branch_ctx_trees = [
-        jax.jit(branch_fn).trace(ctx.push(), *invals[1:]).out_info
-        for branch_fn in context_aware_branch_fns
-    ]
     assert len(branches) > 0, "cond must have at least one branch"
-    # Normalize by stripping tracebacks before structural comparison
-    normalized = [_normalize_ctx_for_comparison(t) for t in branch_ctx_trees]
-    try:
-        for tree in normalized[1:]:
-            _assert_same_tree(normalized[0], tree)
-    except ValueError as e:
-        raise ValueError("Cond branches return inconsistent contexts.") from e
 
-    # Wrap branches to strip tracebacks from output contexts so that
-    # jax.lax.cond sees matching pytree structures across branches.
-    def _wrap_branch(
-        fn: Callable[..., tuple[Any, AssertionContext]],
+    branch_fns = [reinterpret(jaxpr_as_fun(jaxpr), interpreter) for jaxpr in branches]
+
+    # Dry-run trace each branch to learn the assertions it appends; the abstract
+    # leaves (shape/dtype) are used to build placeholders for the other branches.
+    n_in = len(ctx.assertions)
+    suffix_templates = [
+        jax.jit(fn).trace(ctx.push(), *invals[1:]).out_info[1].assertions[n_in:]
+        for fn in branch_fns
+    ]
+
+    def passing(a: RuntimeAssertion[Any, Any]) -> RuntimeAssertion[Any, Any]:
+        """Passing copy of an assertion: True predicate, zeroed fmt/fix args."""
+        a = bind(a).focus(lambda a: a.predicate).apply(jnp.ones_like)
+        return (
+            bind(a)
+            .focus(lambda a: (a.fmt_args, a.fix_args))
+            .apply(partial(jax.tree.map, jnp.zeros_like))
+        )
+
+    def wrap(
+        index: int, fn: Callable[..., tuple[Any, AssertionContext]]
     ) -> Callable[..., tuple[Any, AssertionContext]]:
         def wrapped(ctx: AssertionContext, *args: Any) -> tuple[Any, AssertionContext]:
             outvals, ctx_out = fn(ctx, *args)
-            return outvals, _strip_ctx_tracebacks(
-                ctx_out, note="\n(traceback unavailable: assertion inside cond branch)"
-            )
+            merged = list(ctx_out.assertions[:n_in])
+            for i, templates in enumerate(suffix_templates):
+                merged.extend(
+                    ctx_out.assertions[n_in:] if i == index else map(passing, templates)
+                )
+            return outvals, AssertionContext(tuple(merged))
 
         return wrapped
 
-    normalized_branch_fns = [_wrap_branch(fn) for fn in context_aware_branch_fns]
+    wrapped_fns = [wrap(i, fn) for i, fn in enumerate(branch_fns)]
 
-    outvals, ctx_out = jax.lax.cond(
-        invals[0], *reversed(normalized_branch_fns), ctx, *invals[1:]
-    )
+    # jax.lax.switch selects branch ``invals[0]`` (the cond/switch index) directly,
+    # matching the primitive's branch order and supporting any number of branches.
+    outvals, ctx_out = jax.lax.switch(invals[0], wrapped_fns, ctx, *invals[1:])
     return HandlerResult(ctx_out, outvals)
 
 

--- a/src/kups/core/propagator.py
+++ b/src/kups/core/propagator.py
@@ -247,29 +247,20 @@ def propose_mixed[State, Changes](
     propose_fns: tuple[ChangesFn[State, Changes], ...],
     weights: tuple[float, ...] | None = None,
 ) -> tuple[Changes, LogProbabilityRatio, Array]:
-    """Compute all proposals eagerly and select one at random.
+    """Select one proposal at random and evaluate only it.
 
-    All ``propose_fns`` are evaluated, then ``jax.lax.select_n`` picks one.
+    ``jax.lax.switch`` runs the chosen ``propose_fn`` and leaves the others
+    unevaluated, so only the selected move's assertions are checked.
     Returns (selected_changes, selected_log_ratio, which_index).
     """
     chain = key_chain(key)
-    # We purposefully reuse this key for all proposals!
-    # This is an optimization, since it allows for common subexpression elimination
-    # across proposals.
     key = next(chain)
-    all_results = tuple(fn(key, state) for fn in propose_fns)
-    all_changes = tuple(r[0] for r in all_results)
-    all_log_ratios = tuple(r[1] for r in all_results)
     if weights is None:
-        weights = tuple(1.0 for _ in propose_fns)
         which = jax.random.randint(next(chain), (), 0, len(propose_fns))
     else:
         probs = jnp.array(weights) / sum(weights)
         which = jax.random.choice(next(chain), len(propose_fns), p=probs)
-    selected = tree_map(lambda *cases: jax.lax.select_n(which, *cases), *all_changes)
-    log_ratio = tree_map(
-        lambda *cases: jax.lax.select_n(which, *cases), *all_log_ratios
-    )
+    selected, log_ratio = jax.lax.switch(which, propose_fns, key, state)
     return selected, log_ratio, which
 
 

--- a/src/kups/mcmc/moves.py
+++ b/src/kups/mcmc/moves.py
@@ -63,7 +63,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.functools import pipe
-from kups.core.utils.jax import dataclass, field, key_chain, tree_map
+from kups.core.utils.jax import dataclass, field, key_chain
 from kups.core.utils.math import triangular_3x3_matmul
 from kups.core.utils.position import (
     center_of_mass,
@@ -1255,23 +1255,27 @@ def make_gcmc_mcmc_propagator[State, Move: Patch[Any]](
         def _propose_exchange(key: Array, s: State) -> ExchangeChanges:
             inner = state(s)
             c = key_chain(key)
-            ins = insert_random_motif(
-                next(c),
-                inner.motifs,
-                inner.particles,
-                inner.groups,
-                inner.systems.map_data(lambda d: d.cell),
-                inner.move_capacity,
-            )
-            deletion = delete_random_motif(
-                next(c),
-                inner.motifs,
-                inner.particles,
-                inner.groups,
-                inner.move_capacity,
-            )
+            move_key = next(c)
             w = jax.random.randint(next(c), (), 0, 2)
-            return tree_map(lambda a, b: jax.lax.select_n(w, a, b), ins, deletion)
+            # Only the selected move runs, so just its assertions are checked.
+            return jax.lax.cond(
+                w == 0,
+                lambda: insert_random_motif(
+                    move_key,
+                    inner.motifs,
+                    inner.particles,
+                    inner.groups,
+                    inner.systems.map_data(lambda d: d.cell),
+                    inner.move_capacity,
+                ),
+                lambda: delete_random_motif(
+                    move_key,
+                    inner.motifs,
+                    inner.particles,
+                    inner.groups,
+                    inner.move_capacity,
+                ),
+            )
 
         propose_fns.append(_symmetric(_propose_exchange))
         wts.append(exchange_weight)

--- a/test/core/test_assertion.py
+++ b/test/core/test_assertion.py
@@ -304,13 +304,13 @@ class TestAssertionTracing:
         assert len(assertions) == 1
         assert isinstance(assertions[0], RuntimeAssertion)
 
-    def test_cond_tracing_fails_for_divergent_branches(self):
-        """Test assertion tracing through jax.lax.cond."""
+    def test_cond_unions_divergent_branches(self):
+        """Branches with different assertions are unioned; the unchosen branch is padded passing."""
 
         @jax.jit
         @with_runtime_assertions
         def cond_fn(x):
-            def f(x, y):
+            def f(x, y):  # true branch
                 runtime_assert(
                     predicate=x > 10,
                     message="Assertion failed: {a} < 10",
@@ -318,7 +318,7 @@ class TestAssertionTracing:
                 )
                 return 2 * x
 
-            def g(x, y):
+            def g(x, y):  # false branch
                 runtime_assert(
                     predicate=x > 10,
                     message="Assertion failed: {b} > 10",
@@ -328,18 +328,27 @@ class TestAssertionTracing:
 
             return jax.lax.cond(x == 6, f, g, x, x * 2)
 
-        with pytest.raises(
-            ValueError, match="Cond branches return inconsistent contexts."
-        ):
-            out, assertions = cond_fn(jnp.array(5.0))
+        # x != 6 takes the false branch (g, slot 0); its predicate (5 > 10) fails.
+        out, assertions = cond_fn(jnp.array(5.0))
+        assert isinstance(out, jax.Array)
+        assert len(assertions) == 2
+        assert not assertions[0].predicate
+        assert "{b} > 10" in assertions[0].message
+        # The true branch (f, slot 1) is padded passing.
+        assert assertions[1].predicate
+        assert "{a} < 10" in assertions[1].message
 
     def test_cond_tracing(self):
-        """Test assertion tracing through jax.lax.cond."""
+        """Test assertion tracing through jax.lax.cond.
+
+        The output unions both branches' assertions: slot 0 belongs to the false
+        branch, slot 1 to the true branch. The unchosen branch is padded passing.
+        """
 
         @with_runtime_assertions
         @jax.jit
         def cond_fn(x):
-            def falsy_fun(x, y):
+            def falsy_fun(x, y):  # false branch -> slot 0
                 runtime_assert(
                     predicate=x > 10,
                     message="Assertion failed: {a} < 10",
@@ -347,7 +356,7 @@ class TestAssertionTracing:
                 )
                 return 2 * x
 
-            def truthy_fun(x, y):
+            def truthy_fun(x, y):  # true branch -> slot 1
                 runtime_assert(
                     predicate=y > 10,
                     message="Assertion failed: {a} < 10",
@@ -357,13 +366,16 @@ class TestAssertionTracing:
 
             return jax.lax.cond(x > 5, truthy_fun, falsy_fun, x, x * 2)
 
+        # x = 5 takes the false branch; its predicate (5 > 10) fails.
         out, assertions = cond_fn(jnp.array(5.0))
         assert isinstance(out, jax.Array)
-        assert len(assertions) == 1
-        assert not assertions[0].predicate  # should fail since 5 < 10
+        assert len(assertions) == 2
+        assert not assertions[0].predicate  # false branch ran and failed
+        assert assertions[1].predicate  # true branch padded passing
 
+        # x = 6 takes the true branch; its predicate (12 > 10) passes.
         out, assertions = cond_fn(jnp.array(6.0))
-        assert assertions[0].predicate  # should pass since 12 > 10
+        assert all(bool(a.predicate) for a in assertions)
 
     def test_traceback_present_in_message(self):
         """Test that assertion messages include the creation-site traceback."""
@@ -378,8 +390,8 @@ class TestAssertionTracing:
         assert "\nAssertion created at:\n" in assertions[0].message
         assert "test_traceback_present_in_message" in assertions[0].message
 
-    def test_traceback_unavailable_in_cond(self):
-        """Test that assertions inside cond branches note the missing traceback."""
+    def test_traceback_present_in_cond(self):
+        """Test that assertions inside cond branches retain their creation-site traceback."""
 
         @with_runtime_assertions
         @jax.jit
@@ -395,9 +407,9 @@ class TestAssertionTracing:
             return jax.lax.cond(x > 5, true_branch, false_branch, x)
 
         _, assertions = cond_fn(jnp.array(3.0))
-        assert len(assertions) == 1
-        assert "\nAssertion created at:\n" not in assertions[0].message
-        assert "traceback unavailable" in assertions[0].message
+        assert len(assertions) == 2
+        assert all("\nAssertion created at:\n" in a.message for a in assertions)
+        assert all("test_traceback_present_in_cond" in a.message for a in assertions)
 
     def test_complex_nested_transformations(self):
         """Test assertion tracing through complex nested transformations."""
@@ -828,9 +840,13 @@ class TestAssertionErrorHandling:
 
             invalid_while(jnp.array(1.0))
 
-    def test_cond_branch_mismatch_errors(self):
-        """Test cond branches with mismatched assertions/fmt_args/shapes/dtypes/predicates."""
-        # Each factory creates a JIT function with inconsistent cond branches
+    def test_cond_branch_divergent_unions(self):
+        """Cond branches may declare different assertions/fmt_args/shapes/dtypes/predicates.
+
+        The output unions every branch's assertions, padding the unchosen branch
+        with passing placeholders, so none of these cases error.
+        """
+        # Each factory creates a JIT function with divergent cond branches
 
         # 1. Different number of assertions
         def make_mismatch_assertion_count():
@@ -987,19 +1003,23 @@ class TestAssertionErrorHandling:
 
             return test_fn
 
+        # (factory, expected number of unioned assertions across both branches)
         factories = [
-            make_mismatch_assertion_count,
-            make_mismatch_fmt_args_count,
-            make_mismatch_fmt_args_shapes,
-            make_mismatch_fmt_args_dtypes,
-            make_mismatch_predicate_shapes,
-            make_mismatch_predicate_dtypes,
+            (make_mismatch_assertion_count, 3),
+            (make_mismatch_fmt_args_count, 2),
+            (make_mismatch_fmt_args_shapes, 2),
+            (make_mismatch_fmt_args_dtypes, 2),
+            (make_mismatch_predicate_shapes, 2),
+            (make_mismatch_predicate_dtypes, 2),
         ]
 
-        for factory in factories:
+        for factory, expected in factories:
             fn = factory()
-            with pytest.raises(ValueError, match="return inconsistent contexts"):
-                fn(jnp.array(3.0))
+            # x = 3 takes the false branch; its real predicates pass and the true
+            # branch is padded passing, so the whole union passes.
+            _, assertions = fn(jnp.array(3.0))
+            assert len(assertions) == expected
+            assert all(bool(jnp.all(a.predicate)) for a in assertions)
 
 
 class TestAssertionIntegrationWithJAXEcosystem:

--- a/test/mcmc/test_moves.py
+++ b/test/mcmc/test_moves.py
@@ -1,6 +1,8 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -8,7 +10,7 @@ import numpy.testing as npt
 import pytest
 from jax import Array
 
-from kups.core.capacity import CapacityError, LensCapacity
+from kups.core.capacity import Capacity, CapacityError, LensCapacity
 from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
 from kups.core.data import WithIndices
 from kups.core.data.buffered import Buffered, system_view
@@ -723,16 +725,22 @@ class TestExchangeMove:
         cls.move = staticmethod(_exchange_move_cache["move"])
 
     def test_insufficient_sizes_and_capacity(self):
-        """Merged: insufficient group size, particle size, and capacity."""
+        """Merged: insufficient group size, particle size, and capacity.
+
+        These assertions are checked against ``insert_random_motif`` directly:
+        ``ExchangeMove`` dispatches randomly and checks only the selected move's
+        assertions, so it cannot reliably exercise the insertion path.
+        """
         motifs = _make_motifs(jnp.zeros((1, 3)), jnp.zeros((1,), dtype=int), 1, 1)
-        cap1 = LensCapacity(1, lens(lambda x: x["capacity"], cls=dict))
-        cases = [
-            # (key_seed, positions_shape, sys_ids_p, n_sys_p, group_ids, n_groups,
-            #  max_gs, species, sys_ids_g, n_sys_g, max_count_g, capacity, exc, match)
-            {
-                "label": "insufficient_group_size",
-                "key_seed": 2,
-                "particles": _make_particles(
+        cell = Table.arange(self.systems, label=SystemId)
+        insert = jax.jit(
+            as_result_function(insert_random_motif), static_argnames="capacity"
+        )
+        cap1 = LensCapacity(1, lens(lambda x: x, cls=int))
+        # (particles, groups, capacity, expected_exception, match)
+        cases: list[tuple[Any, Any, Capacity[int], type[Exception], str | None]] = [
+            (  # No free group slot for the inserted motif.
+                _make_particles(
                     jax.random.uniform(
                         jax.random.key(2), (11, 3), minval=-0.5, maxval=0.5
                     ),
@@ -742,20 +750,15 @@ class TestExchangeMove:
                     11,
                     1,
                 ),
-                "groups": _make_groups(
-                    jnp.zeros((10,), dtype=int),
-                    jnp.zeros((10,), dtype=int),
-                    1,
+                _make_groups(
+                    jnp.zeros((10,), dtype=int), jnp.zeros((10,), dtype=int), 1
                 ),
-                "capacity": cap1,
-                "exc": AssertionError,
-                "match": "Array size insufficient",
-                "method": "fix_or_raise",
-            },
-            {
-                "label": "insufficient_particle_size",
-                "key_seed": 3,
-                "particles": _make_particles(
+                cap1,
+                AssertionError,
+                "Array size insufficient",
+            ),
+            (  # No free particle slot for the inserted motif.
+                _make_particles(
                     jax.random.uniform(
                         jax.random.key(3), (10, 3), minval=-0.5, maxval=0.5
                     ),
@@ -765,21 +768,18 @@ class TestExchangeMove:
                     10,
                     1,
                 ),
-                "groups": _make_groups(
+                _make_groups(
                     jnp.zeros((11,), dtype=int),
                     jnp.array([0] * 10 + [1]),
                     1,
                     max_count=12,
                 ),
-                "capacity": cap1,
-                "exc": AssertionError,
-                "match": "Array size insufficient",
-                "method": "fix_or_raise",
-            },
-            {
-                "label": "insufficient_capacity",
-                "key_seed": 3,
-                "particles": _make_particles(
+                cap1,
+                AssertionError,
+                "Array size insufficient",
+            ),
+            (  # Move capacity too small to hold the selected motif.
+                _make_particles(
                     jax.random.uniform(
                         jax.random.key(3), (11, 3), minval=-0.5, maxval=0.5
                     ),
@@ -789,34 +789,23 @@ class TestExchangeMove:
                     11,
                     1,
                 ),
-                "groups": _make_groups(
+                _make_groups(
                     jnp.zeros((11,), dtype=int),
                     jnp.array([0] * 10 + [1]),
                     1,
                     max_count=12,
                 ),
-                "capacity": LensCapacity(0, lens(lambda x: x["capacity"], cls=dict)),
-                "exc": CapacityError,
-                "match": None,
-                "method": "raise_assertion",
-            },
+                LensCapacity(0, lens(lambda x: x, cls=int)),
+                CapacityError,
+                None,
+            ),
         ]
-        for case in cases:
-            chain = key_chain(jax.random.key(case["key_seed"]))
-            _ = next(chain)  # consume one key for uniform
-            state = {
-                "particles": case["particles"],
-                "groups": case["groups"],
-                "motifs": motifs,
-                "systems": self.systems,
-                "capacity": case["capacity"],
-            }
-            if case["match"]:
-                with pytest.raises(case["exc"], match=case["match"]):
-                    self.move(next(chain), state).fix_or_raise(state)
-            else:
-                with pytest.raises(case["exc"]):
-                    self.move(next(chain), state).raise_assertion()
+        for particles, groups, capacity, exc, match in cases:
+            result = insert(
+                jax.random.key(0), motifs, particles, groups, cell, capacity
+            )
+            with pytest.raises(exc, match=match):
+                result.raise_assertion()
 
     def test_atomic_single_system(self):
         chain = key_chain(jax.random.key(3))


### PR DESCRIPTION
## Replace eager branch evaluation with lazy `jax.lax.switch`-based union for `cond` handlers

Previously, `jax.lax.cond` branches were required to produce identical assertion contexts (same number of assertions, matching shapes/dtypes/messages). This was enforced by tracing both branches, normalizing traceback strings, and raising an error if the structures diverged. Proposals in `propose_mixed` and GCMC exchange moves also evaluated all branches eagerly using `jax.lax.select_n`, meaning every branch's assertions were checked regardless of which branch was actually taken.

This PR replaces that approach with a union strategy backed by `jax.lax.switch`:

- **`cond_handler`** now dry-runs each branch to discover the assertions it appends, then wraps each branch so that it emits its own real assertions for its own slots and passing placeholders (predicate `True`, zeroed `fmt_args`/`fix_args`) for every other branch's slots. `jax.lax.switch` then selects the active branch, meaning only the chosen branch's assertions carry real predicates. The previous restriction that all branches must declare the same assertions is removed entirely, and traceback strings are preserved in assertion messages.

- **`propose_mixed`** drops the eager evaluation of all proposals in favor of a single `jax.lax.switch` call, so only the selected proposal's assertions are checked.

- **`_propose_exchange`** in the GCMC propagator replaces the `jax.lax.select_n` over eagerly computed insert/delete results with a `jax.lax.cond`, again ensuring only the chosen move's assertions are evaluated.

Tests are updated to reflect the new behavior: divergent branches no longer raise errors, assertion counts reflect the full union across branches, unchosen branches contribute only passing assertions, and creation-site tracebacks are now preserved inside `cond` branches.