### PR TITLE
chore: Add `uv lock --check` pre-commit hook and dynamic `__version__`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
 
   - repo: local # Run pyright type checker
     hooks:
+      - id: uv-lock-check
+        name: check uv.lock is up to date
+        entry: uv lock --check
+        language: system
+        files: ^(pyproject\.toml|uv\.lock)$
+        pass_filenames: false
+
       - id: pyrefly
         name: pyrefly check
         entry: uv run pyrefly check src/

--- a/src/kups/__init__.py
+++ b/src/kups/__init__.py
@@ -1,3 +1,5 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "1.0.2"
+from importlib.metadata import version
+
+__version__ = version("kups")


### PR DESCRIPTION
## Changes

### Dynamic version resolution
Replaces the hardcoded `__version__` string in `kups/__init__.py` with a dynamic lookup using `importlib.metadata.version`, so the package version is always derived from the installed package metadata rather than requiring a manual update in source.

### Pre-commit lock file validation
Adds a `uv-lock-check` pre-commit hook that runs `uv lock --check` whenever `pyproject.toml` or `uv.lock` is modified, ensuring the lock file stays in sync with the project dependencies and preventing stale or inconsistent lock files from being committed.