### PR TITLE
feat: flat-histogram (TMMC) post-processing

### DIFF
--- a/src/kups/mcmc/__init__.py
+++ b/src/kups/mcmc/__init__.py
@@ -13,7 +13,8 @@ support batched parallel systems.
 - **[moves][kups.mcmc.moves]**: MC move proposals (translations, rotations, insertions/deletions)
 - **[probability][kups.mcmc.probability]**: Acceptance criteria (Boltzmann, fugacity, combined µVT)
 - **[fugacity][kups.mcmc.fugacity]**: Equation of state calculations for real gas mixtures
-- **[widom][kups.mcmc.widom]**: Widom ghost-insertion primitives (µ_ex, K_H, q_st)
+- **[widom][kups.mcmc.widom]**: Widom ghost-insertion primitives (µ_ex, K_H, q_st), TMMC C-matrix and energy-moment accumulators
+- **[flat_histogram][kups.mcmc.flat_histogram]**: Post-processing for flat-histogram (TMMC) adsorption data — Taylor-extrapolated isotherms and isosteric heats
 
 ## Typical Usage
 
@@ -45,6 +46,6 @@ combined = compose_propagators(nvt_propagator, gcmc_propagator)
 See individual module documentation for detailed APIs.
 """
 
-from kups.mcmc import fugacity, moves, probability, widom
+from kups.mcmc import flat_histogram, fugacity, moves, probability, widom
 
-__all__ = ["moves", "probability", "fugacity", "widom"]
+__all__ = ["moves", "probability", "fugacity", "widom", "flat_histogram"]

--- a/src/kups/mcmc/flat_histogram.py
+++ b/src/kups/mcmc/flat_histogram.py
@@ -1,0 +1,558 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Post-processing for flat-histogram (TMMC) adsorption simulations.
+
+Implements the temperature-extrapolation scheme of Witman, Mahynski & Smit
+(2018) [^witman2018] for computing adsorption isotherms, isosteric heats and
+working capacities from an NVT+W simulation performed at a single temperature.
+
+Pipeline:
+
+1. C-matrix $\to$ transition probabilities $P(N \to N \pm 1)$ (eq 7).
+2. Transition probabilities $\to$ $\ln Q_c(N, V, \beta_\mathrm{sim})$ via
+   a prefix sum of the detailed-balance ratio (eq 8). This replaces a
+   Python loop with a single [`jnp.cumsum`][jax.numpy.cumsum].
+3. Taylor-expand $\ln Q_c(N, V, \beta)$ in $\beta$ using the per-macrostate
+   energy cumulants collected during simulation (eq 9--10).
+4. Reweight into the grand canonical ensemble (eq 3) using
+   [peng_robinson_log_fugacity][kups.mcmc.fugacity.peng_robinson_log_fugacity]
+   for the reservoir fugacity.
+
+The isosteric heat of adsorption (eq 19) is computed with [`jax.grad`][jax.grad]
+through the full $\langle N \rangle(T, \ln P)$ pipeline, including the
+Peng--Robinson equation of state. Autodiff is enabled by the implicit-function
+JVP attached to [`cubic_roots`][kups.core.utils.math.cubic_roots] and the
+double-where sanitisation in
+[`peng_robinson_log_fugacity`][kups.mcmc.fugacity.peng_robinson_log_fugacity].
+No ``delta_T`` hyperparameter and no finite-difference truncation error.
+
+All public functions and the [`TMMCSummary`][kups.mcmc.flat_histogram.TMMCSummary]
+dataclass operate on plain [`jax.Array`][jax.Array] inputs and are fully
+vectorised across pressure grids.
+
+[^witman2018]:
+    Witman, M., Mahynski, N. A. & Smit, B. (2018). *J. Chem. Theory Comput.*
+    **14**, 6149--6158. DOI: 10.1021/acs.jctc.8b00534
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.constants import BOLTZMANN_CONSTANT, KELVIN, PASCAL
+from kups.core.utils.jax import dataclass, field
+from kups.mcmc.fugacity import peng_robinson_log_fugacity
+from kups.mcmc.widom import EnergyCumulants
+
+type LogPartitionFunction = Array
+r"""Natural logarithm of $Q_c(N, V, \beta)$, shape ``(n_max+1,)``."""
+
+type MacrostateDistribution = Array
+r"""Grand-canonical distribution $\Pi(N; \mu, V, \beta)$, shape ``(n_max+1,)``."""
+
+type Loading = Array
+r"""Expected loading $\langle N \rangle$, scalar or shape ``(n_pressures,)``."""
+
+type IsostericHeat = Array
+r"""Isosteric heat $q_\mathrm{st}$ [energy], scalar or shape ``(n_pressures,)``."""
+
+type InsertionProbability = Array
+r"""TMMC insertion probability $P(N \to N+1)$, shape ``(n_max+1,)``."""
+
+type DeletionProbability = Array
+r"""TMMC deletion probability $P(N \to N-1)$, shape ``(n_max+1,)``."""
+
+
+def transition_probabilities(
+    acceptance_insertion: Array,
+    acceptance_deletion: Array,
+    n_trials_insertion: Array,
+    n_trials_deletion: Array,
+) -> tuple[InsertionProbability, DeletionProbability]:
+    r"""Normalise accumulated C-matrix counts into per-macrostate transition probabilities.
+
+    Applies Witman 2018 eq 7:
+
+    $$P(N \to N + \Delta) = \frac{C(N, N + \Delta)}{\sum_\Delta C(N, N + \Delta)}.$$
+
+    Args:
+        acceptance_insertion: Accumulated $\min(1, \mathrm{acc})$ for
+            $N \to N+1$, shape ``(n_max+1,)``.
+        acceptance_deletion: Accumulated $\min(1, \mathrm{acc})$ for
+            $N \to N-1$, shape ``(n_max+1,)``.
+        n_trials_insertion: Ghost-insertion trial count per macrostate.
+        n_trials_deletion: Ghost-deletion trial count per macrostate
+            (includes trials at $N = 0$, which contribute zero acceptance).
+
+    Returns:
+        A pair ``(P(N → N+1), P(N → N-1))``, each shape ``(n_max+1,)``.
+    """
+    total = n_trials_insertion + n_trials_deletion
+    safe_total = jnp.where(total > 0, total, 1)
+    return (
+        acceptance_insertion / safe_total,
+        acceptance_deletion / safe_total,
+    )
+
+
+def reconstruct_log_partition_fn(
+    insertion_probability: InsertionProbability,
+    deletion_probability: DeletionProbability,
+    beta: Array,
+    log_fugacity: Array,
+) -> LogPartitionFunction:
+    r"""Reconstruct $\ln Q_c(N, V, \beta_\mathrm{sim})$ from TMMC transition probabilities.
+
+    Applies Witman 2018 eq 8 as a prefix sum over macrostates:
+
+    $$\ln Q_c(N+1) - \ln Q_c(N)
+        = -\ln[q(\beta)\exp(\beta\mu)] + \ln\frac{P(N \to N+1)}{P(N+1 \to N)}.$$
+
+    For an ideal-gas reference, $q(\beta)\exp(\beta\mu) = \beta f$, so the
+    correction term is $\ln\beta + \ln f$ at every macrostate. The full
+    reconstruction is a single [`jnp.cumsum`][jax.numpy.cumsum] over the
+    macrostate axis.
+
+    Args:
+        insertion_probability: $P(N \to N+1)$, shape ``(n_max+1,)``.
+        deletion_probability: $P(N \to N-1)$, shape ``(n_max+1,)``.
+        beta: Simulation inverse temperature $1/(k_B T_\mathrm{sim})$
+            [1/energy].
+        log_fugacity: Simulation log-fugacity $\ln f$ [dimensionless after
+            unit scaling].
+
+    Returns:
+        $\ln Q_c(N, V, \beta_\mathrm{sim})$ of shape ``(n_max+1,)``, anchored
+        to ``0`` at $N = 0$.
+    """
+    ratio = jnp.log(insertion_probability[:-1]) - jnp.log(deletion_probability[1:])
+    delta_log_qc = ratio - (log_fugacity + jnp.log(beta))
+    return jnp.concatenate([jnp.zeros(1), jnp.cumsum(delta_log_qc)])
+
+
+def extrapolate_log_partition_fn(
+    log_partition_fn_sim: LogPartitionFunction,
+    cumulants: EnergyCumulants,
+    beta_sim: Array,
+    beta_target: Array,
+    order: int = 3,
+) -> LogPartitionFunction:
+    r"""Taylor-expand $\ln Q_c$ from $\beta_\mathrm{sim}$ to $\beta_\mathrm{target}$.
+
+    Implements Witman 2018 eq 9 to the specified order using the per-macrostate
+    energy cumulants collected during simulation. Using the convention that
+    [`EnergyCumulants.mean`][kups.mcmc.widom.EnergyCumulants] stores the raw
+    running mean $\langle E\rangle$ and ``third``/``fourth`` already carry the
+    signs appropriate for $\partial^n \ln Q_c / \partial \beta^n$:
+
+    $$\ln Q_c(\beta')
+        \approx \ln Q_c(\beta)
+        - \langle E\rangle\,\delta\beta
+        + \tfrac{1}{2}\mathrm{Var}\,\delta\beta^2
+        + \tfrac{1}{6}\kappa_3\,\delta\beta^3
+        + \tfrac{1}{24}\kappa_4\,\delta\beta^4$$
+
+    with $\delta\beta = \beta_\mathrm{target} - \beta_\mathrm{sim}$.
+
+    Args:
+        log_partition_fn_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$, shape
+            ``(n_max+1,)``.
+        cumulants: Per-macrostate energy cumulants.
+        beta_sim: Simulation inverse temperature.
+        beta_target: Target inverse temperature.
+        order: Taylor order (1--4). Higher orders require more sampling to
+            converge.
+
+    Returns:
+        Extrapolated $\ln Q_c(N, V, \beta_\mathrm{target})$, shape
+        ``(n_max+1,)``.
+
+    Raises:
+        ValueError: If ``order`` is not in 1--4.
+    """
+    if not 1 <= order <= 4:
+        raise ValueError(f"order must be in 1..4, got {order}")
+
+    db = beta_target - beta_sim
+    result = log_partition_fn_sim - cumulants.mean * db
+    if order >= 2:
+        result = result + cumulants.variance * db**2 / 2.0
+    if order >= 3:
+        result = result + cumulants.third * db**3 / 6.0
+    if order >= 4:
+        result = result + cumulants.fourth * db**4 / 24.0
+    return result
+
+
+def macrostate_distribution(
+    log_partition_fn: LogPartitionFunction,
+    beta: Array,
+    log_fugacity: Array,
+) -> MacrostateDistribution:
+    r"""Compute $\Pi(N; \mu, V, \beta)$ from $\ln Q_c$ and a reservoir fugacity.
+
+    Witman 2018 eq 3 with $\beta\mu = \ln(\beta f / q(\beta))$; the
+    ideal-gas $q$-factor cancels with the one absorbed into ``log_partition_fn``
+    by :func:`reconstruct_log_partition_fn`.
+
+    Uses the standard log-sum-exp trick to avoid overflow at large $N$.
+
+    Args:
+        log_partition_fn: $\ln Q_c(N, V, \beta)$, shape ``(n_max+1,)``.
+        beta: Inverse temperature.
+        log_fugacity: $\ln f$ at target conditions.
+
+    Returns:
+        Normalised distribution $\Pi(N)$, shape ``(n_max+1,)``.
+    """
+    n_values = jnp.arange(log_partition_fn.shape[0])
+    log_weights = (log_fugacity + jnp.log(beta)) * n_values + log_partition_fn
+    log_weights = log_weights - jnp.max(log_weights)
+    weights = jnp.exp(log_weights)
+    return weights / jnp.sum(weights)
+
+
+def average_loading(distribution: MacrostateDistribution) -> Loading:
+    r"""Compute $\langle N \rangle = \sum_N N\,\Pi(N)$."""
+    n_values = jnp.arange(distribution.shape[0])
+    return jnp.sum(n_values * distribution)
+
+
+def _log_fugacity_at_pressures(
+    pressures_pa: Array,
+    temperature_k: Array,
+    critical_pressure_pa: float,
+    critical_temperature_k: float,
+    acentric_factor: float,
+) -> Array:
+    r"""Return $\ln f$ at each pressure for a single-component gas. Shape ``(n_p,)``.
+
+    Uses kUPS's internal units (``PASCAL``, ``KELVIN``). Peng-Robinson's
+    numpy-style ``vectorize`` broadcasts the leading pressure axis
+    automatically.
+    """
+    result = peng_robinson_log_fugacity(
+        pressures_pa * PASCAL,
+        temperature_k * KELVIN,
+        jnp.atleast_1d(jnp.asarray(critical_pressure_pa)) * PASCAL,
+        jnp.atleast_1d(jnp.asarray(critical_temperature_k)) * KELVIN,
+        jnp.atleast_1d(jnp.asarray(acentric_factor)),
+    )
+    return result.log_fugacity[..., 0]
+
+
+def isotherm(
+    log_partition_fn: LogPartitionFunction,
+    beta: Array,
+    pressures: Array,
+    temperature: Array,
+    critical_pressure: float,
+    critical_temperature: float,
+    acentric_factor: float,
+) -> Loading:
+    r"""Vectorised adsorption isotherm $\langle N \rangle(P)$ at fixed $T$.
+
+    Evaluates Witman 2018 eq 18 for every pressure in ``pressures`` in a single
+    JAX computation — no Python loop. Fugacity comes from Peng-Robinson; the
+    macrostate distribution is rebuilt at each pressure.
+
+    Args:
+        log_partition_fn: $\ln Q_c(N, V, \beta)$ at the target $\beta$,
+            shape ``(n_max+1,)``.
+        beta: Inverse temperature corresponding to ``temperature``.
+        pressures: Pressure grid [Pa], shape ``(n_pressures,)``.
+        temperature: Temperature [K].
+        critical_pressure: $P_c$ of the adsorbate [Pa].
+        critical_temperature: $T_c$ of the adsorbate [K].
+        acentric_factor: $\omega$ of the adsorbate [-].
+
+    Returns:
+        $\langle N \rangle$ at each pressure, shape ``(n_pressures,)``.
+    """
+    log_fugacities = _log_fugacity_at_pressures(
+        pressures,
+        temperature,
+        critical_pressure,
+        critical_temperature,
+        acentric_factor,
+    )
+    distributions = jax.vmap(
+        macrostate_distribution,
+        in_axes=(None, None, 0),
+    )(log_partition_fn, beta, log_fugacities)
+    return jax.vmap(average_loading)(distributions)
+
+
+def _loading_from_T_logP(
+    temperature: Array,
+    log_pressure_pa: Array,
+    log_partition_fn_sim: LogPartitionFunction,
+    cumulants: EnergyCumulants,
+    beta_sim: Array,
+    order: int,
+    critical_pressure: float,
+    critical_temperature: float,
+    acentric_factor: float,
+) -> Array:
+    r"""Pure, differentiable $\langle N \rangle(T, \ln P)$ at one state point.
+
+    Used by :func:`isosteric_heat` as the target of ``jax.grad`` — composes
+    the Taylor extrapolation, Peng--Robinson fugacity, macrostate distribution,
+    and $\langle N\rangle$ marginalisation.
+    """
+    beta = 1.0 / (BOLTZMANN_CONSTANT * temperature)
+    log_qc = extrapolate_log_partition_fn(
+        log_partition_fn_sim,
+        cumulants,
+        beta_sim,
+        beta,
+        order,
+    )
+    pressure = jnp.exp(log_pressure_pa)
+    log_fugacity = _log_fugacity_at_pressures(
+        jnp.atleast_1d(pressure),
+        temperature,
+        critical_pressure,
+        critical_temperature,
+        acentric_factor,
+    )[0]
+    return average_loading(macrostate_distribution(log_qc, beta, log_fugacity))
+
+
+def isosteric_heat(
+    log_partition_fn_sim: LogPartitionFunction,
+    cumulants: EnergyCumulants,
+    beta_sim: Array,
+    pressures: Array,
+    temperature: Array,
+    critical_pressure: float,
+    critical_temperature: float,
+    acentric_factor: float,
+    order: int = 3,
+) -> IsostericHeat:
+    r"""Isosteric heat $q_\mathrm{st}$ via Clausius--Clapeyron with autodiff.
+
+    Uses the triple-product rule
+
+    $$q_\mathrm{st} = k_B T^2
+        \frac{(\partial \langle N\rangle / \partial T)_P}
+             {(\partial \langle N\rangle / \partial \ln P)_T}.$$
+
+    Both partial derivatives come from [`jax.grad`][jax.grad] on the pure
+    loading function $\langle N \rangle(T, \ln P)$, vmapped across the
+    pressure grid. No ``delta_T`` hyperparameter, no finite-difference
+    truncation error.
+
+    Args:
+        log_partition_fn_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$,
+            shape ``(n_max+1,)``.
+        cumulants: Per-macrostate energy cumulants.
+        beta_sim: Simulation inverse temperature.
+        pressures: Pressure grid [Pa], shape ``(n_pressures,)``.
+        temperature: Target temperature [K].
+        critical_pressure: $P_c$ of the adsorbate [Pa].
+        critical_temperature: $T_c$ of the adsorbate [K].
+        acentric_factor: $\omega$ of the adsorbate [-].
+        order: Taylor order for the $\beta$-extrapolation.
+
+    Returns:
+        $q_\mathrm{st}$ [energy] at each pressure, shape ``(n_pressures,)``.
+    """
+
+    def loading_fn(t: Array, log_p: Array) -> Array:
+        return _loading_from_T_logP(
+            t,
+            log_p,
+            log_partition_fn_sim,
+            cumulants,
+            beta_sim,
+            order,
+            critical_pressure,
+            critical_temperature,
+            acentric_factor,
+        )
+
+    dN_dT = jax.grad(loading_fn, argnums=0)
+    dN_dlogP = jax.grad(loading_fn, argnums=1)
+
+    def q_st_at(log_p: Array) -> Array:
+        return (
+            BOLTZMANN_CONSTANT
+            * temperature**2
+            * dN_dT(temperature, log_p)
+            / dN_dlogP(temperature, log_p)
+        )
+
+    return jax.vmap(q_st_at)(jnp.log(pressures))
+
+
+def working_capacity(
+    log_partition_fn_sim: LogPartitionFunction,
+    cumulants: EnergyCumulants,
+    beta_sim: Array,
+    temperature_ads: Array,
+    pressure_ads: Array,
+    temperature_des: Array,
+    pressure_des: Array,
+    critical_pressure: float,
+    critical_temperature: float,
+    acentric_factor: float,
+    order: int = 3,
+) -> Array:
+    r"""Working capacity $n_\mathrm{wc} = \langle N\rangle_\mathrm{ads} - \langle N\rangle_\mathrm{des}$.
+
+    Evaluates Witman 2018 eq 20 for a single $(T_\mathrm{ads}, P_\mathrm{ads}) \to (T_\mathrm{des}, P_\mathrm{des})$
+    swing process. Both end points use the Taylor-extrapolated $\ln Q_c$.
+    """
+
+    def loading(t: Array, p: Array) -> Array:
+        beta = 1.0 / (BOLTZMANN_CONSTANT * t)
+        log_qc = extrapolate_log_partition_fn(
+            log_partition_fn_sim,
+            cumulants,
+            beta_sim,
+            beta,
+            order,
+        )
+        return isotherm(
+            log_qc,
+            beta,
+            jnp.atleast_1d(p),
+            t,
+            critical_pressure,
+            critical_temperature,
+            acentric_factor,
+        )[0]
+
+    return loading(temperature_ads, pressure_ads) - loading(
+        temperature_des, pressure_des
+    )
+
+
+@dataclass
+class AdsorbateEOS:
+    r"""Peng-Robinson equation-of-state parameters for a single adsorbate species.
+
+    All values are in SI units (Pa, K, dimensionless) at the boundary; internal
+    unit conversion is handled downstream by
+    [peng_robinson_log_fugacity][kups.mcmc.fugacity.peng_robinson_log_fugacity].
+    """
+
+    critical_pressure: float = field(static=True)
+    critical_temperature: float = field(static=True)
+    acentric_factor: float = field(static=True)
+
+
+@dataclass
+class TMMCSummary:
+    r"""Post-processed TMMC simulation at a single temperature.
+
+    Bundles $\ln Q_c(\beta_\mathrm{sim})$, the per-macrostate energy cumulants,
+    and the reservoir EOS so that downstream observables are one method call
+    away. All methods are pure and JIT/vmap-compatible.
+
+    Attributes:
+        log_partition_fn_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$, shape
+            ``(n_max+1,)``.
+        cumulants: Per-macrostate energy cumulants.
+        beta_sim: Simulation inverse temperature.
+        adsorbate: Peng-Robinson parameters for the reservoir species.
+        order: Taylor order for the $\beta$-extrapolation (default 3).
+    """
+
+    log_partition_fn_sim: LogPartitionFunction
+    cumulants: EnergyCumulants
+    beta_sim: Array
+    adsorbate: AdsorbateEOS
+    order: int = field(static=True, default=3)
+
+    @staticmethod
+    def from_transition_statistics(
+        acceptance_insertion: Array,
+        acceptance_deletion: Array,
+        n_trials_insertion: Array,
+        n_trials_deletion: Array,
+        cumulants: EnergyCumulants,
+        beta_sim: Array,
+        log_fugacity_sim: Array,
+        adsorbate: AdsorbateEOS,
+        order: int = 3,
+    ) -> TMMCSummary:
+        r"""Build a summary directly from raw C-matrix counts."""
+        p_ins, p_del = transition_probabilities(
+            acceptance_insertion,
+            acceptance_deletion,
+            n_trials_insertion,
+            n_trials_deletion,
+        )
+        log_qc = reconstruct_log_partition_fn(p_ins, p_del, beta_sim, log_fugacity_sim)
+        return TMMCSummary(
+            log_partition_fn_sim=log_qc,
+            cumulants=cumulants,
+            beta_sim=beta_sim,
+            adsorbate=adsorbate,
+            order=order,
+        )
+
+    def extrapolate(self, beta_target: Array) -> LogPartitionFunction:
+        r"""$\ln Q_c$ at a target inverse temperature via Taylor expansion."""
+        return extrapolate_log_partition_fn(
+            self.log_partition_fn_sim,
+            self.cumulants,
+            self.beta_sim,
+            beta_target,
+            self.order,
+        )
+
+    def isotherm(self, pressures: Array, temperature: Array) -> Loading:
+        r"""$\langle N \rangle(P)$ at fixed $T$, vectorised across pressures."""
+        beta = 1.0 / (BOLTZMANN_CONSTANT * temperature)
+        log_qc = self.extrapolate(beta)
+        return isotherm(
+            log_qc,
+            beta,
+            pressures,
+            temperature,
+            self.adsorbate.critical_pressure,
+            self.adsorbate.critical_temperature,
+            self.adsorbate.acentric_factor,
+        )
+
+    def isosteric_heat(self, pressures: Array, temperature: Array) -> IsostericHeat:
+        r"""Autodiff Clausius--Clapeyron heat across a pressure grid."""
+        return isosteric_heat(
+            self.log_partition_fn_sim,
+            self.cumulants,
+            self.beta_sim,
+            pressures,
+            temperature,
+            self.adsorbate.critical_pressure,
+            self.adsorbate.critical_temperature,
+            self.adsorbate.acentric_factor,
+            self.order,
+        )
+
+    def working_capacity(
+        self,
+        temperature_ads: Array,
+        pressure_ads: Array,
+        temperature_des: Array,
+        pressure_des: Array,
+    ) -> Array:
+        r"""Working capacity between adsorption and desorption conditions."""
+        return working_capacity(
+            self.log_partition_fn_sim,
+            self.cumulants,
+            self.beta_sim,
+            temperature_ads,
+            pressure_ads,
+            temperature_des,
+            pressure_des,
+            self.adsorbate.critical_pressure,
+            self.adsorbate.critical_temperature,
+            self.adsorbate.acentric_factor,
+            self.order,
+        )

--- a/src/kups/mcmc/flat_histogram.py
+++ b/src/kups/mcmc/flat_histogram.py
@@ -11,8 +11,7 @@ Pipeline:
 
 1. C-matrix $\to$ transition probabilities $P(N \to N \pm 1)$ (eq 7).
 2. Transition probabilities $\to$ $\ln Q_c(N, V, \beta_\mathrm{sim})$ via
-   a prefix sum of the detailed-balance ratio (eq 8). This replaces a
-   Python loop with a single [`jnp.cumsum`][jax.numpy.cumsum].
+   a prefix sum of the detailed-balance ratio (eq 8).
 3. Taylor-expand $\ln Q_c(N, V, \beta)$ in $\beta$ using the per-macrostate
    energy cumulants collected during simulation (eq 9--10).
 4. Reweight into the grand canonical ensemble (eq 3) using
@@ -25,7 +24,6 @@ Peng--Robinson equation of state. Autodiff is enabled by the implicit-function
 JVP attached to [`cubic_roots`][kups.core.utils.math.cubic_roots] and the
 double-where sanitisation in
 [`peng_robinson_log_fugacity`][kups.mcmc.fugacity.peng_robinson_log_fugacity].
-No ``delta_T`` hyperparameter and no finite-difference truncation error.
 
 All public functions and the [`TMMCSummary`][kups.mcmc.flat_histogram.TMMCSummary]
 dataclass operate on plain [`jax.Array`][jax.Array] inputs and are fully
@@ -56,7 +54,7 @@ from kups.core.utils.jax import dataclass, field
 from kups.mcmc.fugacity import peng_robinson_log_fugacity
 from kups.mcmc.widom import EnergyCumulants, TransitionStatistics
 
-type LogPartitionFunction = Array
+type LogPartition = Array
 r"""Natural logarithm of $Q_c(N, V, \beta)$, shape ``(n_max+1,)``."""
 
 type MacrostateDistribution = Array
@@ -113,12 +111,12 @@ def transition_probabilities(
     )
 
 
-def reconstruct_log_partition_fn(
+def reconstruct_log_partition(
     insertion_probability: InsertionProbability,
     deletion_probability: DeletionProbability,
     beta: Array,
     log_fugacity: Array,
-) -> LogPartitionFunction:
+) -> LogPartition:
     r"""Reconstruct $\ln Q_c(N, V, \beta_\mathrm{sim})$ from TMMC transition probabilities.
 
     Applies Witman 2018 eq 8 as a prefix sum over macrostates:
@@ -127,9 +125,9 @@ def reconstruct_log_partition_fn(
         = -\ln[q(\beta)\exp(\beta\mu)] + \ln\frac{P(N \to N+1)}{P(N+1 \to N)}.$$
 
     For an ideal-gas reference, $q(\beta)\exp(\beta\mu) = \beta f$, so the
-    correction term is $\ln\beta + \ln f$ at every macrostate. The full
-    reconstruction is a single [`jnp.cumsum`][jax.numpy.cumsum] over the
-    macrostate axis.
+    correction term is $\ln\beta + \ln f$ at every macrostate, so the
+    reconstruction is a [`jnp.cumsum`][jax.numpy.cumsum] over the macrostate
+    axis.
 
     Args:
         insertion_probability: $P(N \to N+1)$, shape ``(n_max+1,)``.
@@ -148,13 +146,13 @@ def reconstruct_log_partition_fn(
     return jnp.concatenate([jnp.zeros(1), jnp.cumsum(delta_log_qc)])
 
 
-def extrapolate_log_partition_fn(
-    log_partition_fn_sim: LogPartitionFunction,
+def extrapolate_log_partition(
+    log_partition_sim: LogPartition,
     cumulants: EnergyCumulants,
     beta_sim: Array,
     beta_target: Array,
     order: int = 3,
-) -> LogPartitionFunction:
+) -> LogPartition:
     r"""Taylor-expand $\ln Q_c$ from $\beta_\mathrm{sim}$ to $\beta_\mathrm{target}$.
 
     Implements Witman 2018 eq 9 to arbitrary order using the per-macrostate
@@ -168,7 +166,7 @@ def extrapolate_log_partition_fn(
     \qquad \delta\beta = \beta' - \beta.$$
 
     Args:
-        log_partition_fn_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$, shape
+        log_partition_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$, shape
             ``(n_max+1,)``.
         cumulants: Per-macrostate energy cumulants.
         beta_sim: Simulation inverse temperature.
@@ -187,42 +185,45 @@ def extrapolate_log_partition_fn(
         raise ValueError(f"order must be in 1..{cumulants.max_order}, got {order}")
 
     db = beta_target - beta_sim
-    result = log_partition_fn_sim - cumulants.mean * db
+    result = log_partition_sim - cumulants.mean * db
     for k in range(2, order + 1):
         result = result + cumulants.cumulants[..., k - 2] * (-db) ** k / factorial(k)
     return result
 
 
 def macrostate_distribution(
-    log_partition_fn: LogPartitionFunction,
+    log_partition: LogPartition,
     beta: Array,
     log_fugacity: Array,
 ) -> MacrostateDistribution:
     r"""Compute $\Pi(N; \mu, V, \beta)$ from $\ln Q_c$ and a reservoir fugacity.
 
     Witman 2018 eq 3 with $\beta\mu = \ln(\beta f / q(\beta))$; the
-    ideal-gas $q$-factor cancels with the one absorbed into ``log_partition_fn``
-    by :func:`reconstruct_log_partition_fn`.
-
-    Uses the standard log-sum-exp trick to avoid overflow at large $N$.
+    ideal-gas $q$-factor cancels with the one absorbed into ``log_partition``
+    by :func:`reconstruct_log_partition`.
 
     Args:
-        log_partition_fn: $\ln Q_c(N, V, \beta)$, shape ``(n_max+1,)``.
+        log_partition: $\ln Q_c(N, V, \beta)$, shape ``(n_max+1,)``.
         beta: Inverse temperature.
         log_fugacity: $\ln f$ at target conditions.
 
     Returns:
         Normalised distribution $\Pi(N)$, shape ``(n_max+1,)``.
     """
-    n_values = jnp.arange(log_partition_fn.shape[0])
-    log_weights = (log_fugacity + jnp.log(beta)) * n_values + log_partition_fn
-    log_weights = log_weights - jnp.max(log_weights)
-    weights = jnp.exp(log_weights)
-    return weights / jnp.sum(weights)
+    n_values = jnp.arange(log_partition.shape[0])
+    log_weights = (log_fugacity + jnp.log(beta)) * n_values + log_partition
+    return jax.nn.softmax(log_weights)
 
 
 def average_loading(distribution: MacrostateDistribution) -> Loading:
-    r"""Compute $\langle N \rangle = \sum_N N\,\Pi(N)$."""
+    r"""Compute $\langle N \rangle = \sum_N N\,\Pi(N)$.
+
+    Args:
+        distribution: Normalised $\Pi(N)$, shape ``(n_max+1,)``.
+
+    Returns:
+        Scalar expected loading $\langle N \rangle$.
+    """
     n_values = jnp.arange(distribution.shape[0])
     return jnp.sum(n_values * distribution)
 
@@ -250,8 +251,8 @@ def _log_fugacity_at_pressures(
     return result.log_fugacity[..., 0]
 
 
-def isotherm_from_log_partition_fn(
-    log_partition_fn: LogPartitionFunction,
+def isotherm_from_log_partition(
+    log_partition: LogPartition,
     beta: Array,
     pressures: Array,
     temperature: Array,
@@ -261,12 +262,12 @@ def isotherm_from_log_partition_fn(
 ) -> Loading:
     r"""Vectorised adsorption isotherm $\langle N \rangle(P)$ at fixed $T$.
 
-    Evaluates Witman 2018 eq 18 for every pressure in ``pressures`` in a single
-    JAX computation — no Python loop. Fugacity comes from Peng-Robinson; the
-    macrostate distribution is rebuilt at each pressure.
+    Evaluates Witman 2018 eq 18 for every pressure in ``pressures``, vmapped
+    over the pressure grid. Fugacity comes from Peng-Robinson; the macrostate
+    distribution is rebuilt at each pressure.
 
     Args:
-        log_partition_fn: $\ln Q_c(N, V, \beta)$ at the target $\beta$,
+        log_partition: $\ln Q_c(N, V, \beta)$ at the target $\beta$,
             shape ``(n_max+1,)``.
         beta: Inverse temperature corresponding to ``temperature``.
         pressures: Pressure grid [Pa], shape ``(n_pressures,)``.
@@ -288,14 +289,14 @@ def isotherm_from_log_partition_fn(
     distributions = jax.vmap(
         macrostate_distribution,
         in_axes=(None, None, 0),
-    )(log_partition_fn, beta, log_fugacities)
+    )(log_partition, beta, log_fugacities)
     return jax.vmap(average_loading)(distributions)
 
 
-def _loading_from_T_logP(
+def _loading_from_temperature_log_pressure(
     temperature: Array,
     log_pressure_pa: Array,
-    log_partition_fn_sim: LogPartitionFunction,
+    log_partition_sim: LogPartition,
     cumulants: EnergyCumulants,
     beta_sim: Array,
     order: int,
@@ -310,8 +311,8 @@ def _loading_from_T_logP(
     and $\langle N\rangle$ marginalisation.
     """
     beta = 1.0 / (BOLTZMANN_CONSTANT * temperature)
-    log_qc = extrapolate_log_partition_fn(
-        log_partition_fn_sim,
+    log_qc = extrapolate_log_partition(
+        log_partition_sim,
         cumulants,
         beta_sim,
         beta,
@@ -328,8 +329,8 @@ def _loading_from_T_logP(
     return average_loading(macrostate_distribution(log_qc, beta, log_fugacity))
 
 
-def isosteric_heat_from_log_partition_fn(
-    log_partition_fn_sim: LogPartitionFunction,
+def isosteric_heat_from_log_partition(
+    log_partition_sim: LogPartition,
     cumulants: EnergyCumulants,
     beta_sim: Array,
     pressures: Array,
@@ -347,13 +348,12 @@ def isosteric_heat_from_log_partition_fn(
         \frac{(\partial \langle N\rangle / \partial T)_P}
              {(\partial \langle N\rangle / \partial \ln P)_T}.$$
 
-    Both partial derivatives come from [`jax.grad`][jax.grad] on the pure
-    loading function $\langle N \rangle(T, \ln P)$, vmapped across the
-    pressure grid. No ``delta_T`` hyperparameter, no finite-difference
-    truncation error.
+    Both partial derivatives come from a single [`jax.grad`][jax.grad] on the
+    pure loading function $\langle N \rangle(T, \ln P)$, vmapped across the
+    pressure grid.
 
     Args:
-        log_partition_fn_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$,
+        log_partition_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$,
             shape ``(n_max+1,)``.
         cumulants: Per-macrostate energy cumulants.
         beta_sim: Simulation inverse temperature.
@@ -369,10 +369,10 @@ def isosteric_heat_from_log_partition_fn(
     """
 
     def loading_fn(t: Array, log_p: Array) -> Array:
-        return _loading_from_T_logP(
+        return _loading_from_temperature_log_pressure(
             t,
             log_p,
-            log_partition_fn_sim,
+            log_partition_sim,
             cumulants,
             beta_sim,
             order,
@@ -381,22 +381,17 @@ def isosteric_heat_from_log_partition_fn(
             acentric_factor,
         )
 
-    dN_dT = jax.grad(loading_fn, argnums=0)
-    dN_dlogP = jax.grad(loading_fn, argnums=1)
+    loading_grad = jax.grad(loading_fn, argnums=(0, 1))
 
     def q_st_at(log_p: Array) -> Array:
-        return (
-            BOLTZMANN_CONSTANT
-            * temperature**2
-            * dN_dT(temperature, log_p)
-            / dN_dlogP(temperature, log_p)
-        )
+        dn_dt, dn_dlog_p = loading_grad(temperature, log_p)
+        return BOLTZMANN_CONSTANT * temperature**2 * dn_dt / dn_dlog_p
 
     return jax.vmap(q_st_at)(jnp.log(pressures))
 
 
-def working_capacity_from_log_partition_fn(
-    log_partition_fn_sim: LogPartitionFunction,
+def working_capacity_from_log_partition(
+    log_partition_sim: LogPartition,
     cumulants: EnergyCumulants,
     beta_sim: Array,
     temperature_ads: Array,
@@ -412,26 +407,37 @@ def working_capacity_from_log_partition_fn(
 
     Evaluates Witman 2018 eq 20 for a single $(T_\mathrm{ads}, P_\mathrm{ads}) \to (T_\mathrm{des}, P_\mathrm{des})$
     swing process. Both end points use the Taylor-extrapolated $\ln Q_c$.
+
+    Args:
+        log_partition_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$,
+            shape ``(n_max+1,)``.
+        cumulants: Per-macrostate energy cumulants.
+        beta_sim: Simulation inverse temperature.
+        temperature_ads: Adsorption temperature [K].
+        pressure_ads: Adsorption pressure [Pa].
+        temperature_des: Desorption temperature [K].
+        pressure_des: Desorption pressure [Pa].
+        critical_pressure: $P_c$ of the adsorbate [Pa].
+        critical_temperature: $T_c$ of the adsorbate [K].
+        acentric_factor: $\omega$ of the adsorbate [-].
+        order: Taylor order for the $\beta$-extrapolation.
+
+    Returns:
+        Scalar $n_\mathrm{wc}$ [particles].
     """
 
     def loading(t: Array, p: Array) -> Array:
-        beta = 1.0 / (BOLTZMANN_CONSTANT * t)
-        log_qc = extrapolate_log_partition_fn(
-            log_partition_fn_sim,
+        return _loading_from_temperature_log_pressure(
+            t,
+            jnp.log(p),
+            log_partition_sim,
             cumulants,
             beta_sim,
-            beta,
             order,
-        )
-        return isotherm_from_log_partition_fn(
-            log_qc,
-            beta,
-            jnp.atleast_1d(p),
-            t,
             critical_pressure,
             critical_temperature,
             acentric_factor,
-        )[0]
+        )
 
     return loading(temperature_ads, pressure_ads) - loading(
         temperature_des, pressure_des
@@ -463,7 +469,7 @@ class TMMCSummary:
     away. All methods are pure and JIT/vmap-compatible.
 
     Attributes:
-        log_partition_fn_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$, shape
+        log_partition_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$, shape
             ``(n_max+1,)``.
         cumulants: Per-macrostate energy cumulants.
         beta_sim: Simulation inverse temperature.
@@ -471,7 +477,7 @@ class TMMCSummary:
         order: Taylor order for the $\beta$-extrapolation (default 3).
     """
 
-    log_partition_fn_sim: LogPartitionFunction
+    log_partition_sim: LogPartition
     cumulants: EnergyCumulants
     beta_sim: Array
     adsorbate: AdsorbateEOS
@@ -500,19 +506,19 @@ class TMMCSummary:
             Summary ready for isotherm / heat / capacity evaluation.
         """
         p_ins, p_del = transition_probabilities(statistics)
-        log_qc = reconstruct_log_partition_fn(p_ins, p_del, beta_sim, log_fugacity_sim)
+        log_qc = reconstruct_log_partition(p_ins, p_del, beta_sim, log_fugacity_sim)
         return TMMCSummary(
-            log_partition_fn_sim=log_qc,
+            log_partition_sim=log_qc,
             cumulants=cumulants,
             beta_sim=beta_sim,
             adsorbate=adsorbate,
             order=order,
         )
 
-    def extrapolate(self, beta_target: Array) -> LogPartitionFunction:
+    def extrapolate(self, beta_target: Array) -> LogPartition:
         r"""$\ln Q_c$ at a target inverse temperature via Taylor expansion."""
-        return extrapolate_log_partition_fn(
-            self.log_partition_fn_sim,
+        return extrapolate_log_partition(
+            self.log_partition_sim,
             self.cumulants,
             self.beta_sim,
             beta_target,
@@ -523,7 +529,7 @@ class TMMCSummary:
         r"""$\langle N \rangle(P)$ at fixed $T$, vectorised across pressures."""
         beta = 1.0 / (BOLTZMANN_CONSTANT * temperature)
         log_qc = self.extrapolate(beta)
-        return isotherm_from_log_partition_fn(
+        return isotherm_from_log_partition(
             log_qc,
             beta,
             pressures,
@@ -535,8 +541,8 @@ class TMMCSummary:
 
     def isosteric_heat(self, pressures: Array, temperature: Array) -> IsostericHeat:
         r"""Autodiff Clausius--Clapeyron heat across a pressure grid."""
-        return isosteric_heat_from_log_partition_fn(
-            self.log_partition_fn_sim,
+        return isosteric_heat_from_log_partition(
+            self.log_partition_sim,
             self.cumulants,
             self.beta_sim,
             pressures,
@@ -555,8 +561,8 @@ class TMMCSummary:
         pressure_des: Array,
     ) -> Array:
         r"""Working capacity between adsorption and desorption conditions."""
-        return working_capacity_from_log_partition_fn(
-            self.log_partition_fn_sim,
+        return working_capacity_from_log_partition(
+            self.log_partition_sim,
             self.cumulants,
             self.beta_sim,
             temperature_ads,

--- a/src/kups/mcmc/flat_histogram.py
+++ b/src/kups/mcmc/flat_histogram.py
@@ -31,12 +31,21 @@ All public functions and the [`TMMCSummary`][kups.mcmc.flat_histogram.TMMCSummar
 dataclass operate on plain [`jax.Array`][jax.Array] inputs and are fully
 vectorised across pressure grids.
 
+Scope: the macrostate axis is the 1-D loading $N$ of a **single adsorbate
+species** in a **single system** (Witman 2018 treats exactly this case);
+mixtures would need a multi-dimensional macrostate lattice and a tensor
+C-matrix. Batches of systems are handled by [`jax.vmap`][jax.vmap] over the
+leading axis of the per-macrostate arrays.
+
 [^witman2018]:
     Witman, M., Mahynski, N. A. & Smit, B. (2018). *J. Chem. Theory Comput.*
     **14**, 6149--6158. DOI: 10.1021/acs.jctc.8b00534
 """
 
 from __future__ import annotations
+
+from math import factorial
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -45,7 +54,7 @@ from jax import Array
 from kups.core.constants import BOLTZMANN_CONSTANT, KELVIN, PASCAL
 from kups.core.utils.jax import dataclass, field
 from kups.mcmc.fugacity import peng_robinson_log_fugacity
-from kups.mcmc.widom import EnergyCumulants
+from kups.mcmc.widom import EnergyCumulants, TransitionStatistics
 
 type LogPartitionFunction = Array
 r"""Natural logarithm of $Q_c(N, V, \beta)$, shape ``(n_max+1,)``."""
@@ -66,35 +75,41 @@ type DeletionProbability = Array
 r"""TMMC deletion probability $P(N \to N-1)$, shape ``(n_max+1,)``."""
 
 
+class TransitionProbabilities(NamedTuple):
+    r"""Per-macrostate TMMC transition probabilities, each shape ``(n_max+1,)``.
+
+    Attributes:
+        insertion: $P(N \to N+1)$.
+        deletion: $P(N \to N-1)$.
+    """
+
+    insertion: InsertionProbability
+    deletion: DeletionProbability
+
+
 def transition_probabilities(
-    acceptance_insertion: Array,
-    acceptance_deletion: Array,
-    n_trials_insertion: Array,
-    n_trials_deletion: Array,
-) -> tuple[InsertionProbability, DeletionProbability]:
-    r"""Normalise accumulated C-matrix counts into per-macrostate transition probabilities.
+    statistics: TransitionStatistics,
+) -> TransitionProbabilities:
+    r"""Normalise an accumulated C-matrix into per-macrostate transition probabilities.
 
     Applies Witman 2018 eq 7:
 
     $$P(N \to N + \Delta) = \frac{C(N, N + \Delta)}{\sum_\Delta C(N, N + \Delta)}.$$
 
     Args:
-        acceptance_insertion: Accumulated $\min(1, \mathrm{acc})$ for
-            $N \to N+1$, shape ``(n_max+1,)``.
-        acceptance_deletion: Accumulated $\min(1, \mathrm{acc})$ for
-            $N \to N-1$, shape ``(n_max+1,)``.
-        n_trials_insertion: Ghost-insertion trial count per macrostate.
-        n_trials_deletion: Ghost-deletion trial count per macrostate
-            (includes trials at $N = 0$, which contribute zero acceptance).
+        statistics: Accumulated TMMC C-matrix
+            ([`TransitionStatistics`][kups.mcmc.widom.TransitionStatistics]),
+            with each field indexed by macrostate $N$, shape ``(n_max+1,)``.
 
     Returns:
-        A pair ``(P(N → N+1), P(N → N-1))``, each shape ``(n_max+1,)``.
+        ``TransitionProbabilities(insertion, deletion)``, each shape
+        ``(n_max+1,)``.
     """
-    total = n_trials_insertion + n_trials_deletion
+    total = statistics.n_trials_insertion + statistics.n_trials_deletion
     safe_total = jnp.where(total > 0, total, 1)
-    return (
-        acceptance_insertion / safe_total,
-        acceptance_deletion / safe_total,
+    return TransitionProbabilities(
+        insertion=statistics.acceptance_insertion / safe_total,
+        deletion=statistics.acceptance_deletion / safe_total,
     )
 
 
@@ -128,8 +143,8 @@ def reconstruct_log_partition_fn(
         $\ln Q_c(N, V, \beta_\mathrm{sim})$ of shape ``(n_max+1,)``, anchored
         to ``0`` at $N = 0$.
     """
-    ratio = jnp.log(insertion_probability[:-1]) - jnp.log(deletion_probability[1:])
-    delta_log_qc = ratio - (log_fugacity + jnp.log(beta))
+    log_ratio = jnp.log(insertion_probability[:-1]) - jnp.log(deletion_probability[1:])
+    delta_log_qc = log_ratio - (log_fugacity + jnp.log(beta))
     return jnp.concatenate([jnp.zeros(1), jnp.cumsum(delta_log_qc)])
 
 
@@ -142,20 +157,15 @@ def extrapolate_log_partition_fn(
 ) -> LogPartitionFunction:
     r"""Taylor-expand $\ln Q_c$ from $\beta_\mathrm{sim}$ to $\beta_\mathrm{target}$.
 
-    Implements Witman 2018 eq 9 to the specified order using the per-macrostate
-    energy cumulants collected during simulation. Using the convention that
-    [`EnergyCumulants.mean`][kups.mcmc.widom.EnergyCumulants] stores the raw
-    running mean $\langle E\rangle$ and ``third``/``fourth`` already carry the
-    signs appropriate for $\partial^n \ln Q_c / \partial \beta^n$:
+    Implements Witman 2018 eq 9 to arbitrary order using the per-macrostate
+    energy cumulants collected during simulation. Since
+    $\partial^k \ln Q_c / \partial\beta^k = (-1)^k \kappa_k$ (see
+    [`EnergyCumulants`][kups.mcmc.widom.EnergyCumulants]),
 
     $$\ln Q_c(\beta')
         \approx \ln Q_c(\beta)
-        - \langle E\rangle\,\delta\beta
-        + \tfrac{1}{2}\mathrm{Var}\,\delta\beta^2
-        + \tfrac{1}{6}\kappa_3\,\delta\beta^3
-        + \tfrac{1}{24}\kappa_4\,\delta\beta^4$$
-
-    with $\delta\beta = \beta_\mathrm{target} - \beta_\mathrm{sim}$.
+        + \sum_{k=1}^{K} \frac{(-\delta\beta)^k}{k!}\,\kappa_k,
+    \qquad \delta\beta = \beta' - \beta.$$
 
     Args:
         log_partition_fn_sim: $\ln Q_c(N, V, \beta_\mathrm{sim})$, shape
@@ -163,27 +173,23 @@ def extrapolate_log_partition_fn(
         cumulants: Per-macrostate energy cumulants.
         beta_sim: Simulation inverse temperature.
         beta_target: Target inverse temperature.
-        order: Taylor order (1--4). Higher orders require more sampling to
-            converge.
+        order: Taylor order $K$, at most ``cumulants.max_order``. Higher
+            orders require more sampling to converge.
 
     Returns:
         Extrapolated $\ln Q_c(N, V, \beta_\mathrm{target})$, shape
         ``(n_max+1,)``.
 
     Raises:
-        ValueError: If ``order`` is not in 1--4.
+        ValueError: If ``order`` is not in ``1..cumulants.max_order``.
     """
-    if not 1 <= order <= 4:
-        raise ValueError(f"order must be in 1..4, got {order}")
+    if not 1 <= order <= cumulants.max_order:
+        raise ValueError(f"order must be in 1..{cumulants.max_order}, got {order}")
 
     db = beta_target - beta_sim
     result = log_partition_fn_sim - cumulants.mean * db
-    if order >= 2:
-        result = result + cumulants.variance * db**2 / 2.0
-    if order >= 3:
-        result = result + cumulants.third * db**3 / 6.0
-    if order >= 4:
-        result = result + cumulants.fourth * db**4 / 24.0
+    for k in range(2, order + 1):
+        result = result + cumulants.cumulants[k - 2] * (-db) ** k / factorial(k)
     return result
 
 
@@ -224,9 +230,9 @@ def average_loading(distribution: MacrostateDistribution) -> Loading:
 def _log_fugacity_at_pressures(
     pressures_pa: Array,
     temperature_k: Array,
-    critical_pressure_pa: float,
-    critical_temperature_k: float,
-    acentric_factor: float,
+    critical_pressure_pa: Array | float,
+    critical_temperature_k: Array | float,
+    acentric_factor: Array | float,
 ) -> Array:
     r"""Return $\ln f$ at each pressure for a single-component gas. Shape ``(n_p,)``.
 
@@ -244,14 +250,14 @@ def _log_fugacity_at_pressures(
     return result.log_fugacity[..., 0]
 
 
-def isotherm(
+def isotherm_from_log_partition_fn(
     log_partition_fn: LogPartitionFunction,
     beta: Array,
     pressures: Array,
     temperature: Array,
-    critical_pressure: float,
-    critical_temperature: float,
-    acentric_factor: float,
+    critical_pressure: Array | float,
+    critical_temperature: Array | float,
+    acentric_factor: Array | float,
 ) -> Loading:
     r"""Vectorised adsorption isotherm $\langle N \rangle(P)$ at fixed $T$.
 
@@ -293,9 +299,9 @@ def _loading_from_T_logP(
     cumulants: EnergyCumulants,
     beta_sim: Array,
     order: int,
-    critical_pressure: float,
-    critical_temperature: float,
-    acentric_factor: float,
+    critical_pressure: Array | float,
+    critical_temperature: Array | float,
+    acentric_factor: Array | float,
 ) -> Array:
     r"""Pure, differentiable $\langle N \rangle(T, \ln P)$ at one state point.
 
@@ -322,15 +328,15 @@ def _loading_from_T_logP(
     return average_loading(macrostate_distribution(log_qc, beta, log_fugacity))
 
 
-def isosteric_heat(
+def isosteric_heat_from_log_partition_fn(
     log_partition_fn_sim: LogPartitionFunction,
     cumulants: EnergyCumulants,
     beta_sim: Array,
     pressures: Array,
     temperature: Array,
-    critical_pressure: float,
-    critical_temperature: float,
-    acentric_factor: float,
+    critical_pressure: Array | float,
+    critical_temperature: Array | float,
+    acentric_factor: Array | float,
     order: int = 3,
 ) -> IsostericHeat:
     r"""Isosteric heat $q_\mathrm{st}$ via Clausius--Clapeyron with autodiff.
@@ -389,7 +395,7 @@ def isosteric_heat(
     return jax.vmap(q_st_at)(jnp.log(pressures))
 
 
-def working_capacity(
+def working_capacity_from_log_partition_fn(
     log_partition_fn_sim: LogPartitionFunction,
     cumulants: EnergyCumulants,
     beta_sim: Array,
@@ -397,9 +403,9 @@ def working_capacity(
     pressure_ads: Array,
     temperature_des: Array,
     pressure_des: Array,
-    critical_pressure: float,
-    critical_temperature: float,
-    acentric_factor: float,
+    critical_pressure: Array | float,
+    critical_temperature: Array | float,
+    acentric_factor: Array | float,
     order: int = 3,
 ) -> Array:
     r"""Working capacity $n_\mathrm{wc} = \langle N\rangle_\mathrm{ads} - \langle N\rangle_\mathrm{des}$.
@@ -417,7 +423,7 @@ def working_capacity(
             beta,
             order,
         )
-        return isotherm(
+        return isotherm_from_log_partition_fn(
             log_qc,
             beta,
             jnp.atleast_1d(p),
@@ -439,11 +445,13 @@ class AdsorbateEOS:
     All values are in SI units (Pa, K, dimensionless) at the boundary; internal
     unit conversion is handled downstream by
     [peng_robinson_log_fugacity][kups.mcmc.fugacity.peng_robinson_log_fugacity].
+    The parameters are pytree leaves, so they may be plain floats or traced
+    arrays (e.g. to differentiate observables w.r.t. the EOS parameters).
     """
 
-    critical_pressure: float = field(static=True)
-    critical_temperature: float = field(static=True)
-    acentric_factor: float = field(static=True)
+    critical_pressure: Array | float
+    critical_temperature: Array | float
+    acentric_factor: Array | float
 
 
 @dataclass
@@ -471,23 +479,27 @@ class TMMCSummary:
 
     @staticmethod
     def from_transition_statistics(
-        acceptance_insertion: Array,
-        acceptance_deletion: Array,
-        n_trials_insertion: Array,
-        n_trials_deletion: Array,
+        statistics: TransitionStatistics,
         cumulants: EnergyCumulants,
         beta_sim: Array,
         log_fugacity_sim: Array,
         adsorbate: AdsorbateEOS,
         order: int = 3,
     ) -> TMMCSummary:
-        r"""Build a summary directly from raw C-matrix counts."""
-        p_ins, p_del = transition_probabilities(
-            acceptance_insertion,
-            acceptance_deletion,
-            n_trials_insertion,
-            n_trials_deletion,
-        )
+        r"""Build a summary directly from an accumulated C-matrix.
+
+        Args:
+            statistics: Accumulated TMMC C-matrix, indexed by macrostate $N$.
+            cumulants: Per-macrostate energy cumulants.
+            beta_sim: Simulation inverse temperature.
+            log_fugacity_sim: Simulation log-fugacity $\ln f$.
+            adsorbate: Peng-Robinson parameters for the reservoir species.
+            order: Taylor order for the $\beta$-extrapolation.
+
+        Returns:
+            Summary ready for isotherm / heat / capacity evaluation.
+        """
+        p_ins, p_del = transition_probabilities(statistics)
         log_qc = reconstruct_log_partition_fn(p_ins, p_del, beta_sim, log_fugacity_sim)
         return TMMCSummary(
             log_partition_fn_sim=log_qc,
@@ -511,7 +523,7 @@ class TMMCSummary:
         r"""$\langle N \rangle(P)$ at fixed $T$, vectorised across pressures."""
         beta = 1.0 / (BOLTZMANN_CONSTANT * temperature)
         log_qc = self.extrapolate(beta)
-        return isotherm(
+        return isotherm_from_log_partition_fn(
             log_qc,
             beta,
             pressures,
@@ -523,7 +535,7 @@ class TMMCSummary:
 
     def isosteric_heat(self, pressures: Array, temperature: Array) -> IsostericHeat:
         r"""Autodiff Clausius--Clapeyron heat across a pressure grid."""
-        return isosteric_heat(
+        return isosteric_heat_from_log_partition_fn(
             self.log_partition_fn_sim,
             self.cumulants,
             self.beta_sim,
@@ -543,7 +555,7 @@ class TMMCSummary:
         pressure_des: Array,
     ) -> Array:
         r"""Working capacity between adsorption and desorption conditions."""
-        return working_capacity(
+        return working_capacity_from_log_partition_fn(
             self.log_partition_fn_sim,
             self.cumulants,
             self.beta_sim,

--- a/src/kups/mcmc/flat_histogram.py
+++ b/src/kups/mcmc/flat_histogram.py
@@ -189,7 +189,7 @@ def extrapolate_log_partition_fn(
     db = beta_target - beta_sim
     result = log_partition_fn_sim - cumulants.mean * db
     for k in range(2, order + 1):
-        result = result + cumulants.cumulants[k - 2] * (-db) ** k / factorial(k)
+        result = result + cumulants.cumulants[..., k - 2] * (-db) ** k / factorial(k)
     return result
 
 

--- a/test/mcmc/test_flat_histogram.py
+++ b/test/mcmc/test_flat_histogram.py
@@ -1,0 +1,509 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for [kups.mcmc.flat_histogram][kups.mcmc.flat_histogram]."""
+
+from __future__ import annotations
+
+import math
+
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from kups.core.constants import BOLTZMANN_CONSTANT, KELVIN, PASCAL
+from kups.mcmc.flat_histogram import (
+    AdsorbateEOS,
+    TMMCSummary,
+    average_loading,
+    extrapolate_log_partition_fn,
+    isosteric_heat,
+    isotherm,
+    macrostate_distribution,
+    reconstruct_log_partition_fn,
+    transition_probabilities,
+    working_capacity,
+)
+from kups.mcmc.fugacity import peng_robinson_log_fugacity
+from kups.mcmc.widom import EnergyCumulants
+
+# CO2-like EOS parameters for integration tests.
+_CO2 = AdsorbateEOS(
+    critical_pressure=7.38e6,  # Pa
+    critical_temperature=304.2,  # K
+    acentric_factor=0.228,
+)
+
+
+# -- transition_probabilities --------------------------------------------
+
+
+class TestTransitionProbabilities:
+    def test_normalises_by_total_trials(self):
+        acc_ins = jnp.array([1.0, 2.0, 0.5])
+        acc_del = jnp.array([0.0, 1.0, 0.3])
+        n_ins = jnp.array([4, 4, 4], dtype=jnp.int32)
+        n_del = jnp.array([4, 4, 4], dtype=jnp.int32)
+        p_ins, p_del = transition_probabilities(acc_ins, acc_del, n_ins, n_del)
+        npt.assert_allclose(p_ins, acc_ins / 8.0)
+        npt.assert_allclose(p_del, acc_del / 8.0)
+
+    def test_safe_at_zero_trials(self):
+        """No divide-by-zero when a macrostate was never visited."""
+        acc = jnp.zeros(3)
+        n = jnp.zeros(3, dtype=jnp.int32)
+        p_ins, p_del = transition_probabilities(acc, acc, n, n)
+        npt.assert_array_equal(p_ins, jnp.zeros(3))
+        npt.assert_array_equal(p_del, jnp.zeros(3))
+
+
+# -- reconstruct_log_partition_fn ---------------------------------------
+
+
+class TestReconstructLogPartitionFn:
+    def test_roundtrip_from_known_log_qc(self):
+        """Given ln Q_c, construct P_ins/P_del from detailed balance and recover it."""
+        ln_qc_true = jnp.array([0.0, -1.0, -2.5, -4.0, -5.0])
+        beta = jnp.asarray(1.5)
+        beta_f = 0.01
+        log_f = jnp.log(beta_f)
+
+        delta_true = jnp.diff(ln_qc_true)
+        p_del = jnp.array([0.5, 1.0, 1.0, 1.0, 1.0])
+        # P_ins[N] = β f · exp(Δ ln Q_c(N)) · P_del[N+1]
+        p_ins_core = beta * beta_f * jnp.exp(delta_true) * p_del[1:]
+        p_ins_full = jnp.concatenate([p_ins_core, jnp.zeros(1)])
+
+        reconstructed = reconstruct_log_partition_fn(p_ins_full, p_del, beta, log_f)
+        npt.assert_allclose(reconstructed, ln_qc_true, rtol=1e-10, atol=1e-12)
+
+    def test_anchors_to_zero_at_N0(self):
+        p_ins = jnp.array([0.1, 0.2, 0.0])
+        p_del = jnp.array([0.5, 0.3, 0.4])
+        result = reconstruct_log_partition_fn(
+            p_ins, p_del, jnp.asarray(1.0), jnp.asarray(0.0)
+        )
+        assert float(result[0]) == 0.0
+
+
+# -- extrapolate_log_partition_fn ---------------------------------------
+
+
+class TestExtrapolate:
+    def test_cubic_ln_qc_is_exact_at_order_3(self):
+        r"""For $\ln Q_c(\beta)$ cubic in $\beta$, the 3rd-order Taylor is exact."""
+        beta_0 = 2.0
+        c0, c1, c2, c3 = 0.5, -3.0, 1.2, -0.4
+
+        def true_log_qc(beta: float) -> float:
+            return c0 + c1 * beta + c2 * beta**2 + c3 * beta**3
+
+        # Build derivatives ⟨E⟩=-dln Q/dβ, Var=d²ln Q/dβ², κ_3=d³ln Q/dβ³.
+        dlnq_dbeta = c1 + 2 * c2 * beta_0 + 3 * c3 * beta_0**2
+        cumulants = EnergyCumulants(
+            mean=jnp.asarray(-dlnq_dbeta),
+            variance=jnp.asarray(2 * c2 + 6 * c3 * beta_0),
+            third=jnp.asarray(6 * c3),
+            fourth=jnp.asarray(0.0),
+        )
+        log_qc_sim = jnp.asarray(true_log_qc(beta_0))
+        for beta_target in [2.0, 2.1, 1.8, 3.0]:
+            result = extrapolate_log_partition_fn(
+                log_qc_sim,
+                cumulants,
+                jnp.asarray(beta_0),
+                jnp.asarray(beta_target),
+                order=3,
+            )
+            npt.assert_allclose(
+                float(result), true_log_qc(beta_target), rtol=1e-10, atol=1e-10
+            )
+
+    def test_zero_displacement_returns_simulation_value(self):
+        cumulants = EnergyCumulants(
+            mean=jnp.array([1.0, 2.0, 3.0]),
+            variance=jnp.array([0.1, 0.2, 0.3]),
+            third=jnp.array([0.01, 0.02, 0.03]),
+            fourth=jnp.array([0.001, 0.002, 0.003]),
+        )
+        log_qc = jnp.array([0.0, -1.0, -2.0])
+        result = extrapolate_log_partition_fn(
+            log_qc, cumulants, jnp.asarray(1.0), jnp.asarray(1.0), order=4
+        )
+        npt.assert_allclose(result, log_qc, rtol=1e-12)
+
+    @pytest.mark.parametrize("order", [0, 5, -1])
+    def test_invalid_order_raises(self, order: int):
+        cumulants = EnergyCumulants(
+            mean=jnp.array([0.0]),
+            variance=jnp.array([0.0]),
+            third=jnp.array([0.0]),
+            fourth=jnp.array([0.0]),
+        )
+        with pytest.raises(ValueError):
+            extrapolate_log_partition_fn(
+                jnp.array([0.0]),
+                cumulants,
+                jnp.asarray(1.0),
+                jnp.asarray(1.0),
+                order=order,
+            )
+
+
+# -- macrostate_distribution + average_loading --------------------------
+
+
+class TestMacrostateDistribution:
+    def test_normalises_to_unity(self):
+        log_qc = jnp.array([0.0, -1.0, -0.5, -2.0])
+        dist = macrostate_distribution(log_qc, jnp.asarray(1.0), jnp.asarray(-1.0))
+        npt.assert_allclose(float(jnp.sum(dist)), 1.0, rtol=1e-12)
+        assert jnp.all(dist >= 0)
+
+    def test_matches_analytical_weights(self):
+        """For a 2-state system, the distribution follows the sigmoid form."""
+        ln_qc = jnp.array([0.0, 0.7])
+        beta = 2.0
+        log_f = -1.5
+        dist = macrostate_distribution(ln_qc, jnp.asarray(beta), jnp.asarray(log_f))
+        # log-weights: N=0 → 0, N=1 → (log_f + log β)·1 + 0.7
+        log_w = np.array([0.0, log_f + np.log(beta) + 0.7])
+        expected = np.exp(log_w) / np.exp(log_w).sum()
+        npt.assert_allclose(dist, expected, rtol=1e-10)
+
+    def test_average_loading_matches_hand_calculation(self):
+        dist = jnp.array([0.2, 0.3, 0.4, 0.1])
+        expected = 0 * 0.2 + 1 * 0.3 + 2 * 0.4 + 3 * 0.1
+        npt.assert_allclose(float(average_loading(dist)), expected, rtol=1e-12)
+
+
+# -- isotherm -----------------------------------------------------------
+
+
+class TestIsotherm:
+    def test_shape_matches_pressure_grid(self):
+        log_qc = jnp.array([0.0, -1.0, -2.0, -2.5])
+        pressures = jnp.array([1e4, 1e5, 1e6])
+        loadings = isotherm(
+            log_qc,
+            jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0)),
+            pressures,
+            jnp.asarray(300.0),
+            _CO2.critical_pressure,
+            _CO2.critical_temperature,
+            _CO2.acentric_factor,
+        )
+        assert loadings.shape == (3,)
+        assert jnp.all(loadings >= 0)
+        assert jnp.all(loadings <= len(log_qc) - 1)
+
+    def test_monotonic_in_pressure_for_attractive_site(self):
+        """⟨N⟩ must be non-decreasing in P for a fixed-site attractive model."""
+        log_qc = jnp.linspace(0.0, -10.0, 6)  # increasingly favourable binding
+        pressures = jnp.logspace(3, 7, 10)
+        loadings = isotherm(
+            log_qc,
+            jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0)),
+            pressures,
+            jnp.asarray(300.0),
+            _CO2.critical_pressure,
+            _CO2.critical_temperature,
+            _CO2.acentric_factor,
+        )
+        diffs = jnp.diff(loadings)
+        assert jnp.all(diffs >= -1e-10), f"loadings non-monotonic: {loadings}"
+
+
+# -- isosteric heat (autodiff Clausius-Clapeyron) -----------------------
+
+
+class TestIsostericHeat:
+    def test_finite_and_has_correct_shape(self):
+        log_qc_sim = jnp.array([0.0, -3.0, -5.0, -6.0])
+        cumulants = EnergyCumulants(
+            mean=jnp.array([0.0, -0.2, -0.35, -0.5]),
+            variance=jnp.array([0.0, 0.01, 0.02, 0.03]),
+            third=jnp.zeros(4),
+            fourth=jnp.zeros(4),
+        )
+        beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
+        pressures = jnp.array([1e4, 1e5, 1e6])
+
+        q = isosteric_heat(
+            log_qc_sim,
+            cumulants,
+            beta_sim,
+            pressures,
+            jnp.asarray(300.0),
+            _CO2.critical_pressure,
+            _CO2.critical_temperature,
+            _CO2.acentric_factor,
+            order=2,
+        )
+        assert q.shape == (3,)
+        assert jnp.all(jnp.isfinite(q))
+
+    def test_matches_central_difference(self):
+        """Autodiff q_st must agree with a local central-difference oracle.
+
+        Regression guard: autodiff through Peng-Robinson relies on the custom
+        JVP attached to
+        [`cubic_roots`][kups.core.utils.math.cubic_roots] and the double-where
+        sanitisation in
+        [`peng_robinson_log_fugacity`][kups.mcmc.fugacity.peng_robinson_log_fugacity].
+        A regression in either would show up as a divergence between the
+        autodiff Clausius--Clapeyron result and local finite differences.
+        """
+        from kups.mcmc.flat_histogram import _loading_from_T_logP
+
+        log_qc_sim = jnp.array([0.0, -3.0, -5.0, -6.0])
+        cumulants = EnergyCumulants(
+            mean=jnp.array([0.0, -0.2, -0.35, -0.5]),
+            variance=jnp.array([0.0, 0.01, 0.02, 0.03]),
+            third=jnp.zeros(4),
+            fourth=jnp.zeros(4),
+        )
+        beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
+        T = 300.0
+        P_test = 1e5
+        log_P = float(jnp.log(P_test))
+
+        def loading(t: float, lp: float) -> float:
+            return float(
+                _loading_from_T_logP(
+                    jnp.asarray(t),
+                    jnp.asarray(lp),
+                    log_qc_sim,
+                    cumulants,
+                    beta_sim,
+                    2,
+                    _CO2.critical_pressure,
+                    _CO2.critical_temperature,
+                    _CO2.acentric_factor,
+                )
+            )
+
+        h_T = 0.1
+        h_lp = 1e-3
+        dT_fd = (loading(T + h_T, log_P) - loading(T - h_T, log_P)) / (2.0 * h_T)
+        dlogP_fd = (loading(T, log_P + h_lp) - loading(T, log_P - h_lp)) / (2.0 * h_lp)
+        q_fd = BOLTZMANN_CONSTANT * T**2 * dT_fd / dlogP_fd
+
+        q_ad = isosteric_heat(
+            log_qc_sim,
+            cumulants,
+            beta_sim,
+            jnp.array([P_test]),
+            jnp.asarray(T),
+            _CO2.critical_pressure,
+            _CO2.critical_temperature,
+            _CO2.acentric_factor,
+            order=2,
+        )
+        npt.assert_allclose(float(q_ad[0]), q_fd, rtol=1e-3)
+
+
+# -- working_capacity ---------------------------------------------------
+
+
+class TestWorkingCapacity:
+    def test_swing_loading_difference(self):
+        """n_wc = ⟨N⟩_ads - ⟨N⟩_des; both terms come from the same summary."""
+        log_qc_sim = jnp.linspace(0.0, -4.0, 5)
+        cumulants = EnergyCumulants(
+            mean=jnp.zeros(5),
+            variance=jnp.zeros(5),
+            third=jnp.zeros(5),
+            fourth=jnp.zeros(5),
+        )
+        beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
+        n_wc = working_capacity(
+            log_qc_sim,
+            cumulants,
+            beta_sim,
+            jnp.asarray(300.0),
+            jnp.asarray(1e6),  # adsorption at high P
+            jnp.asarray(300.0),
+            jnp.asarray(1e3),  # desorption at low P
+            _CO2.critical_pressure,
+            _CO2.critical_temperature,
+            _CO2.acentric_factor,
+            order=1,
+        )
+        # Positive because ads P > des P and the material is attractive.
+        assert float(n_wc) > 0
+
+
+# -- end-to-end post-processing: analytical Langmuir -------------------
+
+
+class TestAnalyticalLangmuirRoundTrip:
+    """The full TMMC post-processing chain must reproduce a known closed-form
+    isotherm to machine precision when fed consistent synthetic statistics.
+
+    Given an $M$-site non-interacting Langmuir model with per-site binding
+    energy $\\varepsilon$,
+
+    $$\\ln Q_c(N) = \\ln\\binom{M}{N} + N \\beta \\varepsilon,$$
+
+    we build transition-matrix counts that exactly satisfy Witman eq 8 and
+    then run the full pipeline:
+
+    C-matrix $\\to$ :func:`transition_probabilities` $\\to$
+    :func:`reconstruct_log_partition_fn` $\\to$
+    :class:`TMMCSummary` $\\to$ :func:`isotherm`.
+
+    The resulting $\\langle N\\rangle(P)$ is compared against the closed-form
+    Langmuir $\\langle N \\rangle = M\\,x/(1+x)$ with
+    $x = \\beta f(P)\\,\\exp(\\beta\\varepsilon)$. Agreement is expected to
+    float64 precision.
+    """
+
+    def test_isotherm_matches_langmuir_closed_form(self):
+        M = 10
+        eps_ev = 0.05
+        T = 298.15
+        beta = 1.0 / (BOLTZMANN_CONSTANT * T)
+        P_sim = 1.0e5
+
+        pr_sim = peng_robinson_log_fugacity(
+            jnp.asarray(P_sim * PASCAL),
+            jnp.asarray(T * KELVIN),
+            jnp.atleast_1d(jnp.asarray(_CO2.critical_pressure) * PASCAL),
+            jnp.atleast_1d(jnp.asarray(_CO2.critical_temperature) * KELVIN),
+            jnp.atleast_1d(jnp.asarray(_CO2.acentric_factor)),
+        )
+        log_f_sim = jnp.asarray(float(pr_sim.log_fugacity[0]))
+
+        n_values = jnp.arange(M + 1)
+        log_choose = jnp.array(
+            [float(np.log(math.comb(M, int(k)))) for k in range(M + 1)]
+        )
+        log_qc_true = log_choose + n_values * beta * eps_ev
+
+        # Invert Witman eq 8 to construct consistent P_ins/P_del arrays.
+        delta = jnp.diff(log_qc_true)
+        p_del = jnp.full(M + 1, 0.5)
+        p_ins_core = p_del[1:] * jnp.exp(delta + log_f_sim + jnp.log(beta))
+        p_ins = jnp.concatenate([p_ins_core, jnp.zeros(1)])
+
+        n_trials = jnp.full(M + 1, 10_000, dtype=jnp.int32)
+        acc_ins = p_ins * 2 * n_trials.astype(jnp.float64)
+        acc_del = p_del * 2 * n_trials.astype(jnp.float64)
+
+        # Cumulants aren't exercised here (β_target == β_sim); pass zeros.
+        cumulants = EnergyCumulants(
+            mean=jnp.zeros(M + 1),
+            variance=jnp.zeros(M + 1),
+            third=jnp.zeros(M + 1),
+            fourth=jnp.zeros(M + 1),
+        )
+        summary = TMMCSummary.from_transition_statistics(
+            acc_ins,
+            acc_del,
+            n_trials,
+            n_trials,
+            cumulants=cumulants,
+            beta_sim=jnp.asarray(beta),
+            log_fugacity_sim=log_f_sim,
+            adsorbate=_CO2,
+            order=1,
+        )
+
+        # ln Q_c must round-trip exactly.
+        npt.assert_allclose(
+            summary.log_partition_fn_sim, log_qc_true, atol=1e-12, rtol=0
+        )
+
+        # Isotherm at several pressures must match the closed-form Langmuir.
+        pressures = jnp.logspace(2, 7, 6)
+        tmmc_loading = summary.isotherm(pressures, jnp.asarray(T))
+
+        def analytical(P_pa: float) -> float:
+            pr = peng_robinson_log_fugacity(
+                jnp.asarray(P_pa * PASCAL),
+                jnp.asarray(T * KELVIN),
+                jnp.atleast_1d(jnp.asarray(_CO2.critical_pressure) * PASCAL),
+                jnp.atleast_1d(jnp.asarray(_CO2.critical_temperature) * KELVIN),
+                jnp.atleast_1d(jnp.asarray(_CO2.acentric_factor)),
+            )
+            log_f = float(pr.log_fugacity[0])
+            x = np.exp(log_f + np.log(float(beta)) + float(beta) * eps_ev)
+            return M * x / (1.0 + x)
+
+        expected = np.array([analytical(float(p)) for p in pressures])
+        npt.assert_allclose(tmmc_loading, expected, atol=1e-12, rtol=1e-10)
+
+
+# -- TMMCSummary facade -------------------------------------------------
+
+
+class TestTMMCSummary:
+    def test_from_transition_statistics_roundtrip(self):
+        ln_qc_true = jnp.array([0.0, -1.5, -3.0, -4.0])
+        beta = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
+        log_f = jnp.asarray(-1.0)
+
+        # Build consistent P_ins/P_del from true ln Q_c, then back out counts.
+        delta = jnp.diff(ln_qc_true)
+        p_del = jnp.array([0.5, 1.0, 1.0, 1.0])
+        beta_f = float(jnp.exp(log_f) * beta)
+        p_ins_core = beta_f * jnp.exp(delta) * p_del[1:]
+        p_ins = jnp.concatenate([p_ins_core, jnp.zeros(1)])
+
+        n_trials = jnp.full(4, 1000, dtype=jnp.int32)
+        # P = acc / (n_ins + n_del) ⇒ acc = P · 2 · n.
+        acc_ins = p_ins * (2 * n_trials.astype(jnp.float64))
+        acc_del = p_del * (2 * n_trials.astype(jnp.float64))
+
+        cumulants = EnergyCumulants(
+            mean=jnp.zeros(4),
+            variance=jnp.zeros(4),
+            third=jnp.zeros(4),
+            fourth=jnp.zeros(4),
+        )
+        summary = TMMCSummary.from_transition_statistics(
+            acc_ins,
+            acc_del,
+            n_trials,
+            n_trials,
+            cumulants=cumulants,
+            beta_sim=beta,
+            log_fugacity_sim=log_f,
+            adsorbate=_CO2,
+            order=1,
+        )
+        npt.assert_allclose(
+            summary.log_partition_fn_sim, ln_qc_true, rtol=1e-10, atol=1e-10
+        )
+
+    def test_methods_dispatch_to_module_level_functions(self):
+        """Sanity: summary methods produce the same values as calling the functions."""
+        ln_qc_sim = jnp.array([0.0, -2.0, -3.5, -4.5])
+        cumulants = EnergyCumulants(
+            mean=jnp.zeros(4),
+            variance=jnp.zeros(4),
+            third=jnp.zeros(4),
+            fourth=jnp.zeros(4),
+        )
+        beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
+        summary = TMMCSummary(
+            log_partition_fn_sim=ln_qc_sim,
+            cumulants=cumulants,
+            beta_sim=beta_sim,
+            adsorbate=_CO2,
+            order=1,
+        )
+        pressures = jnp.array([1e4, 1e5])
+        via_method = summary.isotherm(pressures, jnp.asarray(300.0))
+        via_function = isotherm(
+            summary.extrapolate(beta_sim),
+            beta_sim,
+            pressures,
+            jnp.asarray(300.0),
+            _CO2.critical_pressure,
+            _CO2.critical_temperature,
+            _CO2.acentric_factor,
+        )
+        npt.assert_allclose(via_method, via_function, rtol=1e-10)

--- a/test/mcmc/test_flat_histogram.py
+++ b/test/mcmc/test_flat_histogram.py
@@ -168,9 +168,9 @@ class TestExtrapolate:
             mean=jnp.array([1.0, 2.0, 3.0]),
             cumulants=jnp.array(
                 [
-                    [0.1, 0.2, 0.3],
-                    [0.01, 0.02, 0.03],
-                    [0.001, 0.002, 0.003],
+                    [0.1, 0.01, 0.001],
+                    [0.2, 0.02, 0.002],
+                    [0.3, 0.03, 0.003],
                 ]
             ),
         )
@@ -183,7 +183,7 @@ class TestExtrapolate:
     @pytest.mark.parametrize("order", [0, 5, -1])
     def test_invalid_order_raises(self, order: int):
         cumulants = EnergyCumulants(
-            mean=jnp.array([0.0]), cumulants=jnp.zeros((3, 1))
+            mean=jnp.array([0.0]), cumulants=jnp.zeros((1, 3))
         )
         with pytest.raises(ValueError):
             extrapolate_log_partition_fn(
@@ -268,7 +268,8 @@ class TestIsostericHeat:
         cumulants = EnergyCumulants(
             mean=jnp.array([0.0, -0.2, -0.35, -0.5]),
             cumulants=jnp.stack(
-                [jnp.array([0.0, 0.01, 0.02, 0.03]), jnp.zeros(4), jnp.zeros(4)]
+                [jnp.array([0.0, 0.01, 0.02, 0.03]), jnp.zeros(4), jnp.zeros(4)],
+                axis=-1,
             ),
         )
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
@@ -305,7 +306,8 @@ class TestIsostericHeat:
         cumulants = EnergyCumulants(
             mean=jnp.array([0.0, -0.2, -0.35, -0.5]),
             cumulants=jnp.stack(
-                [jnp.array([0.0, 0.01, 0.02, 0.03]), jnp.zeros(4), jnp.zeros(4)]
+                [jnp.array([0.0, 0.01, 0.02, 0.03]), jnp.zeros(4), jnp.zeros(4)],
+                axis=-1,
             ),
         )
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
@@ -355,7 +357,7 @@ class TestWorkingCapacity:
     def test_swing_loading_difference(self):
         """n_wc = ⟨N⟩_ads - ⟨N⟩_des; both terms come from the same summary."""
         log_qc_sim = jnp.linspace(0.0, -4.0, 5)
-        cumulants = EnergyCumulants(mean=jnp.zeros(5), cumulants=jnp.zeros((3, 5)))
+        cumulants = EnergyCumulants(mean=jnp.zeros(5), cumulants=jnp.zeros((5, 3)))
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
         n_wc = working_capacity_from_log_partition_fn(
             log_qc_sim,
@@ -433,7 +435,7 @@ class TestAnalyticalLangmuirRoundTrip:
 
         # Cumulants aren't exercised here (β_target == β_sim); pass zeros.
         cumulants = EnergyCumulants(
-            mean=jnp.zeros(M + 1), cumulants=jnp.zeros((3, M + 1))
+            mean=jnp.zeros(M + 1), cumulants=jnp.zeros((M + 1, 3))
         )
         summary = TMMCSummary.from_transition_statistics(
             TransitionStatistics(acc_ins, acc_del, n_trials, n_trials),
@@ -490,7 +492,7 @@ class TestTMMCSummary:
         acc_ins = p_ins * (2 * n_trials.astype(float))
         acc_del = p_del * (2 * n_trials.astype(float))
 
-        cumulants = EnergyCumulants(mean=jnp.zeros(4), cumulants=jnp.zeros((3, 4)))
+        cumulants = EnergyCumulants(mean=jnp.zeros(4), cumulants=jnp.zeros((4, 3)))
         summary = TMMCSummary.from_transition_statistics(
             TransitionStatistics(acc_ins, acc_del, n_trials, n_trials),
             cumulants=cumulants,
@@ -506,7 +508,7 @@ class TestTMMCSummary:
     def test_methods_dispatch_to_module_level_functions(self):
         """Sanity: summary methods produce the same values as calling the functions."""
         ln_qc_sim = jnp.array([0.0, -2.0, -3.5, -4.5])
-        cumulants = EnergyCumulants(mean=jnp.zeros(4), cumulants=jnp.zeros((3, 4)))
+        cumulants = EnergyCumulants(mean=jnp.zeros(4), cumulants=jnp.zeros((4, 3)))
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
         summary = TMMCSummary(
             log_partition_fn_sim=ln_qc_sim,

--- a/test/mcmc/test_flat_histogram.py
+++ b/test/mcmc/test_flat_histogram.py
@@ -18,15 +18,15 @@ from kups.mcmc.flat_histogram import (
     TMMCSummary,
     average_loading,
     extrapolate_log_partition_fn,
-    isosteric_heat,
-    isotherm,
+    isosteric_heat_from_log_partition_fn,
+    isotherm_from_log_partition_fn,
     macrostate_distribution,
     reconstruct_log_partition_fn,
     transition_probabilities,
-    working_capacity,
+    working_capacity_from_log_partition_fn,
 )
 from kups.mcmc.fugacity import peng_robinson_log_fugacity
-from kups.mcmc.widom import EnergyCumulants
+from kups.mcmc.widom import EnergyCumulants, TransitionStatistics
 
 # CO2-like EOS parameters for integration tests.
 _CO2 = AdsorbateEOS(
@@ -43,17 +43,19 @@ class TestTransitionProbabilities:
     def test_normalises_by_total_trials(self):
         acc_ins = jnp.array([1.0, 2.0, 0.5])
         acc_del = jnp.array([0.0, 1.0, 0.3])
-        n_ins = jnp.array([4, 4, 4], dtype=jnp.int32)
-        n_del = jnp.array([4, 4, 4], dtype=jnp.int32)
-        p_ins, p_del = transition_probabilities(acc_ins, acc_del, n_ins, n_del)
+        n_ins = jnp.array([4, 4, 4], dtype=int)
+        n_del = jnp.array([4, 4, 4], dtype=int)
+        p_ins, p_del = transition_probabilities(
+            TransitionStatistics(acc_ins, acc_del, n_ins, n_del)
+        )
         npt.assert_allclose(p_ins, acc_ins / 8.0)
         npt.assert_allclose(p_del, acc_del / 8.0)
 
     def test_safe_at_zero_trials(self):
         """No divide-by-zero when a macrostate was never visited."""
         acc = jnp.zeros(3)
-        n = jnp.zeros(3, dtype=jnp.int32)
-        p_ins, p_del = transition_probabilities(acc, acc, n, n)
+        n = jnp.zeros(3, dtype=int)
+        p_ins, p_del = transition_probabilities(TransitionStatistics(acc, acc, n, n))
         npt.assert_array_equal(p_ins, jnp.zeros(3))
         npt.assert_array_equal(p_del, jnp.zeros(3))
 
@@ -101,11 +103,16 @@ class TestExtrapolate:
 
         # Build derivatives ⟨E⟩=-dln Q/dβ, Var=d²ln Q/dβ², κ_3=d³ln Q/dβ³.
         dlnq_dbeta = c1 + 2 * c2 * beta_0 + 3 * c3 * beta_0**2
+        # kappa_2 = d²lnQ/dβ², kappa_3 = -d³lnQ/dβ³ (standard cumulants).
         cumulants = EnergyCumulants(
             mean=jnp.asarray(-dlnq_dbeta),
-            variance=jnp.asarray(2 * c2 + 6 * c3 * beta_0),
-            third=jnp.asarray(6 * c3),
-            fourth=jnp.asarray(0.0),
+            cumulants=jnp.stack(
+                [
+                    jnp.asarray(2 * c2 + 6 * c3 * beta_0),
+                    jnp.asarray(-6 * c3),
+                    jnp.asarray(0.0),
+                ]
+            ),
         )
         log_qc_sim = jnp.asarray(true_log_qc(beta_0))
         for beta_target in [2.0, 2.1, 1.8, 3.0]:
@@ -120,12 +127,52 @@ class TestExtrapolate:
                 float(result), true_log_qc(beta_target), rtol=1e-10, atol=1e-10
             )
 
+    def test_quintic_ln_qc_is_exact_at_order_5(self):
+        r"""Arbitrary-degree extrapolation: a quintic $\ln Q_c(\beta)$ is exact
+        at order 5 when the cumulants encode its derivatives."""
+        beta_0 = 1.5
+        coeffs = [0.3, -2.0, 0.9, -0.25, 0.05, -0.004]  # c_0 .. c_5
+
+        def true_log_qc(beta: float) -> float:
+            return sum(c * beta**j for j, c in enumerate(coeffs))
+
+        def derivative(k: int) -> float:
+            return sum(
+                c * (math.factorial(j) // math.factorial(j - k)) * beta_0 ** (j - k)
+                for j, c in enumerate(coeffs)
+                if j >= k
+            )
+
+        # kappa_k = (-1)^k d^k lnQ/dbeta^k (standard cumulants).
+        cumulants = EnergyCumulants(
+            mean=jnp.asarray(-derivative(1)),
+            cumulants=jnp.stack(
+                [jnp.asarray((-1.0) ** k * derivative(k)) for k in range(2, 6)]
+            ),
+        )
+        log_qc_sim = jnp.asarray(true_log_qc(beta_0))
+        for beta_target in [1.5, 1.2, 2.0]:
+            result = extrapolate_log_partition_fn(
+                log_qc_sim,
+                cumulants,
+                jnp.asarray(beta_0),
+                jnp.asarray(beta_target),
+                order=5,
+            )
+            npt.assert_allclose(
+                float(result), true_log_qc(beta_target), rtol=1e-10, atol=1e-10
+            )
+
     def test_zero_displacement_returns_simulation_value(self):
         cumulants = EnergyCumulants(
             mean=jnp.array([1.0, 2.0, 3.0]),
-            variance=jnp.array([0.1, 0.2, 0.3]),
-            third=jnp.array([0.01, 0.02, 0.03]),
-            fourth=jnp.array([0.001, 0.002, 0.003]),
+            cumulants=jnp.array(
+                [
+                    [0.1, 0.2, 0.3],
+                    [0.01, 0.02, 0.03],
+                    [0.001, 0.002, 0.003],
+                ]
+            ),
         )
         log_qc = jnp.array([0.0, -1.0, -2.0])
         result = extrapolate_log_partition_fn(
@@ -136,10 +183,7 @@ class TestExtrapolate:
     @pytest.mark.parametrize("order", [0, 5, -1])
     def test_invalid_order_raises(self, order: int):
         cumulants = EnergyCumulants(
-            mean=jnp.array([0.0]),
-            variance=jnp.array([0.0]),
-            third=jnp.array([0.0]),
-            fourth=jnp.array([0.0]),
+            mean=jnp.array([0.0]), cumulants=jnp.zeros((3, 1))
         )
         with pytest.raises(ValueError):
             extrapolate_log_partition_fn(
@@ -185,7 +229,7 @@ class TestIsotherm:
     def test_shape_matches_pressure_grid(self):
         log_qc = jnp.array([0.0, -1.0, -2.0, -2.5])
         pressures = jnp.array([1e4, 1e5, 1e6])
-        loadings = isotherm(
+        loadings = isotherm_from_log_partition_fn(
             log_qc,
             jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0)),
             pressures,
@@ -202,7 +246,7 @@ class TestIsotherm:
         """⟨N⟩ must be non-decreasing in P for a fixed-site attractive model."""
         log_qc = jnp.linspace(0.0, -10.0, 6)  # increasingly favourable binding
         pressures = jnp.logspace(3, 7, 10)
-        loadings = isotherm(
+        loadings = isotherm_from_log_partition_fn(
             log_qc,
             jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0)),
             pressures,
@@ -223,14 +267,14 @@ class TestIsostericHeat:
         log_qc_sim = jnp.array([0.0, -3.0, -5.0, -6.0])
         cumulants = EnergyCumulants(
             mean=jnp.array([0.0, -0.2, -0.35, -0.5]),
-            variance=jnp.array([0.0, 0.01, 0.02, 0.03]),
-            third=jnp.zeros(4),
-            fourth=jnp.zeros(4),
+            cumulants=jnp.stack(
+                [jnp.array([0.0, 0.01, 0.02, 0.03]), jnp.zeros(4), jnp.zeros(4)]
+            ),
         )
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
         pressures = jnp.array([1e4, 1e5, 1e6])
 
-        q = isosteric_heat(
+        q = isosteric_heat_from_log_partition_fn(
             log_qc_sim,
             cumulants,
             beta_sim,
@@ -260,9 +304,9 @@ class TestIsostericHeat:
         log_qc_sim = jnp.array([0.0, -3.0, -5.0, -6.0])
         cumulants = EnergyCumulants(
             mean=jnp.array([0.0, -0.2, -0.35, -0.5]),
-            variance=jnp.array([0.0, 0.01, 0.02, 0.03]),
-            third=jnp.zeros(4),
-            fourth=jnp.zeros(4),
+            cumulants=jnp.stack(
+                [jnp.array([0.0, 0.01, 0.02, 0.03]), jnp.zeros(4), jnp.zeros(4)]
+            ),
         )
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
         T = 300.0
@@ -290,7 +334,7 @@ class TestIsostericHeat:
         dlogP_fd = (loading(T, log_P + h_lp) - loading(T, log_P - h_lp)) / (2.0 * h_lp)
         q_fd = BOLTZMANN_CONSTANT * T**2 * dT_fd / dlogP_fd
 
-        q_ad = isosteric_heat(
+        q_ad = isosteric_heat_from_log_partition_fn(
             log_qc_sim,
             cumulants,
             beta_sim,
@@ -311,14 +355,9 @@ class TestWorkingCapacity:
     def test_swing_loading_difference(self):
         """n_wc = ⟨N⟩_ads - ⟨N⟩_des; both terms come from the same summary."""
         log_qc_sim = jnp.linspace(0.0, -4.0, 5)
-        cumulants = EnergyCumulants(
-            mean=jnp.zeros(5),
-            variance=jnp.zeros(5),
-            third=jnp.zeros(5),
-            fourth=jnp.zeros(5),
-        )
+        cumulants = EnergyCumulants(mean=jnp.zeros(5), cumulants=jnp.zeros((3, 5)))
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
-        n_wc = working_capacity(
+        n_wc = working_capacity_from_log_partition_fn(
             log_qc_sim,
             cumulants,
             beta_sim,
@@ -388,22 +427,16 @@ class TestAnalyticalLangmuirRoundTrip:
         p_ins_core = p_del[1:] * jnp.exp(delta + log_f_sim + jnp.log(beta))
         p_ins = jnp.concatenate([p_ins_core, jnp.zeros(1)])
 
-        n_trials = jnp.full(M + 1, 10_000, dtype=jnp.int32)
-        acc_ins = p_ins * 2 * n_trials.astype(jnp.float64)
-        acc_del = p_del * 2 * n_trials.astype(jnp.float64)
+        n_trials = jnp.full(M + 1, 10_000, dtype=int)
+        acc_ins = p_ins * 2 * n_trials.astype(float)
+        acc_del = p_del * 2 * n_trials.astype(float)
 
         # Cumulants aren't exercised here (β_target == β_sim); pass zeros.
         cumulants = EnergyCumulants(
-            mean=jnp.zeros(M + 1),
-            variance=jnp.zeros(M + 1),
-            third=jnp.zeros(M + 1),
-            fourth=jnp.zeros(M + 1),
+            mean=jnp.zeros(M + 1), cumulants=jnp.zeros((3, M + 1))
         )
         summary = TMMCSummary.from_transition_statistics(
-            acc_ins,
-            acc_del,
-            n_trials,
-            n_trials,
+            TransitionStatistics(acc_ins, acc_del, n_trials, n_trials),
             cumulants=cumulants,
             beta_sim=jnp.asarray(beta),
             log_fugacity_sim=log_f_sim,
@@ -452,22 +485,14 @@ class TestTMMCSummary:
         p_ins_core = beta_f * jnp.exp(delta) * p_del[1:]
         p_ins = jnp.concatenate([p_ins_core, jnp.zeros(1)])
 
-        n_trials = jnp.full(4, 1000, dtype=jnp.int32)
+        n_trials = jnp.full(4, 1000, dtype=int)
         # P = acc / (n_ins + n_del) ⇒ acc = P · 2 · n.
-        acc_ins = p_ins * (2 * n_trials.astype(jnp.float64))
-        acc_del = p_del * (2 * n_trials.astype(jnp.float64))
+        acc_ins = p_ins * (2 * n_trials.astype(float))
+        acc_del = p_del * (2 * n_trials.astype(float))
 
-        cumulants = EnergyCumulants(
-            mean=jnp.zeros(4),
-            variance=jnp.zeros(4),
-            third=jnp.zeros(4),
-            fourth=jnp.zeros(4),
-        )
+        cumulants = EnergyCumulants(mean=jnp.zeros(4), cumulants=jnp.zeros((3, 4)))
         summary = TMMCSummary.from_transition_statistics(
-            acc_ins,
-            acc_del,
-            n_trials,
-            n_trials,
+            TransitionStatistics(acc_ins, acc_del, n_trials, n_trials),
             cumulants=cumulants,
             beta_sim=beta,
             log_fugacity_sim=log_f,
@@ -481,12 +506,7 @@ class TestTMMCSummary:
     def test_methods_dispatch_to_module_level_functions(self):
         """Sanity: summary methods produce the same values as calling the functions."""
         ln_qc_sim = jnp.array([0.0, -2.0, -3.5, -4.5])
-        cumulants = EnergyCumulants(
-            mean=jnp.zeros(4),
-            variance=jnp.zeros(4),
-            third=jnp.zeros(4),
-            fourth=jnp.zeros(4),
-        )
+        cumulants = EnergyCumulants(mean=jnp.zeros(4), cumulants=jnp.zeros((3, 4)))
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
         summary = TMMCSummary(
             log_partition_fn_sim=ln_qc_sim,
@@ -497,7 +517,7 @@ class TestTMMCSummary:
         )
         pressures = jnp.array([1e4, 1e5])
         via_method = summary.isotherm(pressures, jnp.asarray(300.0))
-        via_function = isotherm(
+        via_function = isotherm_from_log_partition_fn(
             summary.extrapolate(beta_sim),
             beta_sim,
             pressures,

--- a/test/mcmc/test_flat_histogram.py
+++ b/test/mcmc/test_flat_histogram.py
@@ -182,9 +182,7 @@ class TestExtrapolate:
 
     @pytest.mark.parametrize("order", [0, 5, -1])
     def test_invalid_order_raises(self, order: int):
-        cumulants = EnergyCumulants(
-            mean=jnp.array([0.0]), cumulants=jnp.zeros((1, 3))
-        )
+        cumulants = EnergyCumulants(mean=jnp.array([0.0]), cumulants=jnp.zeros((1, 3)))
         with pytest.raises(ValueError):
             extrapolate_log_partition_fn(
                 jnp.array([0.0]),

--- a/test/mcmc/test_flat_histogram.py
+++ b/test/mcmc/test_flat_histogram.py
@@ -17,13 +17,13 @@ from kups.mcmc.flat_histogram import (
     AdsorbateEOS,
     TMMCSummary,
     average_loading,
-    extrapolate_log_partition_fn,
-    isosteric_heat_from_log_partition_fn,
-    isotherm_from_log_partition_fn,
+    extrapolate_log_partition,
+    isosteric_heat_from_log_partition,
+    isotherm_from_log_partition,
     macrostate_distribution,
-    reconstruct_log_partition_fn,
+    reconstruct_log_partition,
     transition_probabilities,
-    working_capacity_from_log_partition_fn,
+    working_capacity_from_log_partition,
 )
 from kups.mcmc.fugacity import peng_robinson_log_fugacity
 from kups.mcmc.widom import EnergyCumulants, TransitionStatistics
@@ -60,10 +60,10 @@ class TestTransitionProbabilities:
         npt.assert_array_equal(p_del, jnp.zeros(3))
 
 
-# -- reconstruct_log_partition_fn ---------------------------------------
+# -- reconstruct_log_partition ---------------------------------------
 
 
-class TestReconstructLogPartitionFn:
+class TestReconstructLogPartition:
     def test_roundtrip_from_known_log_qc(self):
         """Given ln Q_c, construct P_ins/P_del from detailed balance and recover it."""
         ln_qc_true = jnp.array([0.0, -1.0, -2.5, -4.0, -5.0])
@@ -77,19 +77,19 @@ class TestReconstructLogPartitionFn:
         p_ins_core = beta * beta_f * jnp.exp(delta_true) * p_del[1:]
         p_ins_full = jnp.concatenate([p_ins_core, jnp.zeros(1)])
 
-        reconstructed = reconstruct_log_partition_fn(p_ins_full, p_del, beta, log_f)
+        reconstructed = reconstruct_log_partition(p_ins_full, p_del, beta, log_f)
         npt.assert_allclose(reconstructed, ln_qc_true, rtol=1e-10, atol=1e-12)
 
     def test_anchors_to_zero_at_N0(self):
         p_ins = jnp.array([0.1, 0.2, 0.0])
         p_del = jnp.array([0.5, 0.3, 0.4])
-        result = reconstruct_log_partition_fn(
+        result = reconstruct_log_partition(
             p_ins, p_del, jnp.asarray(1.0), jnp.asarray(0.0)
         )
         assert float(result[0]) == 0.0
 
 
-# -- extrapolate_log_partition_fn ---------------------------------------
+# -- extrapolate_log_partition ---------------------------------------
 
 
 class TestExtrapolate:
@@ -116,7 +116,7 @@ class TestExtrapolate:
         )
         log_qc_sim = jnp.asarray(true_log_qc(beta_0))
         for beta_target in [2.0, 2.1, 1.8, 3.0]:
-            result = extrapolate_log_partition_fn(
+            result = extrapolate_log_partition(
                 log_qc_sim,
                 cumulants,
                 jnp.asarray(beta_0),
@@ -152,7 +152,7 @@ class TestExtrapolate:
         )
         log_qc_sim = jnp.asarray(true_log_qc(beta_0))
         for beta_target in [1.5, 1.2, 2.0]:
-            result = extrapolate_log_partition_fn(
+            result = extrapolate_log_partition(
                 log_qc_sim,
                 cumulants,
                 jnp.asarray(beta_0),
@@ -175,7 +175,7 @@ class TestExtrapolate:
             ),
         )
         log_qc = jnp.array([0.0, -1.0, -2.0])
-        result = extrapolate_log_partition_fn(
+        result = extrapolate_log_partition(
             log_qc, cumulants, jnp.asarray(1.0), jnp.asarray(1.0), order=4
         )
         npt.assert_allclose(result, log_qc, rtol=1e-12)
@@ -184,7 +184,7 @@ class TestExtrapolate:
     def test_invalid_order_raises(self, order: int):
         cumulants = EnergyCumulants(mean=jnp.array([0.0]), cumulants=jnp.zeros((1, 3)))
         with pytest.raises(ValueError):
-            extrapolate_log_partition_fn(
+            extrapolate_log_partition(
                 jnp.array([0.0]),
                 cumulants,
                 jnp.asarray(1.0),
@@ -227,7 +227,7 @@ class TestIsotherm:
     def test_shape_matches_pressure_grid(self):
         log_qc = jnp.array([0.0, -1.0, -2.0, -2.5])
         pressures = jnp.array([1e4, 1e5, 1e6])
-        loadings = isotherm_from_log_partition_fn(
+        loadings = isotherm_from_log_partition(
             log_qc,
             jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0)),
             pressures,
@@ -244,7 +244,7 @@ class TestIsotherm:
         """⟨N⟩ must be non-decreasing in P for a fixed-site attractive model."""
         log_qc = jnp.linspace(0.0, -10.0, 6)  # increasingly favourable binding
         pressures = jnp.logspace(3, 7, 10)
-        loadings = isotherm_from_log_partition_fn(
+        loadings = isotherm_from_log_partition(
             log_qc,
             jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0)),
             pressures,
@@ -273,7 +273,7 @@ class TestIsostericHeat:
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
         pressures = jnp.array([1e4, 1e5, 1e6])
 
-        q = isosteric_heat_from_log_partition_fn(
+        q = isosteric_heat_from_log_partition(
             log_qc_sim,
             cumulants,
             beta_sim,
@@ -298,7 +298,7 @@ class TestIsostericHeat:
         A regression in either would show up as a divergence between the
         autodiff Clausius--Clapeyron result and local finite differences.
         """
-        from kups.mcmc.flat_histogram import _loading_from_T_logP
+        from kups.mcmc.flat_histogram import _loading_from_temperature_log_pressure
 
         log_qc_sim = jnp.array([0.0, -3.0, -5.0, -6.0])
         cumulants = EnergyCumulants(
@@ -315,7 +315,7 @@ class TestIsostericHeat:
 
         def loading(t: float, lp: float) -> float:
             return float(
-                _loading_from_T_logP(
+                _loading_from_temperature_log_pressure(
                     jnp.asarray(t),
                     jnp.asarray(lp),
                     log_qc_sim,
@@ -334,7 +334,7 @@ class TestIsostericHeat:
         dlogP_fd = (loading(T, log_P + h_lp) - loading(T, log_P - h_lp)) / (2.0 * h_lp)
         q_fd = BOLTZMANN_CONSTANT * T**2 * dT_fd / dlogP_fd
 
-        q_ad = isosteric_heat_from_log_partition_fn(
+        q_ad = isosteric_heat_from_log_partition(
             log_qc_sim,
             cumulants,
             beta_sim,
@@ -357,7 +357,7 @@ class TestWorkingCapacity:
         log_qc_sim = jnp.linspace(0.0, -4.0, 5)
         cumulants = EnergyCumulants(mean=jnp.zeros(5), cumulants=jnp.zeros((5, 3)))
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
-        n_wc = working_capacity_from_log_partition_fn(
+        n_wc = working_capacity_from_log_partition(
             log_qc_sim,
             cumulants,
             beta_sim,
@@ -390,7 +390,7 @@ class TestAnalyticalLangmuirRoundTrip:
     then run the full pipeline:
 
     C-matrix $\\to$ :func:`transition_probabilities` $\\to$
-    :func:`reconstruct_log_partition_fn` $\\to$
+    :func:`reconstruct_log_partition` $\\to$
     :class:`TMMCSummary` $\\to$ :func:`isotherm`.
 
     The resulting $\\langle N\\rangle(P)$ is compared against the closed-form
@@ -445,9 +445,7 @@ class TestAnalyticalLangmuirRoundTrip:
         )
 
         # ln Q_c must round-trip exactly.
-        npt.assert_allclose(
-            summary.log_partition_fn_sim, log_qc_true, atol=1e-12, rtol=0
-        )
+        npt.assert_allclose(summary.log_partition_sim, log_qc_true, atol=1e-12, rtol=0)
 
         # Isotherm at several pressures must match the closed-form Langmuir.
         pressures = jnp.logspace(2, 7, 6)
@@ -500,7 +498,7 @@ class TestTMMCSummary:
             order=1,
         )
         npt.assert_allclose(
-            summary.log_partition_fn_sim, ln_qc_true, rtol=1e-10, atol=1e-10
+            summary.log_partition_sim, ln_qc_true, rtol=1e-10, atol=1e-10
         )
 
     def test_methods_dispatch_to_module_level_functions(self):
@@ -509,7 +507,7 @@ class TestTMMCSummary:
         cumulants = EnergyCumulants(mean=jnp.zeros(4), cumulants=jnp.zeros((4, 3)))
         beta_sim = jnp.asarray(1.0 / (BOLTZMANN_CONSTANT * 300.0))
         summary = TMMCSummary(
-            log_partition_fn_sim=ln_qc_sim,
+            log_partition_sim=ln_qc_sim,
             cumulants=cumulants,
             beta_sim=beta_sim,
             adsorbate=_CO2,
@@ -517,7 +515,7 @@ class TestTMMCSummary:
         )
         pressures = jnp.array([1e4, 1e5])
         via_method = summary.isotherm(pressures, jnp.asarray(300.0))
-        via_function = isotherm_from_log_partition_fn(
+        via_function = isotherm_from_log_partition(
             summary.extrapolate(beta_sim),
             beta_sim,
             pressures,


### PR DESCRIPTION
`kups.mcmc.flat_histogram`: pure-function post-processing for TMMC adsorption data —

- Reconstructs `ln Q_c(N, V, β_sim)` from the C-matrix as a single `cumsum` (Witman 2018 eq 7–8).
- Taylor-extrapolates in β using the collected energy cumulants (eq 9–10).
- Derives adsorption isotherms, isosteric heats (Clausius–Clapeyron via `jax.grad` through the Peng-Robinson EOS — no `delta_T` hyperparameter; relies on the autodiff-safe `cubic_roots` lower in the stack), and working capacities.
- `TMMCSummary` bundles the reconstruction + EOS parameters for one-call post-hoc use.

Tests: transition-probability normalisation, Langmuir analytical round-trip to machine precision, extrapolation order behaviour, isosteric heat vs central differences, isotherm monotonicity. Everything is vectorised over pressure grids; no entry-point coupling.

Part of the TMMC stack split out of #17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)