### PR TITLE
perf: Replace dense key comparison with linear dict lookup in `Index.indices_in`

### DIFF
--- a/src/kups/core/data/index.py
+++ b/src/kups/core/data/index.py
@@ -391,15 +391,23 @@ class Index[Key: SupportsSorting]:
             return self.indices
         if self.keys == tokens[: len(self.keys)]:
             return jnp.where(self.indices == len(self.keys), len(tokens), self.indices)
-        keys1 = np.asarray(self.keys, dtype=object)
-        keys2 = np.asarray(tokens, dtype=object)
-        mask = keys1[:, None] == keys2
-        missing = keys1[~(mask.sum(-1) == 1).astype(bool)]
+        counts: dict[Key, int] = {}
+        positions: dict[Key, int] = {}
+        for position, token in enumerate(tokens):
+            counts[token] = counts.get(token, 0) + 1
+            positions.setdefault(token, position)
+        missing = [key for key in self.keys if counts.get(key, 0) != 1]
         if not allow_missing and len(missing) > 0:
-            raise ValueError(f"Keys in self not found in target: {missing.tolist()}")
+            raise ValueError(f"Keys in self not found in target: {missing}")
         if len(tokens) == 0:
             return jnp.full_like(self.indices, fill_value=0)
-        idx_map = jnp.asarray(np.argmax(mask, axis=-1))
+        idx_map = jnp.asarray(
+            np.fromiter(
+                (positions.get(key, 0) for key in self.keys),
+                dtype=int,
+                count=len(self.keys),
+            )
+        )
         return idx_map.at[self.indices].get(mode="fill", fill_value=len(tokens))
 
     def update_labels(

--- a/src/kups/potential/classical/blocking.py
+++ b/src/kups/potential/classical/blocking.py
@@ -276,8 +276,9 @@ class BlockingSpheresSumComposer[State, Ptch: Patch[Any]](
         # Build sphere rh as Indexed[ParticleId, _BlockingSpherePoints]
         p = parameters.positions.shape[0]
         sphere_inclusion = parameters.system.to_cls(InclusionId)
-        # Let's just pick negative exclusion IDs for spheres to avoid any possible overlap with particle exclusion IDs
-        sphere_exclusion = Index.new(tuple(ExclusionId(-1 - i) for i in range(p)))
+        sphere_exclusion = Index.new(
+            tuple(ExclusionId(len(particles) + i) for i in range(p))
+        )
         spheres = Table.arange(
             _BlockingSpherePoints(
                 positions=parameters.positions,

--- a/test/core/test_index.py
+++ b/test/core/test_index.py
@@ -14,7 +14,7 @@ from kups.core.data.index import (
     Index,
     unify_keys_by_cls,
 )
-from kups.core.typing import ParticleId, SystemId
+from kups.core.typing import ExclusionId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
 
 
@@ -197,6 +197,18 @@ class TestMatchIndices:
         merged = ("C", "H", "O")
         assert merged[int(i4[0])] == "H" and merged[int(i4[1])] == "O"
         assert merged[int(j4[0])] == "O" and merged[int(j4[1])] == "C"
+
+    def test_match_many_keys_against_key_below_range(self):
+        # Blocking-sphere shape: many particle exclusion ids matched against one
+        # foreign id that sorts below them, so the merged keyspace does not start
+        # with the particle keys and the lookup cannot short-circuit. Must stay
+        # linear -- a dense key comparison allocates n**2 bytes (37 GiB here).
+        n = 200_000
+        particles = Index.arange(n, label=ExclusionId)
+        foreign = Index.new((ExclusionId(-1),))
+        particle_idx, foreign_idx = Index.match(particles, foreign)
+        npt.assert_array_equal(particle_idx, np.arange(1, n + 1))
+        npt.assert_array_equal(foreign_idx, [0])
 
 
 class TestConcatenate:


### PR DESCRIPTION
## Fix quadratic memory allocation in `Index.indices_in` for large key sets

The previous implementation of `Index.reindex` used a dense boolean mask (`keys1[:, None] == keys2`) to find matching positions between two key arrays. For large key sets, this allocates an `n × m` matrix — in the blocking spheres case with 200,000 exclusion IDs matched against a foreign key, this would require ~37 GiB of memory.

### Changes

**`Index.reindex`** **now uses a linear dictionary-based lookup** instead of the dense mask approach. Keys are scanned once to build `counts` and `positions` dictionaries, making both the missing-key detection and the index mapping O(n) in time and space.

**Blocking sphere exclusion IDs are now assigned positive offsets** (`len(particles) + i`) rather than negative IDs (`-1 - i`). Negative IDs caused the sphere exclusion keys to sort _below_ the particle exclusion keys, preventing the early-exit short-circuit in `reindex` and triggering the expensive dense comparison. Positive offsets place sphere IDs above the particle range, restoring the short-circuit path in the common case and avoiding the issue entirely.

**A regression test** covers the previously failing scenario: 200,000 particle exclusion IDs matched against a single foreign ID that sorts below them, verifying correctness and guarding against reintroduction of the quadratic allocation.