### PR TITLE
feat: TMMC C-matrix and energy-moment accumulators (Witman 2018)

### DIFF
--- a/src/kups/mcmc/widom.py
+++ b/src/kups/mcmc/widom.py
@@ -278,9 +278,10 @@ class EnergyCumulants:
 
     Attributes:
         mean: $\kappa_1 = \langle E \rangle$, shape ``(n_systems,)`` [energy].
-        cumulants: $\kappa_2, \ldots, \kappa_P$ stacked along the leading
-            axis, shape ``(max_order - 1, n_systems)``; entry ``k - 2`` holds
-            $\kappa_k$ [energy$^k$].
+        cumulants: $\kappa_2, \ldots, \kappa_P$ stacked along the trailing
+            axis (leading axes stay per-system, so tables/vmap batch over
+            them), shape ``(n_systems, max_order - 1)``; entry ``[..., k - 2]``
+            holds $\kappa_k$ [energy$^k$].
     """
 
     mean: Energy
@@ -289,12 +290,12 @@ class EnergyCumulants:
     @property
     def max_order(self) -> int:
         """Highest cumulant order $P$ stored."""
-        return self.cumulants.shape[0] + 1
+        return self.cumulants.shape[-1] + 1
 
     @property
     def variance(self) -> Array:
         r"""$\kappa_2 = \mathrm{Var}(E)$, shape ``(n_systems,)``."""
-        return self.cumulants[0]
+        return self.cumulants[..., 0]
 
 
 @dataclass
@@ -312,9 +313,10 @@ class EnergyMoments:
     Attributes:
         count: Number of samples accumulated, shape ``(n_systems,)``.
         mean: Running sample mean $\bar{x}_n$, shape ``(n_systems,)`` [energy].
-        central_sums: $M_2, \ldots, M_P$ stacked along the leading axis,
-            shape ``(max_order - 1, n_systems)``; entry ``p - 2`` holds $M_p$
-            [energy$^p$].
+        central_sums: $M_2, \ldots, M_P$ stacked along the trailing axis
+            (leading axes stay per-system, so tables/vmap batch over them),
+            shape ``(n_systems, max_order - 1)``; entry ``[..., p - 2]`` holds
+            $M_p$ [energy$^p$].
     """
 
     count: Array
@@ -324,7 +326,7 @@ class EnergyMoments:
     @property
     def max_order(self) -> int:
         """Highest moment order $P$ accumulated."""
-        return self.central_sums.shape[0] + 1
+        return self.central_sums.shape[-1] + 1
 
     @staticmethod
     def zeros(n_systems: int, max_order: int = 4) -> EnergyMoments:
@@ -341,7 +343,7 @@ class EnergyMoments:
         return EnergyMoments(
             count=jnp.zeros(n_systems, dtype=int),
             mean=jnp.zeros(n_systems),
-            central_sums=jnp.zeros((max_order - 1, n_systems)),
+            central_sums=jnp.zeros((n_systems, max_order - 1)),
         )
 
     def reset(self) -> EnergyMoments:
@@ -378,7 +380,7 @@ class EnergyMoments:
         delta = energy - self.mean
         delta_n = delta / nf
 
-        old = {p: self.central_sums[p - 2] for p in range(2, self.max_order + 1)}
+        old = {p: self.central_sums[..., p - 2] for p in range(2, self.max_order + 1)}
         new_sums = [
             old[p]
             # Cross terms re-centre the old sums onto the new mean; M_1 = 0
@@ -390,7 +392,7 @@ class EnergyMoments:
         return EnergyMoments(
             count=n,
             mean=self.mean + delta_n,
-            central_sums=jnp.stack(new_sums),
+            central_sums=jnp.stack(new_sums, axis=-1),
         )
 
     def finalize(self) -> EnergyCumulants:
@@ -408,7 +410,7 @@ class EnergyMoments:
             Cumulants $\kappa_1, \ldots, \kappa_P$ of the accumulated samples.
         """
         nf = self.count.astype(float)
-        mu = {p: self.central_sums[p - 2] / nf for p in range(2, self.max_order + 1)}
+        mu = {p: self.central_sums[..., p - 2] / nf for p in range(2, self.max_order + 1)}
         kappa: dict[int, Array] = {}
         for p in range(2, self.max_order + 1):
             kappa[p] = mu[p] - sum(
@@ -416,7 +418,9 @@ class EnergyMoments:
             )
         return EnergyCumulants(
             mean=self.mean,
-            cumulants=jnp.stack([kappa[p] for p in range(2, self.max_order + 1)]),
+            cumulants=jnp.stack(
+                [kappa[p] for p in range(2, self.max_order + 1)], axis=-1
+            ),
         )
 
 

--- a/src/kups/mcmc/widom.py
+++ b/src/kups/mcmc/widom.py
@@ -410,7 +410,9 @@ class EnergyMoments:
             Cumulants $\kappa_1, \ldots, \kappa_P$ of the accumulated samples.
         """
         nf = self.count.astype(float)
-        mu = {p: self.central_sums[..., p - 2] / nf for p in range(2, self.max_order + 1)}
+        mu = {
+            p: self.central_sums[..., p - 2] / nf for p in range(2, self.max_order + 1)
+        }
         kappa: dict[int, Array] = {}
         for p in range(2, self.max_order + 1):
             kappa[p] = mu[p] - sum(

--- a/src/kups/mcmc/widom.py
+++ b/src/kups/mcmc/widom.py
@@ -20,7 +20,8 @@ Contents:
   (Witman 2018).
 - [EnergyMoments][kups.mcmc.widom.EnergyMoments] /
   [EnergyCumulants][kups.mcmc.widom.EnergyCumulants]: Pébay/Welford online
-  central moments 1--4 for Taylor expansion of $\ln Q_c(\beta)$.
+  central moments of arbitrary order (default 4) for Taylor expansion of
+  $\ln Q_c(\beta)$.
 
 References:
     Widom, B. (1963). J. Chem. Phys., 39, 2808.
@@ -33,6 +34,7 @@ References:
 
 from __future__ import annotations
 
+from math import comb
 from typing import Any, Callable
 
 import jax.numpy as jnp
@@ -116,15 +118,26 @@ class WidomStatistics:
 
     @staticmethod
     def zeros(n_systems: int) -> WidomStatistics:
-        """Zero-initialize."""
+        """Create a zero-initialized accumulator.
+
+        Args:
+            n_systems: Number of systems accumulated in parallel.
+
+        Returns:
+            Accumulator with all sums and counts at zero, shape ``(n_systems,)``.
+        """
         return WidomStatistics(
             sum_boltzmann=jnp.zeros(n_systems),
             sum_delta_u_boltzmann=jnp.zeros(n_systems),
-            n_samples=jnp.zeros(n_systems, dtype=jnp.int32),
+            n_samples=jnp.zeros(n_systems, dtype=int),
         )
 
     def reset(self) -> WidomStatistics:
-        """Zero all fields."""
+        """Zero all fields.
+
+        Returns:
+            Fresh accumulator of the same shape with all fields at zero.
+        """
         return self.zeros(int(self.n_samples.shape[0]))
 
     def update(self, ln_alpha: LogAcceptanceRatio, delta_u: Energy) -> WidomStatistics:
@@ -135,6 +148,9 @@ class WidomStatistics:
             delta_u: Per-system ghost insertion energy. With a zero-move-log
                 insertion proposal and a bare Boltzmann log-ratio,
                 $\Delta U = -k_BT \ln\alpha$ exactly.
+
+        Returns:
+            Accumulator with the sample folded into the running sums.
         """
         boltzmann = jnp.exp(ln_alpha)
         return WidomStatistics(
@@ -148,8 +164,10 @@ class WidomStatistics:
 class TransitionStatistics:
     r"""TMMC collection-matrix (C-matrix) accumulator for $N \to N \pm 1$ moves.
 
-    Each ghost evaluation contributes $\min(1, \exp\ln\alpha)$ to the
-    corresponding row (Witman 2018, eq 5--7). Downstream, transition
+    Here $\alpha$ is the Metropolis acceptance ratio of the ghost move (the
+    exponential of the log-ratio produced by the proposal pipeline). Each
+    ghost evaluation contributes the acceptance probability $\min(1, \alpha)$
+    to the corresponding row (Witman 2018, eq 5--7). Downstream, transition
     probabilities are recovered as
 
     $$P(N \to N+1) = \frac{\text{acceptance\_insertion}}
@@ -158,8 +176,8 @@ class TransitionStatistics:
     All arrays have shape ``(n_systems,)``.
 
     Attributes:
-        acceptance_insertion: $\sum \min(1, \exp\ln\alpha_\text{ins})$.
-        acceptance_deletion: $\sum \min(1, \exp\ln\alpha_\text{del})$.
+        acceptance_insertion: $\sum \min(1, \alpha_\text{ins})$.
+        acceptance_deletion: $\sum \min(1, \alpha_\text{del})$.
         n_trials_insertion: Number of ghost insertions evaluated.
         n_trials_deletion: Number of ghost deletions evaluated (incremented
             even when $N = 0$; the accepted fraction is zero there).
@@ -172,20 +190,39 @@ class TransitionStatistics:
 
     @staticmethod
     def zeros(n_systems: int) -> TransitionStatistics:
-        """Create a zero-initialized accumulator for ``n_systems`` macrostates."""
+        """Create a zero-initialized accumulator for ``n_systems`` macrostates.
+
+        Args:
+            n_systems: Number of macrostates accumulated in parallel.
+
+        Returns:
+            Accumulator with all sums and counts at zero, shape ``(n_systems,)``.
+        """
         return TransitionStatistics(
             acceptance_insertion=jnp.zeros(n_systems),
             acceptance_deletion=jnp.zeros(n_systems),
-            n_trials_insertion=jnp.zeros(n_systems, dtype=jnp.int32),
-            n_trials_deletion=jnp.zeros(n_systems, dtype=jnp.int32),
+            n_trials_insertion=jnp.zeros(n_systems, dtype=int),
+            n_trials_deletion=jnp.zeros(n_systems, dtype=int),
         )
 
     def reset(self) -> TransitionStatistics:
-        """Zero all fields."""
+        """Zero all fields.
+
+        Returns:
+            Fresh accumulator of the same shape with all fields at zero.
+        """
         return self.zeros(int(self.n_trials_insertion.shape[0]))
 
     def update_insertion(self, ln_alpha: LogAcceptanceRatio) -> TransitionStatistics:
-        r"""Accumulate a ghost-insertion $\ln\alpha$. Trial count is incremented unconditionally."""
+        r"""Accumulate a ghost insertion. Trial count is incremented unconditionally.
+
+        Args:
+            ln_alpha: Per-system log Metropolis ratio $\ln\alpha$ of the
+                ghost insertion.
+
+        Returns:
+            Accumulator with $\min(1, \alpha)$ added to the insertion row.
+        """
         acceptance = jnp.minimum(1.0, jnp.exp(ln_alpha))
         return TransitionStatistics(
             acceptance_insertion=self.acceptance_insertion + acceptance,
@@ -199,11 +236,20 @@ class TransitionStatistics:
         ln_alpha: LogAcceptanceRatio,
         macrostate_n: ParticleCount,
     ) -> TransitionStatistics:
-        r"""Accumulate a ghost-deletion $\ln\alpha$; zero contribution when $N = 0$.
+        r"""Accumulate a ghost deletion; zero contribution when $N = 0$.
 
         The trial count always increments — the fraction of accepted deletions
         at $N = 0$ is zero, but the denominator still counts the trial, so
         $P(0 \to 1)$ is not inflated.
+
+        Args:
+            ln_alpha: Per-system log Metropolis ratio $\ln\alpha$ of the
+                ghost deletion.
+            macrostate_n: Per-system particle count $N$; systems at $N = 0$
+                contribute nothing to the acceptance sum.
+
+        Returns:
+            Accumulator with $\min(1, \alpha)$ added to the deletion row.
         """
         acceptance = jnp.minimum(1.0, jnp.exp(ln_alpha))
         acceptance = jnp.where(macrostate_n > 0, acceptance, 0.0)
@@ -217,115 +263,160 @@ class TransitionStatistics:
 
 @dataclass
 class EnergyCumulants:
-    r"""Finalized central moments of the potential energy distribution.
+    r"""Finalized cumulants of the potential energy distribution.
 
-    These match the $\beta$-derivatives of the configurational partition function
-    (Witman 2018, eq 10):
+    Stores the standard cumulants $\kappa_2, \ldots, \kappa_P$ of the energy
+    ($\kappa_2 = \mathrm{Var}$, $\kappa_3 = \mu_3$,
+    $\kappa_4 = \mu_4 - 3\mu_2^2$, ... with $\mu_k$ the central moments),
+    plus $\kappa_1 = \langle E \rangle$ as ``mean``. They determine the
+    $\beta$-derivatives of the configurational partition function
+    (Witman 2018, eq 10) via
 
-    $$\kappa_k = \partial^k \ln Q_c / \partial(-\beta)^k.$$
+    $$\partial^k \ln Q_c / \partial\beta^k = (-1)^k \kappa_k,$$
+
+    which is what the flat-histogram Taylor extrapolation consumes.
 
     Attributes:
-        mean: $\kappa_1 = \langle E \rangle$ [energy].
-        variance: $\kappa_2 = \langle (E - \langle E\rangle)^2 \rangle$ [energy$^2$].
-        third: $\kappa_3 = -\langle (E - \langle E\rangle)^3 \rangle$ [energy$^3$].
-        fourth: $\kappa_4 = \langle (E - \langle E\rangle)^4 \rangle - 3\,\mathrm{Var}^2$
-            (excess kurtosis $\times$ variance$^2$) [energy$^4$].
+        mean: $\kappa_1 = \langle E \rangle$, shape ``(n_systems,)`` [energy].
+        cumulants: $\kappa_2, \ldots, \kappa_P$ stacked along the leading
+            axis, shape ``(max_order - 1, n_systems)``; entry ``k - 2`` holds
+            $\kappa_k$ [energy$^k$].
     """
 
     mean: Energy
-    variance: Array
-    third: Array
-    fourth: Array
+    cumulants: Array
+
+    @property
+    def max_order(self) -> int:
+        """Highest cumulant order $P$ stored."""
+        return self.cumulants.shape[0] + 1
+
+    @property
+    def variance(self) -> Array:
+        r"""$\kappa_2 = \mathrm{Var}(E)$, shape ``(n_systems,)``."""
+        return self.cumulants[0]
 
 
 @dataclass
 class EnergyMoments:
-    r"""Pébay one-pass accumulator for central moments 1--4 of per-system energy.
+    r"""Pébay one-pass accumulator for central moments of per-system energy.
 
     Maintains the unnormalized central-moment sums
 
-    $$M_k = \sum_{i=1}^{n} (x_i - \bar{x}_n)^k,$$
+    $$M_p = \sum_{i=1}^{n} (x_i - \bar{x}_n)^p, \qquad p = 2, \ldots, P,$$
 
-    updated via the single-sample specialisations of Pébay (2008) eqs 1.2, 1.5,
-    1.6. Call :meth:`finalize` to convert to physical cumulants.
+    for an arbitrary maximum order $P$ (default 4, enough for the third-order
+    Taylor expansion of $\ln Q_c(\beta)$), updated via the single-sample
+    recurrence of Pébay (2008). Call :meth:`finalize` to convert to cumulants.
 
     Attributes:
-        count: Number of samples accumulated.
-        mean: Running sample mean $\bar{x}_n$ [energy].
-        m2: Sum of squared deviations [energy$^2$].
-        m3: Sum of cubed deviations [energy$^3$].
-        m4: Sum of fourth-order deviations [energy$^4$].
+        count: Number of samples accumulated, shape ``(n_systems,)``.
+        mean: Running sample mean $\bar{x}_n$, shape ``(n_systems,)`` [energy].
+        central_sums: $M_2, \ldots, M_P$ stacked along the leading axis,
+            shape ``(max_order - 1, n_systems)``; entry ``p - 2`` holds $M_p$
+            [energy$^p$].
     """
 
     count: Array
     mean: Energy
-    m2: Array
-    m3: Array
-    m4: Array
+    central_sums: Array
+
+    @property
+    def max_order(self) -> int:
+        """Highest moment order $P$ accumulated."""
+        return self.central_sums.shape[0] + 1
 
     @staticmethod
-    def zeros(n_systems: int) -> EnergyMoments:
-        """Zero-initialize for ``n_systems`` macrostates."""
+    def zeros(n_systems: int, max_order: int = 4) -> EnergyMoments:
+        """Create a zero-initialized accumulator for ``n_systems`` macrostates.
+
+        Args:
+            n_systems: Number of macrostates accumulated in parallel.
+            max_order: Highest central-moment order to track (at least 2).
+
+        Returns:
+            Accumulator with all sums and counts at zero.
+        """
+        assert max_order >= 2, "at least mean and variance must be tracked"
         return EnergyMoments(
-            count=jnp.zeros(n_systems, dtype=jnp.int32),
+            count=jnp.zeros(n_systems, dtype=int),
             mean=jnp.zeros(n_systems),
-            m2=jnp.zeros(n_systems),
-            m3=jnp.zeros(n_systems),
-            m4=jnp.zeros(n_systems),
+            central_sums=jnp.zeros((max_order - 1, n_systems)),
         )
 
     def reset(self) -> EnergyMoments:
-        """Zero all fields."""
-        return self.zeros(int(self.count.shape[0]))
+        """Zero all fields.
+
+        Returns:
+            Fresh accumulator of the same shape and order with all fields zero.
+        """
+        return self.zeros(int(self.count.shape[0]), max_order=self.max_order)
 
     def update(self, energy: Energy) -> EnergyMoments:
         r"""Incorporate one per-system energy sample (Pébay single-sample update).
 
-        Uses the standard Welford-style recurrences for higher moments — cf.
-        Pébay (2008). The coefficients $(n-1)(n-2)$ and $(n-1)(n^2-3n+3)$
-        ensure $M_3 = M_4 = 0$ at $n = 1$ and $M_3 = 0$ for any symmetric pair
-        at $n = 2$.
+        With $\delta = x - \bar{x}_{n-1}$ and $\delta_n = \delta / n$, the
+        general recurrence for a single new sample is
+
+        $$M_p \leftarrow M_p
+            + \sum_{k=1}^{p-2} \binom{p}{k} (-\delta_n)^k M_{p-k}
+            + \delta_n^p (n-1) \left[(n-1)^{p-1} + (-1)^p\right],$$
+
+        the one-value specialisation of Pébay (2008), eq 2.9. For $p \le 4$
+        this reduces to the familiar Welford-style updates; each order reads
+        only the previous orders' old values.
+
+        Args:
+            energy: Per-system energy sample, shape ``(n_systems,)``.
+
+        Returns:
+            Accumulator with the sample folded into all tracked moments.
         """
         n = self.count + 1
         nf = n.astype(energy.dtype)
         n_prev = nf - 1.0
-
         delta = energy - self.mean
         delta_n = delta / nf
-        delta_n_sq = delta_n * delta_n
-        # term1 = δ² (n-1)/n — the single-sample "pair" contribution.
-        term1 = delta * delta_n * n_prev
 
-        new_mean = self.mean + delta_n
-        # Update m4 and m3 before m2 — they read old m2 / m3 values.
-        new_m4 = (
-            self.m4
-            + term1 * delta_n_sq * (nf * nf - 3.0 * nf + 3.0)
-            + 6.0 * delta_n_sq * self.m2
-            - 4.0 * delta_n * self.m3
-        )
-        new_m3 = self.m3 + term1 * delta_n * (nf - 2.0) - 3.0 * delta_n * self.m2
-        new_m2 = self.m2 + term1
-
+        old = {p: self.central_sums[p - 2] for p in range(2, self.max_order + 1)}
+        new_sums = [
+            old[p]
+            # Cross terms re-centre the old sums onto the new mean; M_1 = 0
+            # and the M_0 = n - 1 term is folded into the tail below.
+            + sum(comb(p, k) * (-delta_n) ** k * old[p - k] for k in range(1, p - 1))
+            + delta_n**p * n_prev * (n_prev ** (p - 1) + (-1.0) ** p)
+            for p in range(2, self.max_order + 1)
+        ]
         return EnergyMoments(
             count=n,
-            mean=new_mean,
-            m2=new_m2,
-            m3=new_m3,
-            m4=new_m4,
+            mean=self.mean + delta_n,
+            central_sums=jnp.stack(new_sums),
         )
 
     def finalize(self) -> EnergyCumulants:
-        r"""Normalize $M_k$ by $n$ and map to cumulants for Taylor expansion."""
-        nf = self.count.astype(jnp.float64)
-        variance = self.m2 / nf
-        third_central = self.m3 / nf
-        fourth_central = self.m4 / nf
+        r"""Normalize $M_p$ by $n$ and map central moments to cumulants.
+
+        Uses the standard recursion (valid since $\mu_1 = 0$)
+
+        $$\kappa_p = \mu_p - \sum_{m=2}^{p-2} \binom{p-1}{m-1}
+            \kappa_m \mu_{p-m},$$
+
+        which yields $\kappa_2 = \mu_2$, $\kappa_3 = \mu_3$,
+        $\kappa_4 = \mu_4 - 3\mu_2^2$, ...
+
+        Returns:
+            Cumulants $\kappa_1, \ldots, \kappa_P$ of the accumulated samples.
+        """
+        nf = self.count.astype(float)
+        mu = {p: self.central_sums[p - 2] / nf for p in range(2, self.max_order + 1)}
+        kappa: dict[int, Array] = {}
+        for p in range(2, self.max_order + 1):
+            kappa[p] = mu[p] - sum(
+                comb(p - 1, m - 1) * kappa[m] * mu[p - m] for m in range(2, p - 1)
+            )
         return EnergyCumulants(
             mean=self.mean,
-            variance=variance,
-            third=-third_central,
-            fourth=fourth_central - 3.0 * variance**2,
+            cumulants=jnp.stack([kappa[p] for p in range(2, self.max_order + 1)]),
         )
 
 
@@ -348,6 +439,16 @@ class GhostProbe[State, Changes, Move: Patch[Any], Stat](Propagator[State]):
     update_fn: Callable[[State, Stat, Array], Stat] = field(static=True)
 
     def __call__(self, key: Array, state: State) -> State:
+        r"""Run one ghost move and fold $\ln\alpha$ into the accumulator.
+
+        Args:
+            key: JAX PRNG key.
+            state: Current simulation state; only the lens-accessed statistic
+                changes.
+
+        Returns:
+            State with the updated accumulator written back through the lens.
+        """
         ln_alpha = widom_test(
             key,
             state,

--- a/src/kups/mcmc/widom.py
+++ b/src/kups/mcmc/widom.py
@@ -15,10 +15,20 @@ Contents:
 - [WidomStatistics][kups.mcmc.widom.WidomStatistics]: running-sum accumulator
   reduced to $\mu^\mathrm{ex}$, $K_H$, $q_\mathrm{st}$ by the post-hoc
   analyzer.
+- [TransitionStatistics][kups.mcmc.widom.TransitionStatistics]: TMMC
+  collection-matrix (C-matrix) accumulator for flat-histogram runs
+  (Witman 2018).
+- [EnergyMoments][kups.mcmc.widom.EnergyMoments] /
+  [EnergyCumulants][kups.mcmc.widom.EnergyCumulants]: Pébay/Welford online
+  central moments 1--4 for Taylor expansion of $\ln Q_c(\beta)$.
 
 References:
     Widom, B. (1963). J. Chem. Phys., 39, 2808.
     Vlugt, T. J. H. et al. (2008). J. Chem. Theory Comput., 4, 1107.
+    Witman, M., Mahynski, N. A. & Smit, B. (2018). J. Chem. Theory Comput.,
+    14, 6149--6158. DOI: 10.1021/acs.jctc.8b00534
+    Pébay, P. (2008). Formulas for Robust, One-Pass Parallel Computation of
+    Covariances and Arbitrary-Order Statistical Moments. Sandia SAND2008-6212.
 """
 
 from __future__ import annotations
@@ -45,6 +55,9 @@ r"""Log Metropolis acceptance ratio $\ln\alpha$ [dimensionless]."""
 
 type Energy = Array
 r"""Potential energy [energy]."""
+
+type ParticleCount = Array
+r"""Macrostate particle count $N$ [dimensionless, integer]."""
 
 
 def widom_test[State, Changes, Move: Patch[Any]](
@@ -128,6 +141,191 @@ class WidomStatistics:
             sum_boltzmann=self.sum_boltzmann + boltzmann,
             sum_delta_u_boltzmann=self.sum_delta_u_boltzmann + delta_u * boltzmann,
             n_samples=self.n_samples + 1,
+        )
+
+
+@dataclass
+class TransitionStatistics:
+    r"""TMMC collection-matrix (C-matrix) accumulator for $N \to N \pm 1$ moves.
+
+    Each ghost evaluation contributes $\min(1, \exp\ln\alpha)$ to the
+    corresponding row (Witman 2018, eq 5--7). Downstream, transition
+    probabilities are recovered as
+
+    $$P(N \to N+1) = \frac{\text{acceptance\_insertion}}
+        {n_\text{trials,ins} + n_\text{trials,del}}$$
+
+    All arrays have shape ``(n_systems,)``.
+
+    Attributes:
+        acceptance_insertion: $\sum \min(1, \exp\ln\alpha_\text{ins})$.
+        acceptance_deletion: $\sum \min(1, \exp\ln\alpha_\text{del})$.
+        n_trials_insertion: Number of ghost insertions evaluated.
+        n_trials_deletion: Number of ghost deletions evaluated (incremented
+            even when $N = 0$; the accepted fraction is zero there).
+    """
+
+    acceptance_insertion: Array
+    acceptance_deletion: Array
+    n_trials_insertion: Array
+    n_trials_deletion: Array
+
+    @staticmethod
+    def zeros(n_systems: int) -> TransitionStatistics:
+        """Create a zero-initialized accumulator for ``n_systems`` macrostates."""
+        return TransitionStatistics(
+            acceptance_insertion=jnp.zeros(n_systems),
+            acceptance_deletion=jnp.zeros(n_systems),
+            n_trials_insertion=jnp.zeros(n_systems, dtype=jnp.int32),
+            n_trials_deletion=jnp.zeros(n_systems, dtype=jnp.int32),
+        )
+
+    def reset(self) -> TransitionStatistics:
+        """Zero all fields."""
+        return self.zeros(int(self.n_trials_insertion.shape[0]))
+
+    def update_insertion(self, ln_alpha: LogAcceptanceRatio) -> TransitionStatistics:
+        r"""Accumulate a ghost-insertion $\ln\alpha$. Trial count is incremented unconditionally."""
+        acceptance = jnp.minimum(1.0, jnp.exp(ln_alpha))
+        return TransitionStatistics(
+            acceptance_insertion=self.acceptance_insertion + acceptance,
+            acceptance_deletion=self.acceptance_deletion,
+            n_trials_insertion=self.n_trials_insertion + 1,
+            n_trials_deletion=self.n_trials_deletion,
+        )
+
+    def update_deletion(
+        self,
+        ln_alpha: LogAcceptanceRatio,
+        macrostate_n: ParticleCount,
+    ) -> TransitionStatistics:
+        r"""Accumulate a ghost-deletion $\ln\alpha$; zero contribution when $N = 0$.
+
+        The trial count always increments — the fraction of accepted deletions
+        at $N = 0$ is zero, but the denominator still counts the trial, so
+        $P(0 \to 1)$ is not inflated.
+        """
+        acceptance = jnp.minimum(1.0, jnp.exp(ln_alpha))
+        acceptance = jnp.where(macrostate_n > 0, acceptance, 0.0)
+        return TransitionStatistics(
+            acceptance_insertion=self.acceptance_insertion,
+            acceptance_deletion=self.acceptance_deletion + acceptance,
+            n_trials_insertion=self.n_trials_insertion,
+            n_trials_deletion=self.n_trials_deletion + 1,
+        )
+
+
+@dataclass
+class EnergyCumulants:
+    r"""Finalized central moments of the potential energy distribution.
+
+    These match the $\beta$-derivatives of the configurational partition function
+    (Witman 2018, eq 10):
+
+    $$\kappa_k = \partial^k \ln Q_c / \partial(-\beta)^k.$$
+
+    Attributes:
+        mean: $\kappa_1 = \langle E \rangle$ [energy].
+        variance: $\kappa_2 = \langle (E - \langle E\rangle)^2 \rangle$ [energy$^2$].
+        third: $\kappa_3 = -\langle (E - \langle E\rangle)^3 \rangle$ [energy$^3$].
+        fourth: $\kappa_4 = \langle (E - \langle E\rangle)^4 \rangle - 3\,\mathrm{Var}^2$
+            (excess kurtosis $\times$ variance$^2$) [energy$^4$].
+    """
+
+    mean: Energy
+    variance: Array
+    third: Array
+    fourth: Array
+
+
+@dataclass
+class EnergyMoments:
+    r"""Pébay one-pass accumulator for central moments 1--4 of per-system energy.
+
+    Maintains the unnormalized central-moment sums
+
+    $$M_k = \sum_{i=1}^{n} (x_i - \bar{x}_n)^k,$$
+
+    updated via the single-sample specialisations of Pébay (2008) eqs 1.2, 1.5,
+    1.6. Call :meth:`finalize` to convert to physical cumulants.
+
+    Attributes:
+        count: Number of samples accumulated.
+        mean: Running sample mean $\bar{x}_n$ [energy].
+        m2: Sum of squared deviations [energy$^2$].
+        m3: Sum of cubed deviations [energy$^3$].
+        m4: Sum of fourth-order deviations [energy$^4$].
+    """
+
+    count: Array
+    mean: Energy
+    m2: Array
+    m3: Array
+    m4: Array
+
+    @staticmethod
+    def zeros(n_systems: int) -> EnergyMoments:
+        """Zero-initialize for ``n_systems`` macrostates."""
+        return EnergyMoments(
+            count=jnp.zeros(n_systems, dtype=jnp.int32),
+            mean=jnp.zeros(n_systems),
+            m2=jnp.zeros(n_systems),
+            m3=jnp.zeros(n_systems),
+            m4=jnp.zeros(n_systems),
+        )
+
+    def reset(self) -> EnergyMoments:
+        """Zero all fields."""
+        return self.zeros(int(self.count.shape[0]))
+
+    def update(self, energy: Energy) -> EnergyMoments:
+        r"""Incorporate one per-system energy sample (Pébay single-sample update).
+
+        Uses the standard Welford-style recurrences for higher moments — cf.
+        Pébay (2008). The coefficients $(n-1)(n-2)$ and $(n-1)(n^2-3n+3)$
+        ensure $M_3 = M_4 = 0$ at $n = 1$ and $M_3 = 0$ for any symmetric pair
+        at $n = 2$.
+        """
+        n = self.count + 1
+        nf = n.astype(energy.dtype)
+        n_prev = nf - 1.0
+
+        delta = energy - self.mean
+        delta_n = delta / nf
+        delta_n_sq = delta_n * delta_n
+        # term1 = δ² (n-1)/n — the single-sample "pair" contribution.
+        term1 = delta * delta_n * n_prev
+
+        new_mean = self.mean + delta_n
+        # Update m4 and m3 before m2 — they read old m2 / m3 values.
+        new_m4 = (
+            self.m4
+            + term1 * delta_n_sq * (nf * nf - 3.0 * nf + 3.0)
+            + 6.0 * delta_n_sq * self.m2
+            - 4.0 * delta_n * self.m3
+        )
+        new_m3 = self.m3 + term1 * delta_n * (nf - 2.0) - 3.0 * delta_n * self.m2
+        new_m2 = self.m2 + term1
+
+        return EnergyMoments(
+            count=n,
+            mean=new_mean,
+            m2=new_m2,
+            m3=new_m3,
+            m4=new_m4,
+        )
+
+    def finalize(self) -> EnergyCumulants:
+        r"""Normalize $M_k$ by $n$ and map to cumulants for Taylor expansion."""
+        nf = self.count.astype(jnp.float64)
+        variance = self.m2 / nf
+        third_central = self.m3 / nf
+        fourth_central = self.m4 / nf
+        return EnergyCumulants(
+            mean=self.mean,
+            variance=variance,
+            third=-third_central,
+            fourth=fourth_central - 3.0 * variance**2,
         )
 
 

--- a/src/kups/mcmc/widom.py
+++ b/src/kups/mcmc/widom.py
@@ -50,7 +50,7 @@ from kups.core.propagator import (
     Propagator,
 )
 from kups.core.typing import SystemId
-from kups.core.utils.jax import dataclass, field, key_chain
+from kups.core.utils.jax import dataclass, field, key_chain, tree_zeros_like
 
 type LogAcceptanceRatio = Array
 r"""Log Metropolis acceptance ratio $\ln\alpha$ [dimensionless]."""
@@ -138,7 +138,7 @@ class WidomStatistics:
         Returns:
             Fresh accumulator of the same shape with all fields at zero.
         """
-        return self.zeros(int(self.n_samples.shape[0]))
+        return tree_zeros_like(self)
 
     def update(self, ln_alpha: LogAcceptanceRatio, delta_u: Energy) -> WidomStatistics:
         r"""Accumulate one ghost insertion.
@@ -211,7 +211,7 @@ class TransitionStatistics:
         Returns:
             Fresh accumulator of the same shape with all fields at zero.
         """
-        return self.zeros(int(self.n_trials_insertion.shape[0]))
+        return tree_zeros_like(self)
 
     def update_insertion(self, ln_alpha: LogAcceptanceRatio) -> TransitionStatistics:
         r"""Accumulate a ghost insertion. Trial count is incremented unconditionally.
@@ -223,7 +223,7 @@ class TransitionStatistics:
         Returns:
             Accumulator with $\min(1, \alpha)$ added to the insertion row.
         """
-        acceptance = jnp.minimum(1.0, jnp.exp(ln_alpha))
+        acceptance = jnp.exp(jnp.minimum(0.0, ln_alpha))
         return TransitionStatistics(
             acceptance_insertion=self.acceptance_insertion + acceptance,
             acceptance_deletion=self.acceptance_deletion,
@@ -251,7 +251,7 @@ class TransitionStatistics:
         Returns:
             Accumulator with $\min(1, \alpha)$ added to the deletion row.
         """
-        acceptance = jnp.minimum(1.0, jnp.exp(ln_alpha))
+        acceptance = jnp.exp(jnp.minimum(0.0, ln_alpha))
         acceptance = jnp.where(macrostate_n > 0, acceptance, 0.0)
         return TransitionStatistics(
             acceptance_insertion=self.acceptance_insertion,
@@ -352,7 +352,7 @@ class EnergyMoments:
         Returns:
             Fresh accumulator of the same shape and order with all fields zero.
         """
-        return self.zeros(int(self.count.shape[0]), max_order=self.max_order)
+        return tree_zeros_like(self)
 
     def update(self, energy: Energy) -> EnergyMoments:
         r"""Incorporate one per-system energy sample (Pébay single-sample update).

--- a/test/mcmc/test_widom.py
+++ b/test/mcmc/test_widom.py
@@ -131,7 +131,7 @@ class TestWidomStatistics:
         r = stats.reset()
         npt.assert_array_equal(r.sum_boltzmann, jnp.zeros(2))
         npt.assert_array_equal(r.sum_delta_u_boltzmann, jnp.zeros(2))
-        npt.assert_array_equal(r.n_samples, jnp.zeros(2, dtype=jnp.int32))
+        npt.assert_array_equal(r.n_samples, jnp.zeros(2, dtype=int))
 
 
 class TestGhostProbe:
@@ -164,7 +164,7 @@ class TestGhostProbe:
             energies * jnp.array([1.0, 0.5]),
             rtol=1e-10,
         )
-        npt.assert_array_equal(stats.n_samples, jnp.array([1, 1], dtype=jnp.int32))
+        npt.assert_array_equal(stats.n_samples, jnp.array([1, 1], dtype=int))
 
     def test_does_not_mutate_non_stat_state(self):
         n_systems = 2
@@ -193,20 +193,20 @@ class TestTransitionStatistics:
     def test_zeros_has_correct_shape_and_dtype(self):
         stats = TransitionStatistics.zeros(4)
         assert stats.acceptance_insertion.shape == (4,)
-        assert stats.n_trials_insertion.dtype == jnp.int32
+        assert jnp.issubdtype(stats.n_trials_insertion.dtype, jnp.integer)
         npt.assert_array_equal(stats.acceptance_insertion, jnp.zeros(4))
-        npt.assert_array_equal(stats.n_trials_deletion, jnp.zeros(4, dtype=jnp.int32))
+        npt.assert_array_equal(stats.n_trials_deletion, jnp.zeros(4, dtype=int))
 
     def test_reset_restores_zeros(self):
         stats = TransitionStatistics(
             acceptance_insertion=jnp.array([1.0, 2.0]),
             acceptance_deletion=jnp.array([0.5, 1.5]),
-            n_trials_insertion=jnp.array([7, 9], dtype=jnp.int32),
-            n_trials_deletion=jnp.array([7, 9], dtype=jnp.int32),
+            n_trials_insertion=jnp.array([7, 9], dtype=int),
+            n_trials_deletion=jnp.array([7, 9], dtype=int),
         )
         reset = stats.reset()
         npt.assert_array_equal(reset.acceptance_insertion, jnp.zeros(2))
-        npt.assert_array_equal(reset.n_trials_insertion, jnp.zeros(2, dtype=jnp.int32))
+        npt.assert_array_equal(reset.n_trials_insertion, jnp.zeros(2, dtype=int))
 
     def test_update_insertion_clamps_and_increments(self):
         stats = TransitionStatistics.zeros(3)
@@ -215,10 +215,10 @@ class TestTransitionStatistics:
         updated = stats.update_insertion(ln_alpha)
         expected_acc = jnp.minimum(1.0, jnp.exp(ln_alpha))
         npt.assert_allclose(updated.acceptance_insertion, expected_acc, rtol=1e-10)
-        npt.assert_array_equal(updated.n_trials_insertion, jnp.ones(3, dtype=jnp.int32))
+        npt.assert_array_equal(updated.n_trials_insertion, jnp.ones(3, dtype=int))
         # Deletion side untouched
         npt.assert_array_equal(updated.acceptance_deletion, jnp.zeros(3))
-        npt.assert_array_equal(updated.n_trials_deletion, jnp.zeros(3, dtype=jnp.int32))
+        npt.assert_array_equal(updated.n_trials_deletion, jnp.zeros(3, dtype=int))
 
     def test_update_deletion_masks_at_N0_but_increments_trial(self):
         stats = TransitionStatistics.zeros(3)
@@ -230,7 +230,7 @@ class TestTransitionStatistics:
         expected_acc = jnp.where(macrostate_n > 0, expected_acc, 0.0)
         npt.assert_allclose(updated.acceptance_deletion, expected_acc, rtol=1e-10)
         # The trial count increments even at N = 0 so P(0 → 1) is not inflated.
-        npt.assert_array_equal(updated.n_trials_deletion, jnp.ones(3, dtype=jnp.int32))
+        npt.assert_array_equal(updated.n_trials_deletion, jnp.ones(3, dtype=int))
 
     def test_repeated_updates_accumulate(self):
         stats = TransitionStatistics.zeros(2)
@@ -238,7 +238,7 @@ class TestTransitionStatistics:
             stats = stats.update_insertion(jnp.array([0.0, 0.0]))  # acc=1 each
         npt.assert_allclose(stats.acceptance_insertion, jnp.array([5.0, 5.0]))
         npt.assert_array_equal(
-            stats.n_trials_insertion, jnp.array([5, 5], dtype=jnp.int32)
+            stats.n_trials_insertion, jnp.array([5, 5], dtype=int)
         )
 
 
@@ -270,10 +270,34 @@ class TestEnergyMoments:
 
         npt.assert_allclose(cumulants.mean[0], ref_mean, rtol=1e-10)
         npt.assert_allclose(cumulants.variance[0], ref_m2, rtol=1e-10)
-        # cumulants.third has the sign flip: -third_central
-        npt.assert_allclose(cumulants.third[0], -ref_m3, rtol=1e-9, atol=1e-12)
+        npt.assert_allclose(cumulants.cumulants[1, 0], ref_m3, rtol=1e-9, atol=1e-12)
         npt.assert_allclose(
-            cumulants.fourth[0], ref_m4 - 3 * ref_m2**2, rtol=1e-9, atol=1e-12
+            cumulants.cumulants[2, 0], ref_m4 - 3 * ref_m2**2, rtol=1e-9, atol=1e-12
+        )
+
+    def test_arbitrary_order_matches_numpy_reference(self):
+        """max_order=6: M_p sums and the cumulant recursion (kappa_5, kappa_6)
+        against two-pass NumPy references."""
+        rng = np.random.default_rng(7)
+        samples = rng.exponential(scale=1.5, size=200)  # skewed on purpose
+
+        moments = EnergyMoments.zeros(1, max_order=6)
+        for x in samples:
+            moments = moments.update(jnp.array([x]))
+
+        dev = samples - samples.mean()
+        mu = {p: np.mean(dev**p) for p in range(2, 7)}
+        for p in range(2, 7):
+            npt.assert_allclose(
+                moments.central_sums[p - 2, 0], mu[p] * len(samples), rtol=1e-8
+            )
+
+        c = moments.finalize()
+        npt.assert_allclose(c.cumulants[3, 0], mu[5] - 10 * mu[2] * mu[3], rtol=1e-8)
+        npt.assert_allclose(
+            c.cumulants[4, 0],
+            mu[6] - 15 * mu[2] * mu[4] - 10 * mu[3] ** 2 + 30 * mu[2] ** 3,
+            rtol=1e-8,
         )
 
     def test_multi_system_independence(self):
@@ -297,6 +321,6 @@ class TestEnergyMoments:
         for _ in range(10):
             moments = moments.update(jnp.array([1.0, 2.0, 3.0]))
         reset = moments.reset()
-        npt.assert_array_equal(reset.count, jnp.zeros(3, dtype=jnp.int32))
+        npt.assert_array_equal(reset.count, jnp.zeros(3, dtype=int))
         npt.assert_array_equal(reset.mean, jnp.zeros(3))
-        npt.assert_array_equal(reset.m2, jnp.zeros(3))
+        npt.assert_array_equal(reset.central_sums, jnp.zeros((3, 3)))

--- a/test/mcmc/test_widom.py
+++ b/test/mcmc/test_widom.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import numpy.testing as npt
+import pytest
 from jax import Array
 
 from kups.core.data.table import Table
@@ -22,7 +24,9 @@ from kups.core.propagator import (
 from kups.core.typing import SystemId
 from kups.core.utils.jax import dataclass
 from kups.mcmc.widom import (
+    EnergyMoments,
     GhostProbe,
+    TransitionStatistics,
     WidomStatistics,
     widom_test,
 )
@@ -180,3 +184,119 @@ class TestGhostProbe:
         new_state = probe(jax.random.key(0), state)
         # `energies` is the non-accumulator field and must round-trip unchanged.
         npt.assert_array_equal(new_state.energies, state.energies)
+
+
+# -- TransitionStatistics (TMMC C-matrix) --------------------------------
+
+
+class TestTransitionStatistics:
+    def test_zeros_has_correct_shape_and_dtype(self):
+        stats = TransitionStatistics.zeros(4)
+        assert stats.acceptance_insertion.shape == (4,)
+        assert stats.n_trials_insertion.dtype == jnp.int32
+        npt.assert_array_equal(stats.acceptance_insertion, jnp.zeros(4))
+        npt.assert_array_equal(stats.n_trials_deletion, jnp.zeros(4, dtype=jnp.int32))
+
+    def test_reset_restores_zeros(self):
+        stats = TransitionStatistics(
+            acceptance_insertion=jnp.array([1.0, 2.0]),
+            acceptance_deletion=jnp.array([0.5, 1.5]),
+            n_trials_insertion=jnp.array([7, 9], dtype=jnp.int32),
+            n_trials_deletion=jnp.array([7, 9], dtype=jnp.int32),
+        )
+        reset = stats.reset()
+        npt.assert_array_equal(reset.acceptance_insertion, jnp.zeros(2))
+        npt.assert_array_equal(reset.n_trials_insertion, jnp.zeros(2, dtype=jnp.int32))
+
+    def test_update_insertion_clamps_and_increments(self):
+        stats = TransitionStatistics.zeros(3)
+        # ln α values: log(2) > 0 (clamps to 1), -1 (exp=0.368), -10 (exp≈0)
+        ln_alpha = jnp.array([jnp.log(2.0), -1.0, -10.0])
+        updated = stats.update_insertion(ln_alpha)
+        expected_acc = jnp.minimum(1.0, jnp.exp(ln_alpha))
+        npt.assert_allclose(updated.acceptance_insertion, expected_acc, rtol=1e-10)
+        npt.assert_array_equal(updated.n_trials_insertion, jnp.ones(3, dtype=jnp.int32))
+        # Deletion side untouched
+        npt.assert_array_equal(updated.acceptance_deletion, jnp.zeros(3))
+        npt.assert_array_equal(updated.n_trials_deletion, jnp.zeros(3, dtype=jnp.int32))
+
+    def test_update_deletion_masks_at_N0_but_increments_trial(self):
+        stats = TransitionStatistics.zeros(3)
+        ln_alpha = jnp.array([0.0, -1.0, -2.0])  # exp = 1, 0.368, 0.135
+        macrostate_n = jnp.array([0, 5, 3])  # system 0 has no particles
+        updated = stats.update_deletion(ln_alpha, macrostate_n)
+
+        expected_acc = jnp.minimum(1.0, jnp.exp(ln_alpha))
+        expected_acc = jnp.where(macrostate_n > 0, expected_acc, 0.0)
+        npt.assert_allclose(updated.acceptance_deletion, expected_acc, rtol=1e-10)
+        # The trial count increments even at N = 0 so P(0 → 1) is not inflated.
+        npt.assert_array_equal(updated.n_trials_deletion, jnp.ones(3, dtype=jnp.int32))
+
+    def test_repeated_updates_accumulate(self):
+        stats = TransitionStatistics.zeros(2)
+        for _ in range(5):
+            stats = stats.update_insertion(jnp.array([0.0, 0.0]))  # acc=1 each
+        npt.assert_allclose(stats.acceptance_insertion, jnp.array([5.0, 5.0]))
+        npt.assert_array_equal(
+            stats.n_trials_insertion, jnp.array([5, 5], dtype=jnp.int32)
+        )
+
+
+# -- EnergyMoments (Welford / Pébay) ------------------------------------
+
+
+def _numpy_central_moments(samples: np.ndarray) -> tuple[float, float, float, float]:
+    """Reference: compute mean + central moments 2-4 with NumPy (two-pass)."""
+    mean = samples.mean()
+    deviations = samples - mean
+    m2 = np.mean(deviations**2)
+    m3 = np.mean(deviations**3)
+    m4 = np.mean(deviations**4)
+    return float(mean), float(m2), float(m3), float(m4)
+
+
+class TestEnergyMoments:
+    @pytest.mark.parametrize("n_samples", [1, 2, 5, 20, 100])
+    def test_welford_matches_numpy_reference(self, n_samples: int):
+        rng = np.random.default_rng(42)
+        samples = rng.normal(loc=3.0, scale=2.5, size=n_samples)
+
+        moments = EnergyMoments.zeros(1)
+        for x in samples:
+            moments = moments.update(jnp.array([x]))
+
+        cumulants = moments.finalize()
+        ref_mean, ref_m2, ref_m3, ref_m4 = _numpy_central_moments(samples)
+
+        npt.assert_allclose(cumulants.mean[0], ref_mean, rtol=1e-10)
+        npt.assert_allclose(cumulants.variance[0], ref_m2, rtol=1e-10)
+        # cumulants.third has the sign flip: -third_central
+        npt.assert_allclose(cumulants.third[0], -ref_m3, rtol=1e-9, atol=1e-12)
+        npt.assert_allclose(
+            cumulants.fourth[0], ref_m4 - 3 * ref_m2**2, rtol=1e-9, atol=1e-12
+        )
+
+    def test_multi_system_independence(self):
+        """Two systems with different sample streams must stay independent."""
+        rng = np.random.default_rng(0)
+        s1 = rng.normal(size=50)
+        s2 = rng.normal(loc=10.0, scale=0.1, size=50)
+
+        moments = EnergyMoments.zeros(2)
+        for x1, x2 in zip(s1, s2, strict=True):
+            moments = moments.update(jnp.array([float(x1), float(x2)]))
+        c = moments.finalize()
+
+        npt.assert_allclose(c.mean[0], s1.mean(), rtol=1e-10)
+        npt.assert_allclose(c.mean[1], s2.mean(), rtol=1e-10)
+        npt.assert_allclose(c.variance[0], s1.var(), rtol=1e-10)
+        npt.assert_allclose(c.variance[1], s2.var(), rtol=1e-10)
+
+    def test_reset_restores_zeros(self):
+        moments = EnergyMoments.zeros(3)
+        for _ in range(10):
+            moments = moments.update(jnp.array([1.0, 2.0, 3.0]))
+        reset = moments.reset()
+        npt.assert_array_equal(reset.count, jnp.zeros(3, dtype=jnp.int32))
+        npt.assert_array_equal(reset.mean, jnp.zeros(3))
+        npt.assert_array_equal(reset.m2, jnp.zeros(3))

--- a/test/mcmc/test_widom.py
+++ b/test/mcmc/test_widom.py
@@ -270,9 +270,9 @@ class TestEnergyMoments:
 
         npt.assert_allclose(cumulants.mean[0], ref_mean, rtol=1e-10)
         npt.assert_allclose(cumulants.variance[0], ref_m2, rtol=1e-10)
-        npt.assert_allclose(cumulants.cumulants[1, 0], ref_m3, rtol=1e-9, atol=1e-12)
+        npt.assert_allclose(cumulants.cumulants[0, 1], ref_m3, rtol=1e-9, atol=1e-12)
         npt.assert_allclose(
-            cumulants.cumulants[2, 0], ref_m4 - 3 * ref_m2**2, rtol=1e-9, atol=1e-12
+            cumulants.cumulants[0, 2], ref_m4 - 3 * ref_m2**2, rtol=1e-9, atol=1e-12
         )
 
     def test_arbitrary_order_matches_numpy_reference(self):
@@ -289,13 +289,13 @@ class TestEnergyMoments:
         mu = {p: np.mean(dev**p) for p in range(2, 7)}
         for p in range(2, 7):
             npt.assert_allclose(
-                moments.central_sums[p - 2, 0], mu[p] * len(samples), rtol=1e-8
+                moments.central_sums[0, p - 2], mu[p] * len(samples), rtol=1e-8
             )
 
         c = moments.finalize()
-        npt.assert_allclose(c.cumulants[3, 0], mu[5] - 10 * mu[2] * mu[3], rtol=1e-8)
+        npt.assert_allclose(c.cumulants[0, 3], mu[5] - 10 * mu[2] * mu[3], rtol=1e-8)
         npt.assert_allclose(
-            c.cumulants[4, 0],
+            c.cumulants[0, 4],
             mu[6] - 15 * mu[2] * mu[4] - 10 * mu[3] ** 2 + 30 * mu[2] ** 3,
             rtol=1e-8,
         )

--- a/test/mcmc/test_widom.py
+++ b/test/mcmc/test_widom.py
@@ -237,9 +237,7 @@ class TestTransitionStatistics:
         for _ in range(5):
             stats = stats.update_insertion(jnp.array([0.0, 0.0]))  # acc=1 each
         npt.assert_allclose(stats.acceptance_insertion, jnp.array([5.0, 5.0]))
-        npt.assert_array_equal(
-            stats.n_trials_insertion, jnp.array([5, 5], dtype=int)
-        )
+        npt.assert_array_equal(stats.n_trials_insertion, jnp.array([5, 5], dtype=int))
 
 
 # -- EnergyMoments (Welford / Pébay) ------------------------------------


### PR DESCRIPTION
Adds the two flat-histogram accumulators to `kups.mcmc.widom`, alongside the existing `WidomStatistics`:

- `TransitionStatistics`: collection-matrix accumulator for N → N±1 ghost moves (Witman 2018 eq 5–7). Deletion trials increment the trial count even at N=0 (zero accepted fraction) so P(0 → 1) is not inflated.
- `EnergyMoments` / `EnergyCumulants`: Pébay/Welford one-pass central moments 1–4 of the per-system potential energy, finalized into the β-derivative cumulants used by the ln Q_c Taylor expansion.

Tests: clamping/masking semantics, accumulation over repeated updates, Welford vs two-pass NumPy reference, per-system independence.

Part of the TMMC stack split out of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)