### PR TITLE
feat: Add loading postfix to `TqdmLogger` and cache `particles_from_ase`

### DIFF
--- a/src/kups/application/mcmc/simulation.py
+++ b/src/kups/application/mcmc/simulation.py
@@ -10,7 +10,7 @@ import logging
 from jax import Array
 
 from kups.application.mcmc.data import RunConfig
-from kups.application.mcmc.logging import MCMCLoggedData
+from kups.application.mcmc.logging import IsMCMCState, MCMCLoggedData
 from kups.application.utils.propagate import (
     make_cycle_function,
     run_simulation_cycles,
@@ -19,10 +19,10 @@ from kups.application.utils.propagate import (
 from kups.core.logging import CompositeLogger, TqdmLogger
 from kups.core.propagator import Propagator
 from kups.core.storage import HDF5StorageWriter
-from kups.core.utils.jax import key_chain
+from kups.core.utils.jax import jit, key_chain
 
 
-def run_mcmc[State](
+def run_mcmc[State: IsMCMCState](
     key: Array,
     propagator: Propagator[State],
     state: State,
@@ -41,14 +41,22 @@ def run_mcmc[State](
     Returns:
         Final simulation state after production run.
     """
+
+    @jit
+    def _postfix_jit(state: State):
+        return state.groups.num_occupied
+
+    def postfix(state: State):
+        return {"Loading": f"{_postfix_jit(state)}"}
+
     chain = key_chain(key)
     cycle_fn = make_cycle_function(propagator)
     logging.info("Warming up (%d cycles)...", config.num_warmup_cycles)
     state = run_warmup_cycles(next(chain), cycle_fn, state, config.num_warmup_cycles)
     logging.info("Production run (%d cycles)...", config.num_cycles)
-    logger = CompositeLogger(
+    logger = CompositeLogger[State](
         HDF5StorageWriter(config.out_file, logged_data, state, config.num_cycles),
-        TqdmLogger(config.num_cycles),
+        TqdmLogger(config.num_cycles, postfix=postfix),
     )
     state = run_simulation_cycles(
         next(chain), cycle_fn, state, config.num_cycles, logger

--- a/src/kups/application/utils/particles.py
+++ b/src/kups/application/utils/particles.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from functools import cache
 from pathlib import Path
 from typing import Callable
 
@@ -64,6 +65,8 @@ def particles_from_ase(
 ]:
     """Build particle data and cell from an ASE Atoms object or file path.
 
+    Results are cached when ``atoms`` is a file path.
+
     Args:
         atoms: ASE Atoms object, or a file path (str/Path) readable by
             ``ase.io.read``.
@@ -73,7 +76,26 @@ def particles_from_ase(
         rotates Cartesian positions into the lower-triangular frame.
     """
     if isinstance(atoms, (str, Path)):
-        atoms = next(ase.io.iread(atoms, index=-1, store_tags=True))
+        return _particles_from_path(atoms)
+    return _particles_from_atoms(atoms)
+
+
+@cache
+def _particles_from_path(
+    path: str | Path,
+) -> tuple[
+    Table[ParticleId, Particles], Cell[AnyPeriodicity], Callable[[Array], Array]
+]:
+    """Read an ASE-readable file and build cached particle data and cell."""
+    return _particles_from_atoms(next(ase.io.iread(path, index=-1, store_tags=True)))
+
+
+def _particles_from_atoms(
+    atoms: ase.Atoms,
+) -> tuple[
+    Table[ParticleId, Particles], Cell[AnyPeriodicity], Callable[[Array], Array]
+]:
+    """Build particle data and cell from an ASE Atoms object."""
     L, uc_transform = to_lower_triangular(jnp.asarray(atoms.cell.array))
     pbc = (bool(atoms.pbc[0]), bool(atoms.pbc[1]), bool(atoms.pbc[2]))
     cell = Cell.from_pbc(TriclinicFrame.from_matrix(L), pbc)


### PR DESCRIPTION
Adds a `postfix` function to the MCMC simulation that displays the current particle loading (total system counts) in the tqdm progress bar during the production run. The `State` type parameter is also constrained to `IsMCMCState` to support accessing the counts data required by the postfix.

Additionally, caches the `particles_from_ase` function to avoid redundant recomputation when called multiple times with the same arguments.