### PR TITLE
refactor: Derive `n_sys` from `particles` inside `exchange_changes_from_position_changes`

### DIFF
--- a/src/kups/application/simulations/mcmc_widom.py
+++ b/src/kups/application/simulations/mcmc_widom.py
@@ -309,9 +309,8 @@ def make_propagator(
     def displacement_patch_fn(
         key: Array, state: WidomState, proposal: ParticlePositionChanges
     ) -> MCMCStateUpdate:
-        n_sys = len(state.systems)
         exchange = exchange_changes_from_position_changes(
-            proposal, state.particles, state.groups, n_sys
+            proposal, state.particles, state.groups
         )
         return MCMCStateUpdate.from_changes(key, state, exchange)
 

--- a/src/kups/mcmc/moves.py
+++ b/src/kups/mcmc/moves.py
@@ -537,7 +537,6 @@ def exchange_changes_from_position_changes(
     changes: ParticlePositionChanges,
     particles: Buffered[ParticleId, IsExchangeParticles],
     groups: Buffered[GroupId, HasMotifAndSystemIndex],
-    n_sys: int,
 ) -> ExchangeChanges:
     """Convert a ``ParticlePositionChanges`` into ``ExchangeChanges``.
 
@@ -548,8 +547,8 @@ def exchange_changes_from_position_changes(
         changes: Proposed particle position changes.
         particles: Current buffered particle positions.
         groups: Current buffered group metadata.
-        n_sys: Number of systems (determines group output size).
     """
+    n_sys = particles.data.system.num_labels
     selected = particles[changes.particle_ids]
 
     p_data = ExchangeParticleData(
@@ -1160,7 +1159,6 @@ def make_gcmc_mcmc_propagator[State, Move: Patch[Any]](
                 pos_changes,
                 inner.particles,
                 inner.groups,
-                inner.particles.data.system.num_labels,
             ), log_ratio
 
         return wrapper

--- a/test/application/test_mcmc_rigid.py
+++ b/test/application/test_mcmc_rigid.py
@@ -221,7 +221,6 @@ def _movement_patch(key, state, changes):
         changes,
         state.particles,
         state.groups,
-        state.particles.data.system.num_labels,
     )
     return MCMCStateUpdate.from_changes(key, state, proposal)
 


### PR DESCRIPTION
The `n_sys` parameter has been removed from `exchange_changes_from_position_changes`, as the number of systems can be derived directly from `particles.data.system.num_labels` within the function itself. All call sites have been updated accordingly to no longer pass this value explicitly.