### PR TITLE
feat: Add `KahanSummand` accumulator and propagate it through potential caches

### DIFF
--- a/docs/notebooks/potentials.ipynb
+++ b/docs/notebooks/potentials.ipynb
@@ -41,6 +41,7 @@
     "from kups.core.potential import EMPTY, PotentialOut, sum_potentials\n",
     "from kups.core.typing import ExclusionId, InclusionId, Label, ParticleId, SystemId\n",
     "from kups.core.utils.jax import dataclass\n",
+    "from kups.core.utils.kahan import KahanSummand\n",
     "from kups.potential.classical.lennard_jones import LennardJonesParameters"
    ]
   },
@@ -302,13 +303,15 @@
     "    particles: Table[ParticleId, ParticleData]\n",
     "    systems: Table[SystemId, SystemData]\n",
     "    neighborlist_params: UniversalNeighborlistParameters\n",
-    "    lj_parameters: WithCache[LennardJonesParameters, PotentialOut]\n",
+    "    lj_parameters: WithCache[LennardJonesParameters, KahanSummand[PotentialOut]]\n",
     "\n",
     "\n",
-    "empty_cache = PotentialOut(\n",
-    "    total_energies=Table.arange(jnp.zeros(1), label=SystemId),\n",
-    "    gradients=EMPTY,\n",
-    "    hessians=EMPTY,\n",
+    "empty_cache = KahanSummand.init(\n",
+    "    PotentialOut(\n",
+    "        total_energies=Table.arange(jnp.zeros(1), label=SystemId),\n",
+    "        gradients=EMPTY,\n",
+    "        hessians=EMPTY,\n",
+    "    )\n",
     ")\n",
     "\n",
     "cached_state = CachedLJState(\n",
@@ -374,7 +377,7 @@
     "accept = out_full.data.total_energies.set_data(jnp.ones(1, dtype=bool))\n",
     "cached_state = out_full.patch(cached_state, accept)\n",
     "\n",
-    "print(\"cached energy:\", cached_state.lj_parameters.cache.total_energies.data)"
+    "print(\"cached energy:\", cached_state.lj_parameters.cache.value.total_energies.data)"
    ]
   },
   {

--- a/src/kups/application/mcmc/logging.py
+++ b/src/kups/application/mcmc/logging.py
@@ -28,6 +28,7 @@ from kups.core.propagator import StateProperty
 from kups.core.storage import EveryNStep, Once, WriterGroupConfig
 from kups.core.typing import GroupId, MotifId, MotifParticleId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
+from kups.core.utils.kahan import KahanSummand
 from kups.mcmc.widom import WidomStatistics
 from kups.potential.classical.ewald import EwaldCache, EwaldParameters
 from kups.potential.classical.lennard_jones import (
@@ -58,7 +59,8 @@ class IsMCMCState(Protocol):
     def lj_parameters(
         self,
     ) -> WithCache[
-        GlobalTailCorrectedLennardJonesParameters, PotentialOut[EmptyType, EmptyType]
+        GlobalTailCorrectedLennardJonesParameters,
+        KahanSummand[PotentialOut[EmptyType, EmptyType]],
     ]: ...
     @property
     def ewald_parameters(
@@ -165,11 +167,11 @@ def make_mcmc_logged_data[S: IsMCMCState](
         sys_keys = state.systems.keys
         system_step = MCMCSystemStepData(
             potential_energy=state.systems.data.potential_energy,
-            lj_energy=state.lj_parameters.cache.total_energies.data,
-            ewald_short_range_energy=ewald.short_range.total_energies.data,
-            ewald_long_range_energy=ewald.long_range.total_energies.data,
-            ewald_self_energy=ewald.self_interaction.total_energies.data,
-            ewald_exclusion_energy=ewald.exclusion.total_energies.data,
+            lj_energy=state.lj_parameters.cache.total.total_energies.data,
+            ewald_short_range_energy=ewald.short_range.total.total_energies.data,
+            ewald_long_range_energy=ewald.long_range.total.total_energies.data,
+            ewald_self_energy=ewald.self_interaction.total.total_energies.data,
+            ewald_exclusion_energy=ewald.exclusion.total.total_energies.data,
             translation_step_width=state.translation_params.map_data(
                 lambda p: p.value
             ).data,

--- a/src/kups/application/potential/classical/cosine_angle.py
+++ b/src/kups/application/potential/classical/cosine_angle.py
@@ -31,6 +31,7 @@ from kups.core.potential import (
     empty_patch_idx_view,
 )
 from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.cosine_angle import (
     CosineAngleParameters,
     IsBondedParticles,
@@ -98,7 +99,9 @@ def make_cosine_angle_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsCosineAngleState[
-            HasCache[CosineAngleParameters, PotentialOut[EmptyType, EmptyType]]
+            HasCache[
+                CosineAngleParameters, KahanSummand[PotentialOut[EmptyType, EmptyType]]
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
@@ -113,7 +116,10 @@ def make_cosine_angle_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsCosineAngleState[
-            HasCache[CosineAngleParameters, PotentialOut[PositionsAndCell, EmptyType]]
+            HasCache[
+                CosineAngleParameters,
+                KahanSummand[PotentialOut[PositionsAndCell, EmptyType]],
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
@@ -146,7 +152,8 @@ def make_cosine_angle_from_state[State](
 @overload
 def make_cosine_angle_from_state[State, P: Patch[Any]](
     state: Lens[
-        State, IsCachedCosineAngleGraphState[PotentialOut[EmptyType, EmptyType]]
+        State,
+        IsCachedCosineAngleGraphState[KahanSummand[PotentialOut[EmptyType, EmptyType]]],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
     *,
@@ -158,7 +165,10 @@ def make_cosine_angle_from_state[State, P: Patch[Any]](
 @overload
 def make_cosine_angle_from_state[State, P: Patch[Any]](
     state: Lens[
-        State, IsCachedCosineAngleGraphState[PotentialOut[PositionsAndCell, EmptyType]]
+        State,
+        IsCachedCosineAngleGraphState[
+            KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]
+        ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
     *,

--- a/src/kups/application/potential/classical/dihedral.py
+++ b/src/kups/application/potential/classical/dihedral.py
@@ -30,6 +30,7 @@ from kups.core.potential import (
     empty_patch_idx_view,
 )
 from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.dihedral import (
     DihedralParameters,
     IsBondedParticles,
@@ -91,7 +92,9 @@ def make_dihedral_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsDihedralState[
-            HasCache[DihedralParameters, PotentialOut[EmptyType, EmptyType]]
+            HasCache[
+                DihedralParameters, KahanSummand[PotentialOut[EmptyType, EmptyType]]
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
@@ -106,7 +109,10 @@ def make_dihedral_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsDihedralState[
-            HasCache[DihedralParameters, PotentialOut[PositionsAndCell, EmptyType]]
+            HasCache[
+                DihedralParameters,
+                KahanSummand[PotentialOut[PositionsAndCell, EmptyType]],
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
@@ -138,7 +144,10 @@ def make_dihedral_from_state[State](
 
 @overload
 def make_dihedral_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCachedDihedralGraphState[PotentialOut[EmptyType, EmptyType]]],
+    state: Lens[
+        State,
+        IsCachedDihedralGraphState[KahanSummand[PotentialOut[EmptyType, EmptyType]]],
+    ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
     *,
     parameters: DihedralParameters,
@@ -149,7 +158,10 @@ def make_dihedral_from_state[State, P: Patch[Any]](
 @overload
 def make_dihedral_from_state[State, P: Patch[Any]](
     state: Lens[
-        State, IsCachedDihedralGraphState[PotentialOut[PositionsAndCell, EmptyType]]
+        State,
+        IsCachedDihedralGraphState[
+            KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]
+        ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
     *,

--- a/src/kups/application/potential/classical/harmonic.py
+++ b/src/kups/application/potential/classical/harmonic.py
@@ -32,6 +32,7 @@ from kups.core.potential import (
     empty_patch_idx_view,
 )
 from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.harmonic import (
     HarmonicAngleParameters,
     HarmonicBondParameters,
@@ -104,7 +105,9 @@ def make_harmonic_bond_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsHarmonicBondState[
-            HasCache[HarmonicBondParameters, PotentialOut[EmptyType, EmptyType]]
+            HasCache[
+                HarmonicBondParameters, KahanSummand[PotentialOut[EmptyType, EmptyType]]
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
@@ -119,7 +122,10 @@ def make_harmonic_bond_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsHarmonicBondState[
-            HasCache[HarmonicBondParameters, PotentialOut[PositionsAndCell, EmptyType]]
+            HasCache[
+                HarmonicBondParameters,
+                KahanSummand[PotentialOut[PositionsAndCell, EmptyType]],
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
@@ -151,7 +157,10 @@ def make_harmonic_bond_from_state[State](
 
 @overload
 def make_harmonic_bond_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCachedHarmonicBondState[PotentialOut[EmptyType, EmptyType]]],
+    state: Lens[
+        State,
+        IsCachedHarmonicBondState[KahanSummand[PotentialOut[EmptyType, EmptyType]]],
+    ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
     *,
     parameters: HarmonicBondParameters,
@@ -162,7 +171,10 @@ def make_harmonic_bond_from_state[State, P: Patch[Any]](
 @overload
 def make_harmonic_bond_from_state[State, P: Patch[Any]](
     state: Lens[
-        State, IsCachedHarmonicBondState[PotentialOut[PositionsAndCell, EmptyType]]
+        State,
+        IsCachedHarmonicBondState[
+            KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]
+        ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
     *,
@@ -294,7 +306,10 @@ def make_harmonic_angle_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsHarmonicAngleState[
-            HasCache[HarmonicAngleParameters, PotentialOut[EmptyType, EmptyType]]
+            HasCache[
+                HarmonicAngleParameters,
+                KahanSummand[PotentialOut[EmptyType, EmptyType]],
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
@@ -309,7 +324,10 @@ def make_harmonic_angle_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsHarmonicAngleState[
-            HasCache[HarmonicAngleParameters, PotentialOut[PositionsAndCell, EmptyType]]
+            HasCache[
+                HarmonicAngleParameters,
+                KahanSummand[PotentialOut[PositionsAndCell, EmptyType]],
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
@@ -341,7 +359,10 @@ def make_harmonic_angle_from_state[State](
 
 @overload
 def make_harmonic_angle_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCachedHarmonicAngleState[PotentialOut[EmptyType, EmptyType]]],
+    state: Lens[
+        State,
+        IsCachedHarmonicAngleState[KahanSummand[PotentialOut[EmptyType, EmptyType]]],
+    ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
     *,
     parameters: HarmonicAngleParameters,
@@ -352,7 +373,10 @@ def make_harmonic_angle_from_state[State, P: Patch[Any]](
 @overload
 def make_harmonic_angle_from_state[State, P: Patch[Any]](
     state: Lens[
-        State, IsCachedHarmonicAngleState[PotentialOut[PositionsAndCell, EmptyType]]
+        State,
+        IsCachedHarmonicAngleState[
+            KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]
+        ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[3]]],
     *,

--- a/src/kups/application/potential/classical/inversion.py
+++ b/src/kups/application/potential/classical/inversion.py
@@ -31,6 +31,7 @@ from kups.core.potential import (
     empty_patch_idx_view,
 )
 from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.inversion import (
     InversionParameters,
     IsBondedParticles,
@@ -98,7 +99,9 @@ def make_inversion_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsInversionState[
-            HasCache[InversionParameters, PotentialOut[EmptyType, EmptyType]]
+            HasCache[
+                InversionParameters, KahanSummand[PotentialOut[EmptyType, EmptyType]]
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
@@ -113,7 +116,10 @@ def make_inversion_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsInversionState[
-            HasCache[InversionParameters, PotentialOut[PositionsAndCell, EmptyType]]
+            HasCache[
+                InversionParameters,
+                KahanSummand[PotentialOut[PositionsAndCell, EmptyType]],
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
@@ -145,7 +151,10 @@ def make_inversion_from_state[State](
 
 @overload
 def make_inversion_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCachedInversionGraphState[PotentialOut[EmptyType, EmptyType]]],
+    state: Lens[
+        State,
+        IsCachedInversionGraphState[KahanSummand[PotentialOut[EmptyType, EmptyType]]],
+    ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
     *,
     parameters: InversionParameters,
@@ -156,7 +165,10 @@ def make_inversion_from_state[State, P: Patch[Any]](
 @overload
 def make_inversion_from_state[State, P: Patch[Any]](
     state: Lens[
-        State, IsCachedInversionGraphState[PotentialOut[PositionsAndCell, EmptyType]]
+        State,
+        IsCachedInversionGraphState[
+            KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]
+        ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[4]]],
     *,

--- a/src/kups/application/potential/classical/lennard_jones.py
+++ b/src/kups/application/potential/classical/lennard_jones.py
@@ -39,6 +39,7 @@ from kups.core.potential import (
     empty_patch_idx_view,
 )
 from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, SystemId
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.lennard_jones import (
     GlobalTailCorrectedLennardJonesParameters,
     IsLJGraphParticles,
@@ -108,7 +109,11 @@ def make_lennard_jones_from_state[State](
 def make_lennard_jones_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
-        IsLJState[HasCache[LennardJonesParameters, PotentialOut[EmptyType, EmptyType]]],
+        IsLJState[
+            HasCache[
+                LennardJonesParameters, KahanSummand[PotentialOut[EmptyType, EmptyType]]
+            ]
+        ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
     *,
@@ -123,7 +128,10 @@ def make_lennard_jones_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsLJState[
-            HasCache[LennardJonesParameters, PotentialOut[PositionsAndCell, EmptyType]]
+            HasCache[
+                LennardJonesParameters,
+                KahanSummand[PotentialOut[PositionsAndCell, EmptyType]],
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
@@ -158,7 +166,9 @@ def make_lennard_jones_from_state[State](
 
 @overload
 def make_lennard_jones_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCachedLJGraphState[PotentialOut[EmptyType, EmptyType]]],
+    state: Lens[
+        State, IsCachedLJGraphState[KahanSummand[PotentialOut[EmptyType, EmptyType]]]
+    ],
     probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
     *,
     parameters: LennardJonesParameters,
@@ -169,7 +179,10 @@ def make_lennard_jones_from_state[State, P: Patch[Any]](
 
 @overload
 def make_lennard_jones_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCachedLJGraphState[PotentialOut[PositionsAndCell, EmptyType]]],
+    state: Lens[
+        State,
+        IsCachedLJGraphState[KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]],
+    ],
     probe: Probe[State, P, IsGraphProbe[IsLJGraphParticles, Literal[2]]],
     *,
     parameters: LennardJonesParameters,
@@ -247,7 +260,7 @@ def make_lennard_jones_from_state(
 type IsGlobalTailCorrectedIsLJState = IsLJState[
     MaybeCached[
         GlobalTailCorrectedLennardJonesParameters,
-        PotentialOut[Any, Any],
+        KahanSummand[PotentialOut[Any, Any]],
     ]
 ]
 

--- a/src/kups/application/potential/classical/morse.py
+++ b/src/kups/application/potential/classical/morse.py
@@ -31,6 +31,7 @@ from kups.core.potential import (
     empty_patch_idx_view,
 )
 from kups.core.typing import HasCache, HasCell, IsState, MaybeCached, ParticleId
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.morse import (
     IsBondedParticles,
     MorseBondParameters,
@@ -92,7 +93,9 @@ def make_morse_bond_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsMorseBondState[
-            HasCache[MorseBondParameters, PotentialOut[EmptyType, EmptyType]]
+            HasCache[
+                MorseBondParameters, KahanSummand[PotentialOut[EmptyType, EmptyType]]
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
@@ -107,7 +110,10 @@ def make_morse_bond_from_state[State, P: Patch[Any]](
     state: Lens[
         State,
         IsMorseBondState[
-            HasCache[MorseBondParameters, PotentialOut[PositionsAndCell, EmptyType]]
+            HasCache[
+                MorseBondParameters,
+                KahanSummand[PotentialOut[PositionsAndCell, EmptyType]],
+            ]
         ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
@@ -139,7 +145,10 @@ def make_morse_bond_from_state[State](
 
 @overload
 def make_morse_bond_from_state[State, P: Patch[Any]](
-    state: Lens[State, IsCachedMorseBondGraphState[PotentialOut[EmptyType, EmptyType]]],
+    state: Lens[
+        State,
+        IsCachedMorseBondGraphState[KahanSummand[PotentialOut[EmptyType, EmptyType]]],
+    ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
     *,
     parameters: MorseBondParameters,
@@ -150,7 +159,10 @@ def make_morse_bond_from_state[State, P: Patch[Any]](
 @overload
 def make_morse_bond_from_state[State, P: Patch[Any]](
     state: Lens[
-        State, IsCachedMorseBondGraphState[PotentialOut[PositionsAndCell, EmptyType]]
+        State,
+        IsCachedMorseBondGraphState[
+            KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]
+        ],
     ],
     probe: Probe[State, P, IsGraphProbe[IsBondedParticles, Literal[2]]],
     *,

--- a/src/kups/application/potential/mliap/local.py
+++ b/src/kups/application/potential/mliap/local.py
@@ -32,6 +32,7 @@ from kups.core.neighborlist import (
 from kups.core.patch import Patch, Probe
 from kups.core.potential import EMPTY_LENS, Potential, PotentialOut
 from kups.core.typing import HasCache, HasCell, IsState, MaybeCached
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.graph import IsGraphProbe
 from kups.potential.mliap.local import (
     IsLocalMLIAPGraphParticles,
@@ -86,7 +87,9 @@ def make_local_mliap_from_state[State, Gradient, Hessian](
 def make_local_mliap_from_state[State, Ptch: Patch[Any], Gradient, Hessian](
     state: Lens[
         State,
-        IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut[Gradient, Hessian]]],
+        IsLocalMLIAPState[
+            HasCache[LocalMLIAPData, KahanSummand[PotentialOut[Gradient, Hessian]]]
+        ],
     ],
     probe: Probe[State, Ptch, IsGraphProbe[IsLocalMLIAPGraphParticles, Literal[2]]],
     gradient_lens: Lens[
@@ -95,11 +98,14 @@ def make_local_mliap_from_state[State, Ptch: Patch[Any], Gradient, Hessian](
     ] = ...,
     hessian_lens: Lens[Gradient, Hessian] = ...,
     hessian_idx_view: Lens[State, Hessian] = ...,
-    out_idx_view: Lens[State, PotentialOut[Gradient, Hessian]] | None = None,
+    out_idx_view: Lens[State, KahanSummand[PotentialOut[Gradient, Hessian]]]
+    | None = None,
     *,
     parameters: None = None,
     neighborlist_factory: NeighborListFactory[
-        IsLocalMLIAPState[HasCache[LocalMLIAPData, PotentialOut[Gradient, Hessian]]]
+        IsLocalMLIAPState[
+            HasCache[LocalMLIAPData, KahanSummand[PotentialOut[Gradient, Hessian]]]
+        ]
     ] = ...,
 ) -> Potential[State, Gradient, Hessian, Ptch]: ...
 
@@ -123,7 +129,9 @@ def make_local_mliap_from_state[State, Gradient, Hessian](
 
 @overload
 def make_local_mliap_from_state[State, Ptch: Patch[Any], Gradient, Hessian](
-    state: Lens[State, IsCachedLocalMLIAPState[PotentialOut[Gradient, Hessian]]],
+    state: Lens[
+        State, IsCachedLocalMLIAPState[KahanSummand[PotentialOut[Gradient, Hessian]]]
+    ],
     probe: Probe[State, Ptch, IsGraphProbe[IsLocalMLIAPGraphParticles, Literal[2]]],
     gradient_lens: Lens[
         LocalMLIAPInput[State, IsLocalMLIAPGraphParticles, HasCell[AnyPeriodicity]],
@@ -131,11 +139,12 @@ def make_local_mliap_from_state[State, Ptch: Patch[Any], Gradient, Hessian](
     ] = ...,
     hessian_lens: Lens[Gradient, Hessian] = ...,
     hessian_idx_view: Lens[State, Hessian] = ...,
-    out_idx_view: Lens[State, PotentialOut[Gradient, Hessian]] | None = None,
+    out_idx_view: Lens[State, KahanSummand[PotentialOut[Gradient, Hessian]]]
+    | None = None,
     *,
     parameters: LocalMLIAPData,
     neighborlist_factory: NeighborListFactory[
-        IsCachedLocalMLIAPState[PotentialOut[Gradient, Hessian]]
+        IsCachedLocalMLIAPState[KahanSummand[PotentialOut[Gradient, Hessian]]]
     ] = ...,
 ) -> Potential[State, Gradient, Hessian, Ptch]: ...
 

--- a/src/kups/application/simulations/mcmc_rigid.py
+++ b/src/kups/application/simulations/mcmc_rigid.py
@@ -92,6 +92,7 @@ from kups.core.utils.jax import (
     no_jax_tracing,
     tree_map,
 )
+from kups.core.utils.kahan import KahanSummand
 from kups.mcmc.moves import (
     ExchangeChanges,
     make_gcmc_mcmc_propagator,
@@ -164,7 +165,8 @@ class MCMCState:
     systems: Table[SystemId, MCMCSystems]
     neighborlist_params: UniversalNeighborlistParameters
     lj_parameters: WithCache[
-        GlobalTailCorrectedLennardJonesParameters, PotentialOut[EmptyType, EmptyType]
+        GlobalTailCorrectedLennardJonesParameters,
+        KahanSummand[PotentialOut[EmptyType, EmptyType]],
     ]
     ewald_parameters: WithCache[EwaldParameters, EwaldCache[EmptyType, EmptyType]]
     blocking_spheres_parameters: BlockingSpheresParameters
@@ -460,7 +462,11 @@ def init_state(key: Array, config: Config) -> MCMCState:
         blocking_spheres_neighborlist_params=blocking_nlist,
         lj_parameters=WithCache(
             lj_params,
-            PotentialOut(Table.arange(jnp.zeros(n_sys), label=SystemId), EMPTY, EMPTY),
+            KahanSummand.init(
+                PotentialOut(
+                    Table.arange(jnp.zeros(n_sys), label=SystemId), EMPTY, EMPTY
+                )
+            ),
         ),
         ewald_parameters=WithCache(ewald_params, EwaldCache.make(n_sys, n_kvecs)),
         blocking_spheres_parameters=blocking_spheres,

--- a/src/kups/application/simulations/mcmc_widom.py
+++ b/src/kups/application/simulations/mcmc_widom.py
@@ -80,6 +80,7 @@ from kups.core.result import as_result_function
 from kups.core.storage import HDF5StorageWriter
 from kups.core.typing import GroupId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass, key_chain, tree_map
+from kups.core.utils.kahan import KahanSummand
 from kups.mcmc.moves import (
     ExchangeChanges,
     ExchangeMove,
@@ -221,7 +222,11 @@ def init_state(key: Array, config: Config) -> WidomState:
         blocking_spheres_neighborlist_params=blocking_nlist,
         lj_parameters=WithCache(
             lj_params,
-            PotentialOut(Table.arange(jnp.zeros(n_sys), label=SystemId), EMPTY, EMPTY),
+            KahanSummand.init(
+                PotentialOut(
+                    Table.arange(jnp.zeros(n_sys), label=SystemId), EMPTY, EMPTY
+                )
+            ),
         ),
         ewald_parameters=WithCache(ewald_params, EwaldCache.make(n_sys, n_kvecs)),
         blocking_spheres_parameters=blocking_spheres,

--- a/src/kups/core/utils/kahan.py
+++ b/src/kups/core/utils/kahan.py
@@ -1,0 +1,117 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compensated summation as a composable accumulator.
+
+This module wraps Kahan's compensated summation in a small value type. Adding
+to a ``KahanSummand`` returns a new summand carrying both the running sum and
+the rounding error lost so far, reducing floating-point drift when many values
+are accumulated.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from kups.core.utils.jax import dataclass, kahan_summation
+
+
+@dataclass
+class KahanSummand[T]:
+    """Numerically stable accumulator for repeated addition.
+
+    Holds a running sum together with a compensation term that captures the
+    low-order bits dropped by rounding at each step. The ``+`` operator (and
+    ``+=``) accumulates a value and returns a new ``KahanSummand``, so it can be
+    folded over an iterable or passed to ``sum`` like a plain number.
+
+    Values may be arbitrary PyTrees, mirroring
+    [kahan_summation][kups.core.utils.jax.kahan_summation].
+
+    Attributes:
+        value: Current running sum as a PyTree.
+        compensate: Accumulated rounding error; the best estimate of the true
+            sum is ``value - compensate``.
+
+    Example:
+        ```python
+        accumulator = KahanSummand.init(jnp.zeros(3))
+        for x in observations:
+            accumulator += x
+        result = accumulator.total
+        ```
+    """
+
+    value: T
+    compensate: T
+
+    @classmethod
+    def init(cls, value: T) -> KahanSummand[T]:
+        """Create a summand seeded with `value` and zero compensation.
+
+        Args:
+            value: Initial running sum as a PyTree.
+
+        Returns:
+            A summand starting from `value`.
+        """
+        return cls(value, jax.tree.map(jnp.zeros_like, value))
+
+    @property
+    def total(self) -> T:
+        """Best single-value estimate of the sum, ``value - compensate``."""
+        return jax.tree.map(jnp.subtract, self.value, self.compensate)
+
+    def difference(self, other: KahanSummand[T]) -> T:
+        """Difference ``self - other`` of two accumulators.
+
+        Subtracts the running sums and the compensations separately before
+        combining them. For accumulators that differ by a small increment this
+        recovers the increment to full precision: the running sums cancel
+        exactly, and the low-order bits each of them dropped are carried by the
+        compensations. Folding the compensations in first (as ``+`` does) would
+        instead annihilate them against the much larger running sums.
+
+        Args:
+            other: Accumulator to subtract.
+
+        Returns:
+            The difference as a PyTree, without compensation.
+        """
+        value = jax.tree.map(jnp.subtract, self.value, other.value)
+        compensate = jax.tree.map(jnp.subtract, self.compensate, other.compensate)
+        return jax.tree.map(jnp.subtract, value, compensate)
+
+    def __add__(self, other: KahanSummand[T] | T) -> KahanSummand[T]:
+        """Accumulate a value or another summand.
+
+        Args:
+            other: A PyTree to add, or another ``KahanSummand`` whose value and
+                compensation are both folded in.
+
+        Returns:
+            A new summand with the updated running sum and compensation.
+        """
+        addend: T
+        compensate: T
+        if isinstance(other, KahanSummand):
+            addend = other.value
+            compensate = jax.tree.map(jnp.add, self.compensate, other.compensate)
+        else:
+            addend = other
+            compensate = self.compensate
+        value, error = kahan_summation(self.value, addend, compensate=compensate)
+        return KahanSummand(value, error)
+
+    def __radd__(self, other: KahanSummand[T] | T) -> KahanSummand[T]:
+        """Accumulate from the left so `sum` and `other + summand` work.
+
+        Args:
+            other: A value to add from the left, e.g. the ``0`` start value of
+                ``sum``.
+
+        Returns:
+            A new summand with the updated running sum and compensation.
+        """
+        return self.__add__(other)

--- a/src/kups/potential/classical/cosine_angle.py
+++ b/src/kups/potential/classical/cosine_angle.py
@@ -45,6 +45,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.uff_utils import compute_uff_bond_length
 from kups.potential.common.energy import (
     EnergyFunction,
@@ -230,7 +231,8 @@ def make_cosine_angle_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create UFF-style cosine angle potential for explicitly defined angles.
 

--- a/src/kups/potential/classical/coulomb.py
+++ b/src/kups/potential/classical/coulomb.py
@@ -34,6 +34,7 @@ from kups.core.typing import (
     ParticleId,
     SystemId,
 )
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.energy import (
     PotentialFromEnergy,
 )
@@ -107,7 +108,8 @@ def make_coulomb_vacuum_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create simple Coulomb potential for non-periodic systems.
 

--- a/src/kups/potential/classical/dihedral.py
+++ b/src/kups/potential/classical/dihedral.py
@@ -43,6 +43,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.energy import (
     EnergyFunction,
     PotentialFromEnergy,
@@ -282,7 +283,8 @@ def make_dihedral_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create UFF dihedral potential for explicitly defined dihedrals.
 

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -63,6 +63,7 @@ from kups.core.utils.jax import (
     no_jax_tracing,
     tree_zeros_like,
 )
+from kups.core.utils.kahan import KahanSummand
 from kups.core.utils.math import triangular_3x3_matmul
 from kups.core.utils.ops import where_broadcast_last
 from kups.potential.classical.coulomb import _pairwise_coulomb_energy
@@ -112,10 +113,10 @@ class EwaldCache[Gradient, Hessian]:
     """
 
     structure_factor: Array  # (n_groups, n_kvecs, 2)
-    short_range: PotentialOut[Gradient, Hessian]
-    long_range: PotentialOut[Gradient, Hessian]
-    self_interaction: PotentialOut[Gradient, Hessian]
-    exclusion: PotentialOut[Gradient, Hessian]
+    short_range: KahanSummand[PotentialOut[Gradient, Hessian]]
+    long_range: KahanSummand[PotentialOut[Gradient, Hessian]]
+    self_interaction: KahanSummand[PotentialOut[Gradient, Hessian]]
+    exclusion: KahanSummand[PotentialOut[Gradient, Hessian]]
 
     @classmethod
     @no_jax_tracing
@@ -129,10 +130,10 @@ class EwaldCache[Gradient, Hessian]:
         )
         return EwaldCache(
             jnp.zeros((n_sys, n_kvecs, 2), dtype=float),
-            tree_zeros_like(out),
-            tree_zeros_like(out),
-            tree_zeros_like(out),
-            tree_zeros_like(out),
+            KahanSummand.init(tree_zeros_like(out)),
+            KahanSummand.init(tree_zeros_like(out)),
+            KahanSummand.init(tree_zeros_like(out)),
+            KahanSummand.init(tree_zeros_like(out)),
         )
 
 
@@ -717,7 +718,8 @@ def make_ewald_short_range_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create the Ewald real-space (short-range) potential."""
 
@@ -792,7 +794,8 @@ def make_ewald_self_interaction_potential[
     hessian_lens: Lens[Gradients, Hessians] = EMPTY_LENS,
     hessian_idx_view: View[State, Hessians] = EMPTY_LENS,
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create the Ewald self-interaction correction potential."""
     return PotentialFromEnergy(

--- a/src/kups/potential/classical/harmonic.py
+++ b/src/kups/potential/classical/harmonic.py
@@ -34,6 +34,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.energy import (
     EnergyFunction,
     PotentialFromEnergy,
@@ -172,7 +173,8 @@ def make_harmonic_bond_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, P]:
     """Create harmonic bond potential for explicitly defined bonds.
 
@@ -233,7 +235,8 @@ def make_harmonic_angle_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, P]:
     """Create harmonic angle potential for explicitly defined angles.
 

--- a/src/kups/potential/classical/inversion.py
+++ b/src/kups/potential/classical/inversion.py
@@ -56,6 +56,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.energy import (
     EnergyFunction,
     PotentialFromEnergy,
@@ -216,7 +217,8 @@ def make_inversion_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create UFF-style inversion potential for sp2/sp3 centers.
 

--- a/src/kups/potential/classical/lennard_jones.py
+++ b/src/kups/potential/classical/lennard_jones.py
@@ -55,6 +55,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field, jit
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.energy import (
     EnergyFunction,
     PotentialFromEnergy,
@@ -363,7 +364,8 @@ def make_lennard_jones_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create a standard Lennard-Jones potential with sharp cutoff."""
     graph_fn = GraphConstructor(
@@ -410,7 +412,8 @@ def make_pair_tail_corrected_lennard_jones_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create a Lennard-Jones potential with smooth pairwise tail correction."""
     radius_graph_fn = GraphConstructor(
@@ -450,7 +453,8 @@ def make_global_lennard_jones_tail_correction_potential[State, Gradients, Hessia
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Patch[State]]:
     """Create analytical long-range tail correction for Lennard-Jones potential."""
     return PotentialFromEnergy(

--- a/src/kups/potential/classical/morse.py
+++ b/src/kups/potential/classical/morse.py
@@ -40,6 +40,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.uff_utils import compute_uff_bond_length
 from kups.potential.common.energy import (
     EnergyFunction,
@@ -177,7 +178,8 @@ def make_morse_bond_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, P]:
     """Create Morse bond potential for explicitly defined bonds.
 

--- a/src/kups/potential/common/direct.py
+++ b/src/kups/potential/common/direct.py
@@ -13,7 +13,8 @@ from typing import Any, Protocol
 from kups.core.lens import Lens, View
 from kups.core.patch import ComposedPatch, IdPatch, IndexLensPatch, Patch, WithPatch
 from kups.core.potential import Potential, PotentialOut
-from kups.core.utils.jax import dataclass, field, jit, kahan_summation
+from kups.core.utils.jax import dataclass, field, jit
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.energy import SumComposer
 
 
@@ -44,8 +45,8 @@ class DirectPotential[
         field(static=True)
     )
     composer: SumComposer[State, Input, StatePatch] = field(static=True)
-    cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = field(
-        static=True
+    cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]] | None = (
+        field(static=True)
     )
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = field(
         static=True
@@ -66,16 +67,25 @@ class DirectPotential[
             outs.append(weight * result.data)
             patches.append(result.patch)
 
+        # Fold the weighted deltas into the cached running summand, carrying the
+        # Kahan compensation across calls. A full recompute starts a fresh summand.
         if dp_plan.add_previous_total:
             assert self.cache_lens is not None
-            outs.append(self.cache_lens.get(state))
+            summand = self.cache_lens.get(state)
+            for out in outs:
+                summand = summand + out
+        else:
+            summand = KahanSummand.init(outs[0])
+            for out in outs[1:]:
+                summand = summand + out
 
-        total = kahan_summation(*outs)[0]
+        total = summand.total
 
         if self.cache_lens is not None:
             assert self.patch_idx_view is not None
+            idx = self.patch_idx_view(state)
             cache_patch = IndexLensPatch(
-                total, self.patch_idx_view(state), self.cache_lens
+                summand, KahanSummand(idx, idx), self.cache_lens
             )
         else:
             cache_patch = IdPatch[State]()

--- a/src/kups/potential/common/energy.py
+++ b/src/kups/potential/common/energy.py
@@ -37,10 +37,10 @@ from kups.core.utils.jax import (
     dataclass,
     field,
     jit,
-    kahan_summation,
     linearize,
     tree_structure,
 )
+from kups.core.utils.kahan import KahanSummand
 
 
 class Summand[Input](NamedTuple):
@@ -226,8 +226,8 @@ class PotentialFromEnergy[
     gradient_lens: Lens[Input, Gradients] = field(static=True)
     hessian_lens: Lens[Gradients, Hessians] = field(static=True)
     hessian_idx_view: View[State, Hessians] = field(static=True)
-    cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = field(
-        static=True
+    cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]] | None = (
+        field(static=True)
     )
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = field(
         static=True
@@ -306,21 +306,28 @@ class PotentialFromEnergy[
             outs.append(weight * out)
             patches.append(energy_result.patch)
 
-        # If the dispatcher demands it, we add the previous total potential
+        # Fold the weighted deltas into the cached running summand, carrying the
+        # Kahan compensation across calls. A full recompute starts a fresh summand.
         if dp_plan.add_previous_total:
             assert self.cache_lens is not None, (
                 "Cache lens must be set for caching previous total potential."
             )
-            outs.append(self.cache_lens.get(state))
+            summand = self.cache_lens.get(state)
+            for out in outs:
+                summand = summand + out
+        else:
+            summand = KahanSummand.init(outs[0])
+            for out in outs[1:]:
+                summand = summand + out
 
-        # Aggregate the result with Kahan summation
-        total = kahan_summation(*outs)[0]
+        total = summand.total
         if self.cache_lens is not None:
             assert self.patch_idx_view is not None, (
                 "Patch index view must be set when cache lens is set."
             )
+            idx = self.patch_idx_view(state)
             cache_patch = IndexLensPatch(
-                total, self.patch_idx_view(state), self.cache_lens
+                summand, KahanSummand(idx, idx), self.cache_lens
             )
         else:
             cache_patch = IdPatch[State]()

--- a/src/kups/potential/mliap/direct.py
+++ b/src/kups/potential/mliap/direct.py
@@ -45,6 +45,7 @@ from kups.core.typing import (
     ParticleId,
     SystemId,
 )
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.direct import DirectPotential
 from kups.potential.common.geometry import Geometry, PositionsAndCell
 from kups.potential.common.graph import (
@@ -139,7 +140,8 @@ def make_direct_mliap_potential[
     model_view: View[State, Model],
     *,
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Patch[State]]:
     """Wrap a direct-gradient ``model_fn`` into a kUPS ``Potential``.
 

--- a/src/kups/potential/mliap/local.py
+++ b/src/kups/potential/mliap/local.py
@@ -65,6 +65,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass, field, sequential_vmap_with_vjp, tree_map
+from kups.core.utils.kahan import KahanSummand
 from kups.core.utils.ops import where_broadcast_last
 from kups.potential.common.energy import (
     PotentialFromEnergy,
@@ -547,7 +548,8 @@ def make_local_mliap_potential[
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create a local MLIAP potential with single message passing.
 

--- a/src/kups/potential/mliap/tojax.py
+++ b/src/kups/potential/mliap/tojax.py
@@ -27,6 +27,7 @@ from kups.core.patch import IdPatch, Patch, WithPatch
 from kups.core.potential import Energy, PotentialOut
 from kups.core.typing import HasAtomicNumbers, HasCell, ParticleId, SystemId
 from kups.core.utils.jax import dataclass, field, sequential_vmap_with_vjp
+from kups.core.utils.kahan import KahanSummand
 from kups.core.utils.msgpack import deserialize as msgpack_deserialize
 from kups.potential.common.energy import PotentialFromEnergy
 from kups.potential.common.graph import (
@@ -182,7 +183,8 @@ def make_tojaxed_potential[State, Gradients, Hessians](
     hessian_lens: Lens[Gradients, Hessians],
     hessian_idx_view: View[State, Hessians],
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
-    out_cache_lens: Lens[State, PotentialOut[Gradients, Hessians]] | None = None,
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
+    | None = None,
 ) -> PotentialFromEnergy[State, JaxifiedInput, Gradients, Hessians, Patch[Any]]:
     """Create a jaxified machine learning potential.
 

--- a/src/kups/potential/mliap/torch/interface.py
+++ b/src/kups/potential/mliap/torch/interface.py
@@ -52,6 +52,7 @@ from kups.core.typing import (
 )
 from kups.core.utils.functools import constant
 from kups.core.utils.jax import dataclass, field
+from kups.core.utils.kahan import KahanSummand
 from kups.core.utils.torch import TorchModuleWrapper
 from kups.potential.common.geometry import Geometry, PositionsAndCell
 from kups.potential.common.graph import (
@@ -367,7 +368,7 @@ def make_torch_mliap_potential[
     model: View[State, TorchMliap] | TorchMliap,
     patch_idx_view: View[State, PotentialOut[PositionsAndCell, EmptyType]]
     | None = None,
-    out_cache_lens: Lens[State, PotentialOut[PositionsAndCell, EmptyType]]
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]]
     | None = None,
 ) -> Potential[State, PositionsAndCell, EmptyType, Patch[State]]: ...
 
@@ -385,7 +386,7 @@ def make_torch_mliap_potential[
     model: View[State, TorchMliap] | TorchMliap,
     patch_idx_view: View[State, PotentialOut[PositionsAndCell, EmptyType]]
     | None = None,
-    out_cache_lens: Lens[State, PotentialOut[PositionsAndCell, EmptyType]]
+    out_cache_lens: Lens[State, KahanSummand[PotentialOut[PositionsAndCell, EmptyType]]]
     | None = None,
     *,
     gradient: Lens[Geometry, PositionsAndCell],

--- a/test/application/potential/test_potential_update.py
+++ b/test/application/potential/test_potential_update.py
@@ -48,6 +48,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import dataclass
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.cosine_angle import CosineAngleParameters
 from kups.potential.classical.dihedral import DihedralParameters
 from kups.potential.classical.harmonic import (
@@ -67,8 +68,10 @@ N_PARTICLES = 4
 _LABELS = ("A", "B")
 _PARTICLE_INDEX = tuple(ParticleId(i) for i in range(N_PARTICLES))
 
-EmptyCache = PotentialOut[EmptyType, EmptyType]
-_empty_cache = PotentialOut(Table.arange(jnp.zeros(1), label=SystemId), EMPTY, EMPTY)
+EmptyCache = KahanSummand[PotentialOut[EmptyType, EmptyType]]
+_empty_cache = KahanSummand.init(
+    PotentialOut(Table.arange(jnp.zeros(1), label=SystemId), EMPTY, EMPTY)
+)
 
 
 @dataclass

--- a/test/application/test_mcmc_rigid.py
+++ b/test/application/test_mcmc_rigid.py
@@ -62,6 +62,7 @@ from kups.core.typing import (
     ParticleId,
     SystemId,
 )
+from kups.core.utils.kahan import KahanSummand
 from kups.mcmc.moves import (
     ExchangeChanges,
     ExchangeGroupData,
@@ -141,7 +142,9 @@ def _build_state() -> MCMCState:
             cutoff=Table((SystemId(0),), jnp.array([8.0])),
             tail_corrected=jnp.array([[True]]),
         ),
-        PotentialOut(Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY),
+        KahanSummand.init(
+            PotentialOut(Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY)
+        ),
     )
     ewald_params = WithCache(
         EwaldParameters(
@@ -153,17 +156,25 @@ def _build_state() -> MCMCState:
         ),
         EwaldCache(
             structure_factor=jnp.zeros((1, 1, 2)),
-            short_range=PotentialOut(
-                Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY
+            short_range=KahanSummand.init(
+                PotentialOut(
+                    Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY
+                )
             ),
-            long_range=PotentialOut(
-                Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY
+            long_range=KahanSummand.init(
+                PotentialOut(
+                    Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY
+                )
             ),
-            self_interaction=PotentialOut(
-                Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY
+            self_interaction=KahanSummand.init(
+                PotentialOut(
+                    Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY
+                )
             ),
-            exclusion=PotentialOut(
-                Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY
+            exclusion=KahanSummand.init(
+                PotentialOut(
+                    Table.arange(jnp.zeros((1,)), label=SystemId), EMPTY, EMPTY
+                )
             ),
         ),
     )

--- a/test/core/test_jax_utils.py
+++ b/test/core/test_jax_utils.py
@@ -59,7 +59,7 @@ class TestDataclass:
         assert len({p1, p2, p3}) == 2
 
         # Marker
-        assert getattr(_Point, "_jax_dataclass") is True
+        assert _Point._jax_dataclass is True
 
     def test_dataclass_pytree_operations(self):
         """Test is_jax_pytree, complex_types, empty, idempotent."""
@@ -489,6 +489,16 @@ class TestIsin:
 class TestKahanSummation:
     """Tests for kahan_summation."""
 
+    @pytest.fixture(autouse=True)
+    def _disable_x64(self):
+        """Force float32 so rounding is coarse enough to lose an addend."""
+        prev = jax.config.read("jax_enable_x64")
+        jax.config.update("jax_enable_x64", False)
+        try:
+            yield
+        finally:
+            jax.config.update("jax_enable_x64", prev)
+
     def test_kahan_summation(self):
         # Basic sum
         result, comp = kahan_summation(jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0]))
@@ -498,6 +508,19 @@ class TestKahanSummation:
         total, comp = kahan_summation(jnp.array([1.0]), jnp.array([2.0]))
         total, comp = kahan_summation(total, jnp.array([3.0]), compensate=comp)
         npt.assert_allclose(total, jnp.array([6.0]))
+
+    def test_compensation_tracks_lost_bits(self):
+        """The addend rounded away by the sum is returned as compensation."""
+        # Half an ulp of `big`, so the sum is unchanged and all of `small`
+        # survives in the compensation, which the true total subtracts.
+        big, small = jnp.array(2.0**20), jnp.array(2.0**-4)
+        total, comp = kahan_summation(big, small)
+        npt.assert_array_equal(total, big)
+        npt.assert_array_equal(total - comp, big + small)
+
+        # Feeding it back recovers the increment the running sum cannot hold.
+        total, comp = kahan_summation(total, small, compensate=comp)
+        npt.assert_array_equal(total - big, 2.0**-3)
 
 
 class TestTreeOps:

--- a/test/core/test_kahan.py
+++ b/test/core/test_kahan.py
@@ -1,0 +1,111 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+import pytest
+
+from kups.core.utils.kahan import KahanSummand
+
+
+@pytest.fixture(autouse=True)
+def _disable_x64():
+    """Force float32 for this module without leaking the global flag.
+
+    Compensated summation only earns its keep once rounding is coarse enough to
+    lose an addend. The suite runs in float64, where demonstrating that needs
+    extreme magnitudes; float32 exercises the same code path at ordinary ones.
+    """
+    prev = jax.config.read("jax_enable_x64")
+    jax.config.update("jax_enable_x64", False)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+class TestKahanSummand:
+    def test_init(self):
+        """Seeds value and zeroes compensation for scalars and PyTrees."""
+        s = KahanSummand.init(jnp.array([1.0, 2.0]))
+        npt.assert_array_equal(s.value, [1.0, 2.0])
+        npt.assert_array_equal(s.compensate, [0.0, 0.0])
+
+        tree = KahanSummand.init({"a": jnp.array(1.0), "b": jnp.zeros(2)})
+        npt.assert_array_equal(tree.compensate["a"], 0.0)
+        npt.assert_array_equal(tree.compensate["b"], jnp.zeros(2))
+
+    def test_add_accumulates(self):
+        """`+` and `+=` accumulate values into the running sum."""
+        s = KahanSummand.init(jnp.array(0.0)) + jnp.array(3.0) + jnp.array(4.0)
+        npt.assert_allclose(s.value, 7.0)
+
+        s = KahanSummand.init(jnp.array([1.0, 2.0]))
+        s += jnp.array([3.0, 4.0])
+        npt.assert_allclose(s.value, [4.0, 6.0])
+
+    def test_add_two_summands(self):
+        """Adding two summands folds in both value and compensation."""
+        a = KahanSummand.init(jnp.array(1.0)) + jnp.array(0.5)
+        b = KahanSummand.init(jnp.array(2.0)) + jnp.array(0.25)
+        npt.assert_allclose((a + b).value, 3.75)
+
+    def test_sum_builtin(self):
+        """`sum` works via __radd__ on its 0 start value."""
+        summands = [KahanSummand.init(jnp.array(float(i))) for i in range(4)]
+        total = sum(summands)
+        assert isinstance(total, KahanSummand)
+        npt.assert_allclose(total.value, 6.0)
+
+    def test_numerical_stability(self):
+        """Compensation recovers precision a naive sum loses."""
+        # `small` is half an ulp of `big`, so every naive addition rounds away.
+        # Sixteen of them make exactly 1.0, which the compensation carries.
+        big = jnp.array(2.0**20)
+        small = jnp.array(2.0**-4)
+        assert big.dtype == jnp.float32
+        s = KahanSummand.init(big)
+        naive = big
+        for _ in range(16):
+            s += small
+            naive = naive + small
+        npt.assert_array_equal(s.total - big, 1.0)
+        npt.assert_array_equal(naive - big, 0.0)
+
+    def test_total(self):
+        """`total` reports the compensated sum for scalars and PyTrees."""
+        s = KahanSummand(jnp.array(4.0), jnp.array(0.25))
+        npt.assert_allclose(s.total, 3.75)
+
+        tree = KahanSummand({"a": jnp.array([2.0, 3.0])}, {"a": jnp.array([0.5, 1.0])})
+        npt.assert_allclose(tree.total["a"], [1.5, 2.0])
+
+    def test_difference_recovers_small_increment(self):
+        """`difference` resolves an increment the running sums cannot."""
+        big = jnp.array(1e5)
+        delta = jnp.array(1e-2)
+        old = KahanSummand.init(big)
+        for _ in range(50):
+            old += delta
+        new = old + delta
+
+        npt.assert_allclose(new.difference(old), delta, rtol=1e-5)
+        # float32 cannot represent the increment on top of `big`: the running
+        # sums differ by a multiple of ulp(1e5) = 2**-7 instead.
+        assert abs(float(new.value - old.value) - float(delta)) > 1e-3
+
+    def test_difference_pytree(self):
+        """`difference` maps over PyTrees."""
+        a = KahanSummand.init({"x": jnp.array([1.0, 2.0])}) + {
+            "x": jnp.array([1.0, 1.0])
+        }
+        b = KahanSummand.init({"x": jnp.array([1.0, 2.0])})
+        npt.assert_allclose(a.difference(b)["x"], [1.0, 1.0])
+
+    def test_jit_and_immutability(self):
+        """Works under jit and leaves the original untouched."""
+        s0 = KahanSummand.init(jnp.array([1.0, 2.0]))
+        added = jax.jit(lambda s, x: s + x)(s0, jnp.array([3.0, 4.0]))
+        npt.assert_allclose(added.value, [4.0, 6.0])
+        npt.assert_array_equal(s0.value, [1.0, 2.0])

--- a/test/potential/test_energy_potential.py
+++ b/test/potential/test_energy_potential.py
@@ -15,6 +15,7 @@ from kups.core.lens import lens, view
 from kups.core.patch import IdPatch, Patch, WithPatch
 from kups.core.potential import Energy, PotentialOut
 from kups.core.typing import SystemId
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.common.energy import (
     IdentityComposer,
     PotentialFromEnergy,
@@ -27,7 +28,7 @@ class ExampleState(NamedTuple):
     """Test state containing positions."""
 
     positions: Array
-    total_potential: PotentialOut | None = None
+    total_potential: KahanSummand[PotentialOut] | None = None
 
 
 class ExampleInput(NamedTuple):
@@ -85,7 +86,7 @@ class MockLenses:
                 gradients = ExampleGradients(positions=jnp.zeros_like(state.positions))
                 n_particles, n_dims = state.positions.shape
                 hessians = ExampleHessians(positions=jnp.zeros(n_particles * n_dims))
-                return PotentialOut(energy, gradients, hessians)
+                return KahanSummand.init(PotentialOut(energy, gradients, hessians))
             return state.total_potential
 
         return lens(get_potential)
@@ -238,7 +239,7 @@ class TestPotentialFromEnergy:
         )
         state = ExampleState(
             positions=jnp.array([[1.0, 2.0], [3.0, 4.0]]),
-            total_potential=existing_potential,
+            total_potential=KahanSummand.init(existing_potential),
         )
         result = potential(state)
         expected = 0.5 * jnp.sum(state.positions**2) + 5.0

--- a/test/potential/test_local_mliap.py
+++ b/test/potential/test_local_mliap.py
@@ -21,6 +21,7 @@ from kups.core.potential import PotentialOut
 from kups.core.result import as_result_function
 from kups.core.typing import ExclusionId, InclusionId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.mliap.local import (
     LocalMLIAPCache,
     LocalMLIAPComposer,
@@ -70,7 +71,7 @@ class State:
     atoms: Table[ParticleId, AtomData]
     systems: Table[SystemId, SystemData]
     model_config: LocalMLIAPData
-    out: PotentialOut[tuple[()], tuple[()]]
+    out: KahanSummand[PotentialOut[tuple[()], tuple[()]]]
     full_neighborlist: AllDenseNearestNeighborList
     update_nnlist: AllDenseNearestNeighborList
 
@@ -137,7 +138,9 @@ def simple_system():
                 msg_sum=jnp.zeros((n_atoms, embed_dim)),
             ),
         ),
-        out=PotentialOut(Table.arange(jnp.zeros((1,)), label=SystemId), (), ()),
+        out=KahanSummand.init(
+            PotentialOut(Table.arange(jnp.zeros((1,)), label=SystemId), (), ())
+        ),
         full_neighborlist=AllDenseNearestNeighborList(
             avg_edges=FixedCapacity(n_atoms),
             avg_image_candidates=FixedCapacity(n_atoms),


### PR DESCRIPTION
Potential energy caches now use Kahan compensated summation to reduce floating-point drift when accumulating contributions across many MCMC steps.

A new `KahanSummand[T]` type is introduced in `kups/core/utils/kahan.py`. It wraps any PyTree value together with a compensation term and exposes `+`/`+=` operators that apply Kahan's algorithm at each step. `KahanSummand.init` seeds a summand from an existing value with zero compensation.

All `out_cache_lens` and `cache_lens` parameters that previously accepted `Lens[State, PotentialOut[...]]` now require `Lens[State, KahanSummand[PotentialOut[...]]]`. The `EwaldCache` fields (`short_range`, `long_range`, `self_interaction`, `exclusion`) are similarly promoted from bare `PotentialOut` to `KahanSummand[PotentialOut]`. Logging accessors that read energies from the cache now go through `.value` to unwrap the summand.

Inside `PotentialFromEnergy` and `DirectPotential`, the previous pattern of collecting weighted outputs into a list and calling `kahan_summation(*outs)` is replaced by folding each delta into a `KahanSummand` directly. When `add_previous_total` is set, the existing cached summand is retrieved and the new deltas are folded into it, preserving the accumulated compensation across calls. The `IndexLensPatch` that writes back to the cache is updated to store the full `KahanSummand` (with a matching compensation index view) rather than just the bare total.