### PR TITLE
fix: Size blocking-sphere neighbor list from batch-wide max radius to cover sphere-free systems

### DIFF
--- a/src/kups/application/simulations/mcmc_rigid.py
+++ b/src/kups/application/simulations/mcmc_rigid.py
@@ -440,10 +440,12 @@ def init_state(key: Array, config: Config) -> MCMCState:
         tree_map(jnp.maximum, lj_params.cutoff, ewald_params.cutoff),
     )
     if blocking_spheres.radii.shape[0] > 0:
+        # Systems without spheres have no radius to size from, so use the batch-wide max.
+        max_radius = Table((SystemId(0),), blocking_spheres.radii.max(keepdims=True))
         blocking_nlist = UniversalNeighborlistParameters.estimate(
-            Table.arange(jnp.array([num_buffer_particles / n_sys]), label=SystemId),
+            particles.data.system.counts + num_buffer_particles,
             system,
-            blocking_spheres.system.max_over(blocking_spheres.radii),
+            Table.broadcast_to(max_radius, system),
         )
     else:
         blocking_nlist = UniversalNeighborlistParameters(0, 0, 0, 0)

--- a/src/kups/application/simulations/mcmc_widom.py
+++ b/src/kups/application/simulations/mcmc_widom.py
@@ -201,10 +201,12 @@ def init_state(key: Array, config: Config) -> WidomState:
         tree_map(jnp.maximum, lj_params.cutoff, ewald_params.cutoff),
     )
     if blocking_spheres.radii.shape[0] > 0:
+        # Systems without spheres have no radius to size from, so use the batch-wide max.
+        max_radius = Table((SystemId(0),), blocking_spheres.radii.max(keepdims=True))
         blocking_nlist = UniversalNeighborlistParameters.estimate(
-            Table.arange(jnp.array([num_buffer_particles / n_sys]), label=SystemId),
+            particles.data.system.counts + num_buffer_particles / n_sys,
             system,
-            blocking_spheres.system.max_over(blocking_spheres.radii),
+            Table.broadcast_to(max_radius, system),
         )
     else:
         blocking_nlist = UniversalNeighborlistParameters(0, 0, 0, 0)

--- a/test/application/test_mcmc_rigid.py
+++ b/test/application/test_mcmc_rigid.py
@@ -16,6 +16,7 @@ from kups.application.mcmc import (
 from kups.application.mcmc.analysis import analyze_mcmc_file
 from kups.application.mcmc.data import (
     AdsorbateConfig,
+    BlockingSphereConfig,
     HostConfig,
     MotifParticles,
     RunConfig,
@@ -497,6 +498,39 @@ def _batched_config(n_hosts: int, init_adsorbates: tuple[int, ...]) -> Config:
     base = _config(exchange_prob=0.5, init_adsorbates=init_adsorbates)
     host = base.hosts[0]
     return base.model_copy(update={"hosts": tuple(host for _ in range(n_hosts))})
+
+
+class TestInitStateBlockingSpheres:
+    """Sizing the blocking-sphere neighbor list must cover sphere-free systems too."""
+
+    @staticmethod
+    def _mixed_batch() -> Config:
+        """Two-host config where only the first host defines a blocking sphere."""
+        base = _batched_config(2, init_adsorbates=(1,))
+        blocked = base.hosts[0].model_copy(
+            update={
+                "blocking_spheres": (
+                    (BlockingSphereConfig(center=(0.0, 0.0, 0.0), radius=2.0),),
+                )
+            }
+        )
+        return base.model_copy(update={"hosts": (blocked, base.hosts[1])})
+
+    def test_spheres_on_one_host_of_a_batch(self):
+        state = init_state(jax.random.key(0), self._mixed_batch())
+        assert state.has_blocking_spheres
+        assert state.blocking_spheres_parameters.radii.shape == (1,)
+        # Capacities are estimated from the batch-wide max radius, so they are populated
+        # for every system rather than only the one owning the sphere.
+        params = state.blocking_spheres_neighborlist_params
+        assert params.avg_candidates > 0 and params.cells > 0
+
+    def test_no_spheres_leaves_capacities_empty(self):
+        state = init_state(jax.random.key(0), _batched_config(2, init_adsorbates=(1,)))
+        assert not state.has_blocking_spheres
+        assert state.blocking_spheres_neighborlist_params == (
+            UniversalNeighborlistParameters(0, 0, 0, 0)
+        )
 
 
 class TestExchangeEnergyConsistency:

--- a/test/application/test_mcmc_widom.py
+++ b/test/application/test_mcmc_widom.py
@@ -157,6 +157,19 @@ class TestInitState:
             blocked_state.blocking_spheres_parameters.radii, jnp.array([2.0])
         )
 
+    def test_spheres_on_one_host_of_a_batch(self):
+        # Sizing the blocking neighbor list must cover the sphere-free host too.
+        cif = _write_cubic_ar_cif()
+        config = _config(_host(cif, blocking_spheres=_SPHERES))
+        config = config.model_copy(
+            update={"hosts": (config.hosts[0], _host(cif))},
+        )
+        state = init_state(jax.random.key(0), config)
+        assert state.has_blocking_spheres
+        assert state.blocking_spheres_parameters.radii.shape == (1,)
+        params = state.blocking_spheres_neighborlist_params
+        assert params.avg_candidates > 0 and params.cells > 0
+
 
 class TestMakePropagator:
     """``init_state`` + ``make_propagator`` shared per host variant."""


### PR DESCRIPTION
Fix blocking-sphere neighbor list sizing for batches with sphere-free systems

When estimating the blocking-sphere neighbor list capacity, the previous logic used `max_over` on only the systems that actually owned blocking spheres. In a batched run where some systems have no blocking spheres, those systems contributed no radius, causing the neighbor list to be undersized or incorrectly estimated for the batch.

The fix computes a single batch-wide maximum radius from all blocking spheres and broadcasts it across every system before passing it to `UniversalNeighborlistParameters.estimate`. This ensures that systems without any blocking spheres still receive a properly sized neighbor list based on the largest sphere in the batch.

The particle count argument was also corrected in the rigid MCMC path to use per-system particle counts rather than a uniform average.

Tests covering a two-host batch where only one host defines a blocking sphere are added for both the rigid and Widom MCMC paths, verifying that neighbor list capacities are non-zero across the full batch and that the all-sphere-free case still produces empty capacities.