### PR TITLE
perf: Only update postfix when `tqdm` bar is refreshed

### DIFF
--- a/src/kups/core/logging.py
+++ b/src/kups/core/logging.py
@@ -94,8 +94,8 @@ class TqdmLogger[State]:
 
     def log(self, state: State, step: int) -> None:
         if self._pbar is not None:
-            self._pbar.update(1)
-            if self._postfix is not None:
+            refreshed = self._pbar.update(1)
+            if refreshed and self._postfix is not None:
                 self._pbar.set_postfix(self._postfix(state))
 
 

--- a/test/core/test_logging.py
+++ b/test/core/test_logging.py
@@ -95,9 +95,18 @@ class TestTqdmLogger:
         logger: TqdmLogger[float] = TqdmLogger(num_steps=2, postfix=postfix)
         with logger:
             assert logger._pbar is not None
-            with patch.object(logger._pbar, "set_postfix") as mock_postfix:
+            with (
+                patch.object(logger._pbar, "update") as mock_update,
+                patch.object(logger._pbar, "set_postfix") as mock_postfix,
+            ):
+                # Postfix is only set when update() reports a display refresh.
+                mock_update.return_value = None
                 logger.log(3.14, 0)
-                mock_postfix.assert_called_once_with({"val": 3.14})
+                mock_postfix.assert_not_called()
+
+                mock_update.return_value = True
+                logger.log(2.71, 1)
+                mock_postfix.assert_called_once_with({"val": 2.71})
 
     def test_log_without_enter_is_noop(self) -> None:
         logger: TqdmLogger[str] = TqdmLogger(num_steps=5)


### PR DESCRIPTION
## Fix unnecessary postfix updates in `TqdmLogger`

Previously, `set_postfix` was called on every `log` invocation regardless of whether the progress bar actually refreshed its display. This caused redundant postfix computations and updates even when tqdm throttled the visual refresh.

By checking the return value of `pbar.update(1)` — which indicates whether a display refresh occurred — `set_postfix` is now only called when the progress bar actually updates, avoiding unnecessary work.