### PR TITLE
fix(Table): Enforce sorted primary keys in `Table` and add `Table.new`

### DIFF
--- a/src/kups/core/data/table.py
+++ b/src/kups/core/data/table.py
@@ -19,7 +19,6 @@ from typing import (
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 from jax import Array
 
 from kups.core.data.batched import Batched
@@ -93,6 +92,15 @@ class Table(Batched, Generic[TKey, TData]):
       Any ``Index[TKey]`` leaf inside another table's ``data`` acts as a
       foreign key referencing this table's primary keys.
 
+    **Key ordering:**
+
+    ``keys`` must be strictly increasing; the constructor raises otherwise,
+    mirroring :class:`~kups.core.data.index.Index`.  This is what makes the
+    two interoperable — an ``Index`` built from a table's keys (e.g. via
+    :attr:`index`) shares the same key ordering, so foreign-key lookups
+    resolve positionally.  To build a table from keys in arbitrary order,
+    use :meth:`new`, which sorts them and permutes ``data`` to match.
+
     Attributes:
         keys: Primary key column — unique sorted tuple, one entry per row.
         data: Value column — pytree of arrays with leading dimension ``len(keys)``.
@@ -113,30 +121,8 @@ class Table(Batched, Generic[TKey, TData]):
 
     @skip_post_init_if_disabled
     def __post_init__(self) -> None:
-        n = len(self.keys)
-        assert len(np.unique(np.asarray(self.keys, dtype=object))) == n, (
-            "Primary keys must be unique"
-        )
-
-        def _validate_and_broadcast(leaf: Any) -> Any:
-            if isinstance(leaf, (Index, Table)):
-                return leaf
-            dim = leaf.shape[0]
-            if dim != n and dim != 1:
-                raise ValueError(
-                    f"Leaf has size {dim} along axis 0, "
-                    f"expected {n} (or 1 for broadcasting)."
-                )
-            if dim == 1:
-                shape = (n,) + leaf.shape[1:]
-                return jnp.broadcast_to(leaf, shape)
-            return leaf
-
-        updated_data = tree_map(
-            _validate_and_broadcast,
-            self.data,
-            is_leaf=lambda x: isinstance(x, (Index, Table)),
-        )
+        _check_keys(self.keys)
+        updated_data = _broadcast_rows(self.data, len(self.keys))
         assert all(type(x) is self.cls for x in self.keys), (
             f"Key type mismatch: expected {self.cls.__name__}, "
             f"got {set(type(x).__name__ for x in self.keys)}."
@@ -148,6 +134,46 @@ class Table(Batched, Generic[TKey, TData]):
     def __str__(self) -> str:
         keys_str = _format_keys(self.keys)
         return f"Table({self.cls.__name__}, keys={keys_str}, data={self.data})"
+
+    @classmethod
+    def new[K: SupportsSorting, D](
+        cls, keys: Sequence[K], data: D, *, _cls: type[K] | None = None
+    ) -> Table[K, D]:
+        """Create a ``Table`` from keys given in arbitrary order.
+
+        The constructor requires ``keys`` to be strictly increasing; this
+        sorts them instead, permuting ``data`` to match so that every key
+        keeps the row it was passed with.  Nested ``Index`` columns are
+        permuted along with the arrays.
+
+        Args:
+            keys: Primary keys in any order. Must be unique.
+            data: Value column, aligned to ``keys`` as given.
+            _cls: Key type, for empty input where it cannot be inferred.
+
+        Returns:
+            A ``Table`` with sorted keys and correspondingly permuted rows.
+
+        Raises:
+            ValueError: If ``keys`` contains duplicates, or if a data leaf
+                has the wrong leading dimension.
+
+        Example::
+
+            >>> t = Table.new(("O", "H"), jnp.array([16.0, 1.0]))
+            >>> t.keys                 # ('H', 'O')
+            >>> t.data                 # array([1.0, 16.0])
+        """
+        keys = tuple(keys)
+        order = sorted(range(len(keys)), key=keys.__getitem__)
+        if order == list(range(len(keys))):
+            return Table(keys, data, _cls=_cls)
+        rows = _broadcast_rows(data, len(keys))
+        return Table(
+            tuple(keys[i] for i in order),
+            bind(rows).at((jnp.asarray(order),)).get(),
+            _cls=_cls,
+        )
 
     @classmethod
     def arange[D, Label: SupportsSorting](
@@ -323,9 +349,9 @@ class Table(Batched, Generic[TKey, TData]):
         """Join multiple ``Table`` objects on matching keys into tuple data.
 
         Performs a SQL-style ``JOIN`` on key equality. All arguments must
-        share the same key set. If keys appear in a different order, the
-        ``others`` are reindexed to match ``base``'s key ordering before
-        their data is combined.
+        share the same key set. Because keys are always sorted, a matching
+        key set implies a matching key order; ``others`` are nonetheless
+        reindexed onto ``base``'s keys if the two ever disagree.
 
         Args:
             base: The reference ``Table`` whose key ordering is preserved.
@@ -343,7 +369,7 @@ class Table(Batched, Generic[TKey, TData]):
         Example::
 
             >>> species = Table(("H", "O"), jnp.array([1, 8]))
-            >>> masses  = Table(("O", "H"), jnp.array([16.0, 1.0]))
+            >>> masses  = Table.new(("O", "H"), jnp.array([16.0, 1.0]))
             >>> joined  = Table.join(species, masses)
             >>> joined.data  # (array([1, 8]), array([1.0, 16.0]))
         """
@@ -851,6 +877,59 @@ class Table(Batched, Generic[TKey, TData]):
             return Table(args[0].keys, fn(*[a.data for a in args]))
 
         return wrapped
+
+
+def _check_keys(keys: tuple[Any, ...]) -> None:
+    """Enforce the primary-key invariant: strictly increasing.
+
+    Checked in one pass rather than by sorting, so that both halves of the
+    invariant get their own error message. Unsorted keys point the caller at
+    :meth:`Table.new`, which is the supported way to supply them.
+
+    Raises:
+        ValueError: If ``keys`` is unsorted or contains duplicates.
+    """
+    for a, b in zip(keys, keys[1:]):
+        if b < a:
+            raise ValueError(
+                f"Primary keys must be sorted, got {a!r} before {b!r}. "
+                "Use Table.new() to sort keys and permute data to match."
+            )
+        if not a < b:
+            raise ValueError(f"Primary keys must be unique, got {a!r} twice.")
+
+
+def _broadcast_rows[D](data: D, n: int) -> D:
+    """Check that every data leaf has ``n`` rows, broadcasting size-1 leaves.
+
+    ``Index`` and ``Table`` leaves are left alone — they carry their own key
+    column and validate themselves.
+
+    Args:
+        data: Value column to check.
+        n: Required leading-axis size.
+
+    Returns:
+        ``data`` with any size-1 leaf broadcast to ``n`` rows.
+
+    Raises:
+        ValueError: If a leaf's leading axis is neither ``n`` nor 1.
+    """
+
+    def _leaf(leaf: Any) -> Any:
+        if isinstance(leaf, (Index, Table)):
+            return leaf
+        dim = leaf.shape[0]
+        if dim != n and dim != 1:
+            raise ValueError(
+                f"Leaf has size {dim} along axis 0, "
+                f"expected {n} (or 1 for broadcasting)."
+            )
+        if dim == 1:
+            return jnp.broadcast_to(leaf, (n,) + leaf.shape[1:])
+        return leaf
+
+    return tree_map(_leaf, data, is_leaf=lambda x: isinstance(x, (Index, Table)))
 
 
 def _table_operator[K: SupportsSorting, A1, A2, A3](

--- a/test/core/test_table.py
+++ b/test/core/test_table.py
@@ -80,6 +80,88 @@ class TestConstruction:
         assert Table.arange(data_ar2).keys == (0, 1, 2)
 
 
+class TestKeyOrdering:
+    """Primary keys must be strictly increasing, as ``Index`` requires.
+
+    The constructor rejects anything else; ``Table.new`` is the supported
+    way to pass keys in arbitrary order.
+    """
+
+    def test_constructor_rejects_unsorted_keys(self):
+        with pytest.raises(ValueError, match="must be sorted"):
+            Table(("c", "a", "b"), jnp.array([30.0, 10.0, 20.0]))
+        with pytest.raises(ValueError, match="must be sorted"):
+            Table((SystemId(2), SystemId(0)), jnp.array([2.0, 0.0]), _cls=SystemId)
+        # the error names Table.new, so the fix is discoverable
+        with pytest.raises(ValueError, match=r"Table\.new\(\)"):
+            Table(("b", "a"), jnp.array([1.0, 2.0]))
+
+    def test_constructor_rejects_duplicate_keys(self):
+        with pytest.raises(ValueError, match="must be unique"):
+            Table(("a", "a"), jnp.array([1.0, 2.0]))
+
+    def test_new_sorts_keys_and_data(self):
+        t = Table.new(("c", "a", "b"), jnp.array([30.0, 10.0, 20.0]))
+        assert t.keys == ("a", "b", "c")
+        npt.assert_array_equal(t.data, [10.0, 20.0, 30.0])
+        # key -> value pairing survives the permutation
+        assert {k: float(v) for k, v in t} == {"a": 10.0, "b": 20.0, "c": 30.0}
+
+    def test_new_index_interop(self):
+        t = Table.new(
+            (SystemId(2), SystemId(0), SystemId(1)),
+            jnp.array([2.0, 0.0, 1.0]),
+            _cls=SystemId,
+        )
+        assert t.keys == (SystemId(0), SystemId(1), SystemId(2))
+        assert t.index.keys == t.keys
+        npt.assert_array_equal(t.index.indices, jnp.arange(3))
+        npt.assert_array_equal(t[t.index], t.data)
+        npt.assert_array_equal(t[Index.new([SystemId(1)])], [1.0])
+
+    def test_new_permutes_index_leaves(self):
+        # particle 2 -> system 1, particle 0 -> system 0, particle 1 -> system 0
+        t = Table.new(
+            (ParticleId(2), ParticleId(0), ParticleId(1)),
+            ParticleData(
+                positions=jnp.array([[2.0], [0.0], [1.0]]),
+                system=Index((SystemId(0), SystemId(1)), jnp.array([1, 0, 0])),
+            ),
+        )
+        assert t.keys == (ParticleId(0), ParticleId(1), ParticleId(2))
+        npt.assert_array_equal(t.data.positions, [[0.0], [1.0], [2.0]])
+        # the foreign key column is a per-row column and must be permuted too
+        npt.assert_array_equal(t.data.system.indices, [0, 0, 1])
+        assert t.data.system.keys == (SystemId(0), SystemId(1))
+
+    def test_new_passthrough_and_edge_cases(self):
+        # already sorted: identical to the constructor
+        t = Table.new(("a", "b"), jnp.array([1.0, 2.0]))
+        assert t.keys == ("a", "b")
+        npt.assert_array_equal(t.data, [1.0, 2.0])
+        # empty and single-key
+        assert Table.new((), jnp.zeros(0), _cls=str).keys == ()
+        assert Table.new(("a",), jnp.zeros(1)).keys == ("a",)
+        # duplicates are still rejected, not silently merged
+        with pytest.raises(ValueError, match="must be unique"):
+            Table.new(("b", "a", "b"), jnp.arange(3.0))
+        # size-1 leaves still broadcast, and are not mis-permuted
+        bc = Table.new(("c", "a"), Pair(jnp.array([3.0, 1.0]), jnp.ones(1)))
+        npt.assert_array_equal(bc.data.x, [1.0, 3.0])
+        npt.assert_array_equal(bc.data.y, [1.0, 1.0])
+
+    def test_new_is_stable_through_pytree_roundtrip(self):
+        t = Table.new(("c", "a", "b"), jnp.array([30.0, 10.0, 20.0]))
+        # __post_init__ re-runs on every unflatten; it must not permute again
+        rt = jax.tree.map(lambda x: x * 2, t)
+        assert rt.keys == ("a", "b", "c")
+        npt.assert_array_equal(rt.data, [20.0, 40.0, 60.0])
+
+        jitted = jax.jit(lambda x: x.map_data(lambda d: d + 1))(t)
+        assert jitted.keys == ("a", "b", "c")
+        npt.assert_array_equal(jitted.data, [11.0, 21.0, 31.0])
+
+
 class TestUtilities:
     def test_utilities(self):
         indexed = Table(("a", "b", "c"), jnp.arange(3.0))
@@ -288,8 +370,9 @@ class TestMerge:
         npt.assert_array_equal(result.data[0], [1.0, 2.0])
         npt.assert_array_equal(result.data[1], [3.0, 4.0])
 
-        # Reorders to match self
-        b2 = Table(("y", "x"), jnp.array([8.0, 6.0]))
+        # Keys supplied in a different order are sorted by Table.new, so the
+        # join still pairs x->6.0, y->8.0
+        b2 = Table.new(("y", "x"), jnp.array([8.0, 6.0]))
         result2 = Table.join(a, b2)
         npt.assert_array_equal(result2.data[1], [6.0, 8.0])
 


### PR DESCRIPTION
`Table` documented its `keys` as "unique, sorted" but `__post_init__` only checked uniqueness. An unsorted table therefore constructed happily and then failed the moment it met `Index`, which does enforce sortedness -- `t.index` and `t[t.index]` both raised `ValueError: Keys must be unique and sorted.` from deep inside `Index.__post_init__`.

Enforce the invariant where it is documented:

- `_check_keys` walks the key tuple once and raises `ValueError` with separate messages for unsorted and duplicate keys, pointing the caller at `Table.new`. This replaces the previous `np.unique` uniqueness assert, so it is a `ValueError` rather than a stripped-under-`-O` assert, drops the `numpy` import, and is 4-9x faster than the check it replaces despite testing more (8.2 -> 0.9us at n=8; 5.15 -> 0.95ms at n=10,000). This matters because `__post_init__` re-runs on every pytree unflatten. It also fixes a latent bug in the old check: `np.asarray(keys, dtype=object)` builds a 2-D array for tuple-valued keys, which `np.unique` then miscounts.

- `Table.new(keys, data)` sorts keys and permutes `data` to match, mirroring `Index.new`. Rows are permuted via `bind(rows).at((order,)).get()` -- the same lens path `__getitem__` uses -- so nested `Index` foreign-key columns are permuted with the rows instead of being skipped as opaque leaves.

- `_validate_and_broadcast` is extracted as `_broadcast_rows` and shared, so `new` broadcasts size-1 leaves before permuting rather than gathering them out of bounds.

Instrumenting `__post_init__` across the suite found 7,443 multi-key `Table` constructions at 302 sites, of which exactly one was unsorted: a test that deliberately checks `Table.join` reordering. Nothing in `src/` constructs unsorted keys, so enforcement costs one existing test assertion, which now builds its input with `Table.new` and asserts the same result.