### PR TITLE
perf: allow skipping redundant query-cell dedup

### DIFF
--- a/src/kups/core/neighborlist/cell_list.py
+++ b/src/kups/core/neighborlist/cell_list.py
@@ -40,7 +40,7 @@ from kups.core.neighborlist.types import (
     PipelineContext,
 )
 from kups.core.typing import ParticleId, SystemId
-from kups.core.utils.jax import dataclass, jit
+from kups.core.utils.jax import dataclass, field, jit
 
 
 class IsCellListParams(Protocol):
@@ -81,6 +81,7 @@ def _cell_list_subselect(
     cutoffs: Array,
     max_num_cells: Capacity[int],
     max_num_candidates: Capacity[int],
+    deduplicate_query_cells: bool = True,
 ) -> Candidates:
     cell = systems.data.cell
     key_positions, _ = cell.fold(keys.data.positions)
@@ -138,7 +139,7 @@ def _cell_list_subselect(
     # all-True, making the where a no-op.
     query_neighborhood_hashes = jnp.where(in_cell, hashes, cell_oob)
 
-    if not is_single_cell:
+    if not is_single_cell and deduplicate_query_cells:
         unique_queries = jnp.unique(
             jnp.stack([query_neighborhood_hashes, query_original.indices], axis=-1),
             axis=0,
@@ -153,7 +154,7 @@ def _cell_list_subselect(
         query_neighborhood_hashes,
         output_buffer_size=max_num_candidates,
         num_segments=cell_oob,
-        is_sorted=not is_single_cell,  # unique sorts the multi-cell neighborhood hashes
+        is_sorted=not is_single_cell and deduplicate_query_cells,
     )
     key_idx = Index(keys.keys, selection_result.scatter_idxs)
     query_idx = Index(
@@ -170,13 +171,17 @@ class CellListSelector:
     """Selector for the cell-list algorithm.
 
     Calls the raw spatial-hash candidate emission, then replicates per image
-    multiplicity when ``max(cutoff/perp) > 0.5``.
+    multiplicity when ``max(cutoff/perp) > 0.5``. Query-cell deduplication can
+    be disabled when the caller guarantees at least three cells along every
+    periodic axis; this replaces the multi-key unique sort with a single-key
+    hash sort.
     """
 
     cutoffs: Table[SystemId, Array]
     max_cells: Capacity[int]
     max_candidates: Capacity[int]
     max_image_candidates: Capacity[int]
+    deduplicate_query_cells: bool = field(default=True, static=True)
 
     def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
         query = ctx.query_table
@@ -187,6 +192,7 @@ class CellListSelector:
             cutoffs=self.cutoffs.data,
             max_num_cells=self.max_cells,
             max_num_candidates=self.max_candidates,
+            deduplicate_query_cells=self.deduplicate_query_cells,
         )
         candidates = lift_query_candidates(candidates, ctx)
         return replicate_for_images(

--- a/src/kups/core/neighborlist/cell_list.py
+++ b/src/kups/core/neighborlist/cell_list.py
@@ -12,6 +12,7 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 
+from kups.core.assertion import runtime_assert
 from kups.core.capacity import Capacity, LensCapacity
 from kups.core.data import Index, Table, subselect
 from kups.core.lens import Lens, lens
@@ -138,6 +139,17 @@ def _cell_list_subselect(
     # are excluded). For fully-periodic cells fold guarantees in_cell is
     # all-True, making the where a no-op.
     query_neighborhood_hashes = jnp.where(in_cell, hashes, cell_oob)
+
+    if not is_single_cell and promise_unique_cells:
+        # The promise only breaks through periodic wrap-around: with fewer
+        # than three cells along a periodic axis, distinct stencil offsets
+        # fold onto the same cell and emit duplicate candidates.
+        runtime_assert(
+            ((bins.data >= 3) | ~jnp.array(cell.periodic)).all(),
+            "promise_unique_cells requires at least three cells along every "
+            "periodic axis, got a minimum of {min_bins} per axis.",
+            fmt_args=dict(min_bins=jnp.min(bins.data, axis=0)),
+        )
 
     if not is_single_cell and not promise_unique_cells:
         unique_queries = jnp.unique(

--- a/src/kups/core/neighborlist/cell_list.py
+++ b/src/kups/core/neighborlist/cell_list.py
@@ -81,7 +81,7 @@ def _cell_list_subselect(
     cutoffs: Array,
     max_num_cells: Capacity[int],
     max_num_candidates: Capacity[int],
-    deduplicate_query_cells: bool = True,
+    promise_unique_cells: bool = False,
 ) -> Candidates:
     cell = systems.data.cell
     key_positions, _ = cell.fold(keys.data.positions)
@@ -139,7 +139,7 @@ def _cell_list_subselect(
     # all-True, making the where a no-op.
     query_neighborhood_hashes = jnp.where(in_cell, hashes, cell_oob)
 
-    if not is_single_cell and deduplicate_query_cells:
+    if not is_single_cell and not promise_unique_cells:
         unique_queries = jnp.unique(
             jnp.stack([query_neighborhood_hashes, query_original.indices], axis=-1),
             axis=0,
@@ -154,7 +154,7 @@ def _cell_list_subselect(
         query_neighborhood_hashes,
         output_buffer_size=max_num_candidates,
         num_segments=cell_oob,
-        is_sorted=not is_single_cell and deduplicate_query_cells,
+        is_sorted=not is_single_cell and not promise_unique_cells,
     )
     key_idx = Index(keys.keys, selection_result.scatter_idxs)
     query_idx = Index(
@@ -171,17 +171,18 @@ class CellListSelector:
     """Selector for the cell-list algorithm.
 
     Calls the raw spatial-hash candidate emission, then replicates per image
-    multiplicity when ``max(cutoff/perp) > 0.5``. Query-cell deduplication can
-    be disabled when the caller guarantees at least three cells along every
-    periodic axis; this replaces the multi-key unique sort with a single-key
-    hash sort.
+    multiplicity when ``max(cutoff/perp) > 0.5``. Set ``promise_unique_cells``
+    when the caller guarantees at least three cells along every periodic axis,
+    so each query's stencil cells are already distinct; this skips the
+    query-cell deduplication, replacing the multi-key unique sort with a
+    single-key hash sort.
     """
 
     cutoffs: Table[SystemId, Array]
     max_cells: Capacity[int]
     max_candidates: Capacity[int]
     max_image_candidates: Capacity[int]
-    deduplicate_query_cells: bool = field(default=True, static=True)
+    promise_unique_cells: bool = field(default=False, static=True)
 
     def __call__(self, ctx: PipelineContext) -> CandidateBatch[Literal[2]]:
         query = ctx.query_table
@@ -192,7 +193,7 @@ class CellListSelector:
             cutoffs=self.cutoffs.data,
             max_num_cells=self.max_cells,
             max_num_candidates=self.max_candidates,
-            deduplicate_query_cells=self.deduplicate_query_cells,
+            promise_unique_cells=self.promise_unique_cells,
         )
         candidates = lift_query_candidates(candidates, ctx)
         return replicate_for_images(

--- a/test/core/neighborlist/test_cell_list.py
+++ b/test/core/neighborlist/test_cell_list.py
@@ -5,6 +5,7 @@
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from kups.core.capacity import Capacity, FixedCapacity, LensCapacity
 from kups.core.cell import OrthogonalFrame, PeriodicCell, TriclinicFrame
@@ -163,6 +164,36 @@ class TestCellListSubselect:
             }
 
         assert pairs(False) == pairs(True)
+
+    def test_broken_promise_emits_runtime_assertion(self):
+        from kups.core.result import as_result_function
+
+        positions = jnp.array([[0.02, 0.05, 0.08], [0.52, 0.55, 0.58]])
+        lh = make_lh(positions, jnp.zeros(len(positions), dtype=int))
+        systems, _ = make_systems(
+            PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 4.0)),
+            jnp.array([1.0]),
+        )
+
+        def run(cutoff: float):
+            return as_result_function(
+                lambda: _cell_list_subselect(
+                    lh,
+                    lh,
+                    systems,
+                    cutoffs=jnp.array([cutoff]),
+                    max_num_cells=FixedCapacity(128),
+                    max_num_candidates=FixedCapacity(64),
+                    promise_unique_cells=True,
+                )
+            )()
+
+        # 4 A box, cutoff 2.0 -> 2 bins/axis: stencil offsets wrap onto the
+        # same cell, so the promise is broken.
+        with pytest.raises(AssertionError):
+            run(2.0).raise_assertion()
+        # cutoff 1.0 -> 4 bins/axis satisfies the promise.
+        run(1.0).raise_assertion()
 
 
 class TestFromState:

--- a/test/core/neighborlist/test_cell_list.py
+++ b/test/core/neighborlist/test_cell_list.py
@@ -128,6 +128,42 @@ class TestCellListSubselect:
         assert single == multi
         assert single == {(a, b) for a in range(3) for b in range(3)}
 
+    def test_distinct_stencil_fast_path_matches_deduplicated_path(self):
+        positions = jnp.array(
+            [
+                [0.02, 0.05, 0.08],
+                [0.27, 0.05, 0.08],
+                [0.52, 0.05, 0.08],
+                [0.77, 0.05, 0.08],
+            ]
+        )
+        lh = make_lh(positions, jnp.zeros(len(positions), dtype=int))
+        systems, _ = make_systems(
+            PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3)[None] * 4.0)),
+            jnp.array([1.0]),
+        )
+
+        def pairs(deduplicate_query_cells: bool):
+            candidates = _cell_list_subselect(
+                lh,
+                lh,
+                systems,
+                cutoffs=jnp.array([1.0]),
+                max_num_cells=FixedCapacity(128),
+                max_num_candidates=FixedCapacity(64),
+                deduplicate_query_cells=deduplicate_query_cells,
+            )
+            return {
+                (key, query)
+                for key, query in zip(
+                    candidates.key_idx.indices.tolist(),
+                    candidates.query_idx.indices.tolist(),
+                )
+                if key < len(positions) and query < len(positions)
+            }
+
+        assert pairs(False) == pairs(True)
+
 
 class TestFromState:
     def test_from_state_wires_lens_capacities(self):

--- a/test/core/neighborlist/test_cell_list.py
+++ b/test/core/neighborlist/test_cell_list.py
@@ -143,7 +143,7 @@ class TestCellListSubselect:
             jnp.array([1.0]),
         )
 
-        def pairs(deduplicate_query_cells: bool):
+        def pairs(promise_unique_cells: bool):
             candidates = _cell_list_subselect(
                 lh,
                 lh,
@@ -151,7 +151,7 @@ class TestCellListSubselect:
                 cutoffs=jnp.array([1.0]),
                 max_num_cells=FixedCapacity(128),
                 max_num_candidates=FixedCapacity(64),
-                deduplicate_query_cells=deduplicate_query_cells,
+                promise_unique_cells=promise_unique_cells,
             )
             return {
                 (key, query)


### PR DESCRIPTION
## Summary

- add an opt-in `promise_unique_cells=True` path to `CellListSelector` (named as a caller promise about the data, following the pattern of JAX's `promise_in_bounds`)
- replace the multi-key `jnp.unique` sort with the single-key hash argsort in `subselect` when callers prove stencil cells are distinct
- retain deduplication by default for backward compatibility (`promise_unique_cells=False`)

## Measurement

On one NVIDIA L4 for 8 independent 4,096-point periodic queries (884,736 expanded query-cell records), candidate generation falls from 6.751 ms to 5.415 ms. The 442,327-edge count, row/column checksums, cost sum, and capacity status are identical.

The intended caller guard requires at least three bins along each periodic axis; the option remains explicit because bin counts are runtime data.

## Validation

- focused cell-list and periodicity tests: passed
- Ruff format/check: passed
- Pyright: passed
- rebased onto current `main` to pick up the JAX 0.11 `scan` `num_consts` compatibility fix (#249) that was breaking the `highest` CI jobs
