### PR TITLE
feat: autodiff-safe cubic_roots and Peng-Robinson fugacity

### DIFF
--- a/src/kups/core/utils/math.py
+++ b/src/kups/core/utils/math.py
@@ -48,7 +48,7 @@ def log_factorial_ratio(N: Array, M: Array) -> Array:
 def _cubic_roots_core(coefficients: Array) -> Array:
     """Companion-matrix eigvals solver for a single cubic polynomial."""
     a, b, c, d = coefficients
-    C = jnp.array([[0, 0, -d / a], [1, 0, -c / a], [0, 1, -b / a]], dtype=jnp.float_)
+    C = jnp.array([[0, 0, -d / a], [1, 0, -c / a], [0, 1, -b / a]], dtype=float)
     return jnp.linalg.eigvals(C)
 
 
@@ -63,6 +63,13 @@ def _cubic_roots_core_jvp(  # pyright: ignore[reportUnusedFunction]
     $$\frac{\partial z}{\partial p} = -\frac{\partial F / \partial p}
                                           {\partial F / \partial z}.$$
 
+    At a repeated root $\partial F / \partial z = 0$ and the true sensitivity
+    is unbounded (a perturbed triple root moves like $\varepsilon^{1/3}$);
+    the computed roots there also carry $O(\mathrm{eps}^{1/3})$ error, so any
+    denominator below $O(\mathrm{eps}^{2/3})$ is numerical noise. The modulus
+    of the denominator is therefore clamped from below at that scale (phase
+    preserved), keeping tangents finite — if large — instead of NaN/inf.
+
     Forward uses :func:`jax.numpy.linalg.eigvals` (unchanged numerics);
     backward bypasses its pathological gradient.
 
@@ -76,7 +83,14 @@ def _cubic_roots_core_jvp(  # pyright: ignore[reportUnusedFunction]
     da, db, dc, dd = coefficients_dot
     dF_dz = 3 * a * roots**2 + 2 * b * roots + c
     dF_from_coeffs = roots**3 * da + roots**2 * db + roots * dc + dd
-    return roots, -dF_from_coeffs / dF_dz
+    finfo = jnp.finfo(roots.real.dtype)
+    r = jnp.abs(roots)
+    term_scale = 3 * jnp.abs(a) * r**2 + 2 * jnp.abs(b) * r + jnp.abs(c)
+    tol = finfo.eps ** (2 / 3) * term_scale + finfo.tiny
+    mod = jnp.abs(dF_dz)
+    phase = jnp.where(mod > 0, dF_dz / jnp.where(mod > 0, mod, 1.0), 1.0 + 0.0j)
+    safe_dF_dz = phase * jnp.maximum(mod, tol)
+    return roots, -dF_from_coeffs / safe_dF_dz
 
 
 @jit

--- a/src/kups/core/utils/math.py
+++ b/src/kups/core/utils/math.py
@@ -44,13 +44,51 @@ def log_factorial_ratio(N: Array, M: Array) -> Array:
     return jax.lax.lgamma(N + 1.0) - jax.lax.lgamma(M + 1.0)
 
 
+@jax.custom_jvp
+def _cubic_roots_core(coefficients: Array) -> Array:
+    """Companion-matrix eigvals solver for a single cubic polynomial."""
+    a, b, c, d = coefficients
+    C = jnp.array([[0, 0, -d / a], [1, 0, -c / a], [0, 1, -b / a]], dtype=jnp.float_)
+    return jnp.linalg.eigvals(C)
+
+
+@_cubic_roots_core.defjvp
+def _cubic_roots_core_jvp(  # pyright: ignore[reportUnusedFunction]
+    primals: tuple[Array], tangents: tuple[Array]
+) -> tuple[Array, Array]:
+    r"""Implicit-function-theorem JVP for the cubic roots.
+
+    For each root $z$ of $F(z; a, b, c, d) = az^3 + bz^2 + cz + d = 0$,
+
+    $$\frac{\partial z}{\partial p} = -\frac{\partial F / \partial p}
+                                          {\partial F / \partial z}.$$
+
+    Forward uses :func:`jax.numpy.linalg.eigvals` (unchanged numerics);
+    backward bypasses its pathological gradient.
+
+    Registered via the :func:`jax.custom_jvp` decorator — Pylance cannot see
+    that side-effect, hence the ``reportUnusedFunction`` suppression.
+    """
+    (coefficients,) = primals
+    (coefficients_dot,) = tangents
+    roots = _cubic_roots_core(coefficients)
+    a, b, c, _ = coefficients
+    da, db, dc, dd = coefficients_dot
+    dF_dz = 3 * a * roots**2 + 2 * b * roots + c
+    dF_from_coeffs = roots**3 * da + roots**2 * db + roots * dc + dd
+    return roots, -dF_from_coeffs / dF_dz
+
+
 @jit
 @vectorize(signature="(4)->(3)")
 def cubic_roots(coefficients: Array) -> Array:
     """Find all roots of a cubic polynomial using the companion matrix method.
 
     Solves `ax³ + bx² + cx + d = 0` by computing eigenvalues of the companion
-    matrix. Returns all three roots (real or complex).
+    matrix. Returns all three roots (real or complex). Autodiff-safe in JAX:
+    forward values use :func:`jax.numpy.linalg.eigvals`; the JVP is
+    implicit-function differentiation of the cubic, bypassing
+    ``eigvals``'s gradient (which returns NaN on many physical inputs).
 
     Args:
         coefficients: Array of shape `(..., 4)` containing `[a, b, c, d]` for each
@@ -70,10 +108,7 @@ def cubic_roots(coefficients: Array) -> Array:
         This method is numerically stable and handles multiple polynomials in
         parallel via vectorization.
     """
-    a, b, c, d = coefficients
-    C = jnp.array([[0, 0, -d / a], [1, 0, -c / a], [0, 1, -b / a]], dtype=jnp.float_)
-    solutions = jnp.linalg.eigvals(C)
-    return solutions
+    return _cubic_roots_core(coefficients)
 
 
 @jit

--- a/src/kups/mcmc/fugacity.py
+++ b/src/kups/mcmc/fugacity.py
@@ -103,28 +103,37 @@ def _peng_robinson_log_fugacity(
     )
 
     solutions = cubic_roots(coefficients)
-    Z = jnp.where(jnp.isreal(solutions), solutions, jnp.nan).real  # type: ignore
+    Z_real = solutions.real
+    # A root is "physical" iff it's (nearly) real and compressibility-feasible
+    # (Z > Bmix so the log(Z − Bmix) below is finite).
+    is_real = jnp.abs(solutions.imag) < 1e-8
+    valid_solutions = is_real & (Z_real > Bmix + 1e-12)
+
+    # Double-where: substitute a safe placeholder Z for unphysical branches so
+    # `jnp.log` and friends stay finite. The placeholder value is never
+    # selected by the argmin below because the mask pins it to +inf, but
+    # using it avoids NaN gradients flowing back through unused branches.
+    safe_Z = jnp.where(valid_solutions, Z_real, Bmix + 1.0)
 
     SQ2 = jnp.sqrt(2)
     dA_dyi = 2 * jnp.einsum("ab,b->a", Aij, fraction)[:, None]
     ln_fugacity_coeff = (
-        (B[:, None] / Bmix) * (Z - 1)
-        - jnp.log(Z - Bmix)
+        (B[:, None] / Bmix) * (safe_Z - 1)
+        - jnp.log(safe_Z - Bmix)
         - (Amix / (2 * SQ2 * Bmix))
         * (dA_dyi / Amix - B[:, None] / Bmix)
-        * jnp.log((Z + (1 + SQ2) * Bmix) / (Z + (1 - SQ2) * Bmix))
+        * jnp.log((safe_Z + (1 + SQ2) * Bmix) / (safe_Z + (1 - SQ2) * Bmix))
     )
     # For component i in a mixture: f_i = phi_i * y_i * p
     ln_fugacity = ln_fugacity_coeff + jnp.log(pressure) + jnp.log(fraction)[:, None]
-    # Select gas phase fugacity
+    # Select gas phase fugacity: lowest ln_fugacity_coeff among valid roots.
     # https://github.com/iRASPA/RASPA2/blob/6498ab1eec9c8e0f063dcd0d71dd7add372c529b/src/equations_of_state.c#L364
-    valid_solutions = jnp.isfinite(Z) & (Z > 0)
-    solution_idx = jnp.nanargmin(
+    solution_idx = jnp.argmin(
         jnp.where(valid_solutions, ln_fugacity_coeff, jnp.inf), axis=1
     )
     ln_fugacity = ln_fugacity[jnp.arange(n), solution_idx]
-    Z = Z[solution_idx]
-    return ln_fugacity, Z
+    Z_selected = safe_Z[solution_idx]
+    return ln_fugacity, Z_selected
 
 
 def peng_robinson_log_fugacity(

--- a/src/kups/mcmc/fugacity.py
+++ b/src/kups/mcmc/fugacity.py
@@ -105,9 +105,12 @@ def _peng_robinson_log_fugacity(
     solutions = cubic_roots(coefficients)
     Z_real = solutions.real
     # A root is "physical" iff it's (nearly) real and compressibility-feasible
-    # (Z > Bmix so the log(Z − Bmix) below is finite).
-    is_real = jnp.abs(solutions.imag) < 1e-8
-    valid_solutions = is_real & (Z_real > Bmix + 1e-12)
+    # (Z > Bmix so the log(Z − Bmix) below is finite). Tolerances derive from
+    # the working dtype: eps^(1/2) bounds the imaginary-part noise of real
+    # roots, eps^(3/4) is the strictly-positive margin of log's argument.
+    eps = jnp.finfo(Z_real.dtype).eps
+    is_real = jnp.abs(solutions.imag) < eps**0.5
+    valid_solutions = is_real & (Z_real > Bmix + eps**0.75)
 
     # Double-where: substitute a safe placeholder Z for unphysical branches so
     # `jnp.log` and friends stay finite. The placeholder value is never

--- a/test/core/test_math.py
+++ b/test/core/test_math.py
@@ -172,6 +172,48 @@ class TestCubicRoots:
         assert jnp.all(jnp.isfinite(roots))
 
 
+class TestCubicRootsGradients:
+    """Custom JVP (implicit differentiation) of [`cubic_roots`][kups.core.utils.math.cubic_roots]."""
+
+    @staticmethod
+    def _sorted_real_roots(coeffs: jax.Array) -> jax.Array:
+        return jnp.sort(cubic_roots(coeffs).real)
+
+    def test_matches_finite_differences_distinct_roots(self):
+        """Jacobian for well-separated roots agrees with central differences."""
+        coeffs = jnp.array([1.0, -6.0, 11.0, -6.0])  # roots 1, 2, 3
+        jac = jax.jacfwd(self._sorted_real_roots)(coeffs)
+        h = 1e-6
+        for i in range(4):
+            e = jnp.zeros(4).at[i].set(h)
+            fd = (
+                self._sorted_real_roots(coeffs + e)
+                - self._sorted_real_roots(coeffs - e)
+            ) / (2 * h)
+            npt.assert_allclose(jac[:, i], fd, rtol=1e-5, atol=1e-8)
+
+    def test_matches_implicit_function_theorem(self):
+        """dz/dd = -1 / F'(z) with F'(z) = 3az^2 + 2bz + c."""
+        coeffs = jnp.array([1.0, -6.0, 11.0, -6.0])  # roots 1, 2, 3
+        jac = jax.jacfwd(self._sorted_real_roots)(coeffs)
+        roots = self._sorted_real_roots(coeffs)
+        dF_dz = 3 * roots**2 - 12 * roots + 11
+        npt.assert_allclose(jac[:, 3], -1.0 / dF_dz, rtol=1e-8)
+
+    @pytest.mark.parametrize(
+        "coeffs",
+        [
+            [1.0, -3.0, 3.0, -1.0],  # (x-1)^3, triple root: F'(z) = 0 exactly
+            [1.0, -6.0, 12.0, -8.0],  # (x-2)^3
+            [1.0, -5.0, 7.0, -3.0],  # (x-1)^2 (x-3), double root
+        ],
+    )
+    def test_repeated_roots_stay_finite(self, coeffs: list[float]):
+        """At repeated roots dF/dz vanishes; the clamped JVP must not NaN/inf."""
+        jac = jax.jacfwd(self._sorted_real_roots)(jnp.array(coeffs))
+        assert np.all(np.isfinite(jac)), f"non-finite Jacobian: {jac}"
+
+
 class TestDetAndInverse3x3:
     def test_det_and_inverse(self):
         """Merged: correctness, properties, edge_cases."""

--- a/test/mcmc/test_fugacity.py
+++ b/test/mcmc/test_fugacity.py
@@ -1,11 +1,13 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
+import pytest
 
-from kups.core.constants import BAR, PASCAL
+from kups.core.constants import BAR, KELVIN, PASCAL
 from kups.mcmc.fugacity import peng_robinson_log_fugacity
 
 
@@ -171,3 +173,54 @@ class TestPengRobinsonFugacityMixtures:
         npt.assert_allclose(
             mix.compressibility[0], pure.compressibility[0], rtol=1e-10, atol=1e-10
         )
+
+
+class TestPengRobinsonAutodiff:
+    """Gradients of log_fugacity must be finite and match central differences.
+
+    Regression guard: `jnp.linalg.eigvals` has pathological gradients that
+    return NaN. The custom JVP on
+    [`cubic_roots`][kups.core.utils.math.cubic_roots] plus the double-where
+    sanitisation in
+    [`_peng_robinson_log_fugacity`][kups.mcmc.fugacity._peng_robinson_log_fugacity]
+    together keep autodiff clean.
+    """
+
+    @staticmethod
+    def _pure_log_f(P_pa: float, T_k: float) -> jax.Array:
+        result = peng_robinson_log_fugacity(
+            jnp.asarray(P_pa * PASCAL),
+            jnp.asarray(T_k * KELVIN),
+            jnp.atleast_1d(jnp.asarray(7.38e6 * PASCAL)),
+            jnp.atleast_1d(jnp.asarray(304.2 * KELVIN)),
+            jnp.atleast_1d(jnp.asarray(0.228)),
+        )
+        return result.log_fugacity[0]
+
+    @pytest.mark.parametrize(
+        "P_pa,T_k",
+        [
+            (1e4, 300.0),  # low pressure, near-ideal gas
+            (1e5, 300.0),  # ambient
+            (1e6, 300.0),  # 10 bar, still gas
+            (5e6, 320.0),  # supercritical CO2
+        ],
+    )
+    def test_gradients_finite_and_match_finite_differences(
+        self, P_pa: float, T_k: float
+    ):
+        dP_ad = float(jax.grad(self._pure_log_f, argnums=0)(P_pa, T_k))
+        dT_ad = float(jax.grad(self._pure_log_f, argnums=1)(P_pa, T_k))
+        assert np.isfinite(dP_ad), "∂log_f/∂P must be finite (autodiff regression)"
+        assert np.isfinite(dT_ad), "∂log_f/∂T must be finite (autodiff regression)"
+
+        # Central-difference oracle. Step sizes chosen to avoid catastrophic
+        # cancellation while staying in a locally-linear regime.
+        dP_fd = (
+            self._pure_log_f(P_pa + 1.0, T_k) - self._pure_log_f(P_pa - 1.0, T_k)
+        ) / 2.0
+        dT_fd = (
+            self._pure_log_f(P_pa, T_k + 0.01) - self._pure_log_f(P_pa, T_k - 0.01)
+        ) / 0.02
+        npt.assert_allclose(dP_ad, float(dP_fd), rtol=1e-5)
+        npt.assert_allclose(dT_ad, float(dT_fd), rtol=1e-5)


### PR DESCRIPTION
- `custom_jvp` on `kups.core.utils.math.cubic_roots` via implicit differentiation (`dz/dp = -(∂F/∂p)/(∂F/∂z)`). Forward numerics unchanged (companion-matrix eigvals); only the pathological `eigvals` gradient is bypassed.
- Double-where NaN sanitisation in the Peng-Robinson fugacity root selection: unphysical roots get a safe placeholder Z that is never selected but keeps unused gradient branches finite.
- Regression tests: `jax.grad` of log-fugacity w.r.t. P and T is finite and matches central differences across gas / supercritical states.

Enables isosteric heats as a `jax.grad` through the loading function (no finite-difference hyperparameter) — consumed by the flat-histogram post-processing higher in the stack.

Part of the TMMC stack split out of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)