### PR TITLE
fix: Ensure `Quaternion.random` batch shape is leading dimension for reproducibility

### DIFF
--- a/src/kups/core/utils/quaternion.py
+++ b/src/kups/core/utils/quaternion.py
@@ -84,7 +84,9 @@ class Quaternion(Sliceable):
         Reference:
             K. Shoemake, "Uniform random rotations", Graphics Gems III, 1992.
         """
-        u1, u2, u3 = jax.random.uniform(key, shape=(3, *shape))
+        u = jax.random.uniform(key, shape=(*shape, 3))
+        u1, u2, u3 = u[..., 0], u[..., 1], u[..., 2]
+
         q = jnp.stack(
             [
                 jnp.sqrt(1 - u1) * jnp.sin(2 * jnp.pi * u2),

--- a/test/core/test_quaternion.py
+++ b/test/core/test_quaternion.py
@@ -40,6 +40,14 @@ class TestQuaternionBasics:
             decimal=6,
         )
 
+    def test_random_leading_element_batch_stable(self):
+        """The first sampled quaternion is independent of the batch size."""
+        key = jax.random.key(7)
+        npt.assert_array_equal(
+            Quaternion.random(key, shape=(1,)).components[0],
+            Quaternion.random(key, shape=(5,)).components[0],
+        )
+
 
 class TestQuaternionOperations:
     def test_multiply(self):


### PR DESCRIPTION
Fix random quaternion sampling to use batch-last RNG layout

The `Quaternion.random` method was generating random values with shape `(3, *shape)`, which caused the sampled values to vary depending on the batch size due to how JAX's random number generation traverses the array. The shape is now `(*shape, 3)`, with the three uniform samples in the last dimension, ensuring that the first quaternion in a batch is identical regardless of the total batch size.

A regression test was added to verify this stability property.