### PR TITLE
feat: Scale `estimate_max_adsorbates` by reservoir activity instead of returning full packing capacity

### DIFF
--- a/src/kups/application/mcmc/data.py
+++ b/src/kups/application/mcmc/data.py
@@ -28,7 +28,6 @@ from kups.core.typing import (
     ExclusionId,
     GroupId,
     HasAtomicNumbers,
-    HasCell,
     InclusionId,
     Label,
     MotifId,
@@ -457,29 +456,39 @@ def mcmc_state_from_config(
 def estimate_max_adsorbates(
     particles: Table[Any, MCMCParticles],
     motifs: Table[Any, MotifParticles],
-    systems: Table[SystemId, HasCell[AnyPeriodicity]],
+    systems: Table[SystemId, MCMCSystems],
+    max_enhancement: float = 1e4,
 ) -> Table[SystemId, Array]:
-    """Estimate the maximum number of motifs that could fit in each system.
+    """Estimate the maximum number of motifs that could be inserted per system.
 
-    The free volume per system (cell volume minus the volume occupied by
-    ``particles``) is divided by the smallest motif's occupied volume, giving
-    an upper bound on how many molecules could be inserted.
+    The estimate is ``saturation_capacity`` scaled by an approximate coverage.
+    The saturation capacity is the free volume (cell volume minus the volume
+    occupied by ``particles``) divided by the smallest motif's occupied volume,
+    i.e. the fully-packed limit. The expected occupancy of an ideal gas at the
+    system's reservoir activity, ``exp(log_activity) * free_volume``, is scaled
+    by ``max_enhancement`` to bound the adsorption enrichment and clamped to the
+    saturation capacity. The bound therefore tracks the simulated fugacity
+    rather than always returning the fully-packed count.
 
     Args:
         particles: Existing particles with atomic numbers and system membership.
         motifs: Motif templates, with each motif's atoms grouped by its system index.
-        systems: Per-system table providing the simulation cell.
+        systems: Per-system table providing the cell and reservoir activity.
+        max_enhancement: Upper bound on the adsorption enrichment over the
+            ideal-gas reservoir occupancy (Henry-factor ceiling).
 
     Returns:
         Table mapping each ``SystemId`` to the maximum motif count (clamped at zero).
     """
     total_volume = systems.map_data(lambda s: s.cell.volume)
     taken_volume = estimate_occupied_volume(particles, lambda s: s.system)
-    remaining_volume = total_volume - taken_volume
+    free_volume = (total_volume - taken_volume).map_data(lambda v: jnp.maximum(v, 0.0))
     min_motif_volume = estimate_occupied_volume(motifs, lambda s: s.motif).data.min()
-    return remaining_volume.map_data(
-        lambda v: jnp.floor(jnp.maximum(v, 0.0) / min_motif_volume).astype(int)
-    )
+    capacity = free_volume.map_data(lambda v: v / min_motif_volume)
+    activity = systems.map_data(lambda s: jnp.exp(s.log_activity).max(axis=-1))
+    capacity, ideal = Table.broadcast(capacity, activity * free_volume)
+    estimate = jnp.minimum(capacity.data, ideal.data * max_enhancement)
+    return capacity.set_data(jnp.floor(estimate).astype(int))
 
 
 def estimate_occupied_volume[T: HasAtomicNumbers, K: SupportsSorting](
@@ -498,7 +507,7 @@ def estimate_occupied_volume[T: HasAtomicNumbers, K: SupportsSorting](
         particles: Particle table carrying atomic numbers.
         group_index: Selects the grouping index from the particle data, e.g.
             ``lambda p: p.system`` to aggregate per system.
-        radius_scale: Scale factor applied to the vdW radii (default 1.75 ).
+        radius_scale: Scale factor applied to the vdW radii (default 1.0).
 
     Returns:
         Table mapping each group key to its occupied volume (Ang^3).

--- a/test/application/test_mcmc_data.py
+++ b/test/application/test_mcmc_data.py
@@ -25,6 +25,7 @@ from kups.application.mcmc.data import (
     mcmc_state_from_config,
 )
 from kups.core.cell import PeriodicCell, TriclinicFrame
+from kups.core.constants import BOLTZMANN_CONSTANT
 from kups.core.data import Index, Table
 from kups.core.typing import (
     GroupId,
@@ -372,8 +373,15 @@ def _motifs(species: list[list[int]]) -> Table[MotifParticleId, MotifParticles]:
     )
 
 
-def _systems(sides: list[float]) -> Table[SystemId, MCMCSystems]:
-    """Build a per-system table of cubic cells with the given side lengths."""
+def _systems(
+    sides: list[float], log_fugacity: float = 0.0
+) -> Table[SystemId, MCMCSystems]:
+    """Build a per-system table of cubic cells with the given side lengths.
+
+    Args:
+        sides: Cubic cell side length (Ang) per system.
+        log_fugacity: Log fugacity assigned to every system.
+    """
     n = len(sides)
     frames = TriclinicFrame.from_matrix(jnp.stack([jnp.eye(3) * s for s in sides]))
     return Table.arange(
@@ -381,7 +389,7 @@ def _systems(sides: list[float]) -> Table[SystemId, MCMCSystems]:
             cell=PeriodicCell(frames),
             temperature=jnp.full(n, 300.0),
             potential_energy=jnp.zeros(n),
-            log_fugacity=jnp.zeros((n, 1)),
+            log_fugacity=jnp.full((n, 1), log_fugacity),
         ),
         label=SystemId,
     )
@@ -420,3 +428,25 @@ class TestEstimateMaxAdsorbates:
         particles = _particles([8, 8, 8], [0, 0, 0])
         result = estimate_max_adsorbates(particles, _motifs([[6, 8]]), _systems([1.0]))
         npt.assert_array_equal(result.data, jnp.array([0]))
+
+    def test_low_fugacity_tracks_reservoir(self):
+        # Low fugacity -> estimate follows the enhanced reservoir occupancy.
+        particles = _particles([8], [0])
+        free = L**3 - _sphere_volume(8)
+        capacity = free / _sphere_volume(1)
+        activity = np.exp(-17.0 - np.log(300.0 * BOLTZMANN_CONSTANT))
+        ideal = activity * free * 1e4  # default max_enhancement
+        assert ideal < capacity  # fugacity-limited, not saturation-limited
+        result = estimate_max_adsorbates(
+            particles, _motifs([[1]]), _systems([L], log_fugacity=-17.0)
+        )
+        npt.assert_array_equal(result.data, jnp.array([np.floor(ideal)], dtype=int))
+
+    def test_high_fugacity_capped_at_capacity(self):
+        # High fugacity saturates the pore -> estimate equals geometric capacity.
+        particles = _particles([8], [0])
+        expected = np.floor((L**3 - _sphere_volume(8)) / _sphere_volume(1))
+        result = estimate_max_adsorbates(
+            particles, _motifs([[1]]), _systems([L], log_fugacity=5.0)
+        )
+        npt.assert_array_equal(result.data, jnp.array([expected], dtype=int))


### PR DESCRIPTION
`estimate_max_adsorbates` now takes reservoir activity into account when computing the upper bound on insertable motifs, rather than always returning the fully-packed geometric capacity.

Previously, the estimate divided the free volume by the smallest motif volume and returned that saturation count unconditionally. This was overly conservative at low fugacities, where only a small fraction of sites would realistically be occupied.

The new approach computes an ideal-gas occupancy from `exp(log_activity) * free_volume`, scales it by a configurable `max_enhancement` ceiling (default `1e4`) to bound the adsorption enrichment, and clamps the result to the geometric saturation capacity. At high fugacity the estimate still saturates to the fully-packed count; at low fugacity it tracks the reservoir occupancy instead.

Additional changes:
- `systems` parameter type is narrowed from `HasCell` to `MCMCSystems` so that `log_activity` is accessible.
- `free_volume` is clamped to zero before use rather than after, avoiding a redundant `maximum` call in the floor expression.
- The `radius_scale` default in `estimate_occupied_volume` is corrected in the docstring from `1.75` to `1.0`.
- `_systems` test helper accepts a `log_fugacity` argument, and two new tests cover the fugacity-limited and saturation-limited regimes.