### PR TITLE
refactor: route per-node energy reduction through a Decomposition strategy

### DIFF
--- a/src/kups/potential/classical/cosine_angle.py
+++ b/src/kups/potential/classical/cosine_angle.py
@@ -212,7 +212,7 @@ def cosine_angle_energy(
 
     edge_energy = jnp.where(is_linear, energy_linear, energy_general)
 
-    total_energies = graph.edge_batch_mask.sum_over(edge_energy)
+    total_energies = graph.reduce_edges_to_systems(edge_energy)
     return WithPatch(total_energies, IdPatch[Any]())
 
 

--- a/src/kups/potential/classical/coulomb.py
+++ b/src/kups/potential/classical/coulomb.py
@@ -72,7 +72,7 @@ def _pairwise_coulomb_energy(
     edg = inp.graph.particles[inp.graph.edges.indices]
     qij = edg.charges[:, 0] * edg.charges[:, 1]
     dists = jnp.linalg.norm(inp.graph.edge_shifts[:, 0], axis=-1)
-    energies = inp.graph.edge_batch_mask.sum_over(qij / dists) / 2 * TO_STANDARD_UNITS
+    energies = inp.graph.reduce_edges_to_systems(qij / dists) / 2 * TO_STANDARD_UNITS
     assert len(energies) == inp.graph.batch_size
     return WithPatch(energies, IdPatch[Any]())
 

--- a/src/kups/potential/classical/dihedral.py
+++ b/src/kups/potential/classical/dihedral.py
@@ -264,7 +264,7 @@ def dihedral_energy(
     # UFF torsion energy: U(phi) = 1/2 V [1 - cos(n*phi0)*cos(n*phi)]
     edge_energy = 0.5 * V * (1.0 - jnp.cos(n * phi0) * jnp.cos(n * phi))
 
-    total_energies = graph.edge_batch_mask.sum_over(edge_energy)
+    total_energies = graph.reduce_edges_to_systems(edge_energy)
     return WithPatch(total_energies, IdPatch[Any]())
 
 

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -303,22 +303,16 @@ def ewald_self_interaction_energy(
 
     Math: ``E_self = -alpha / sqrt(pi) * sum_i q_i^2 * TO_STANDARD_UNITS``.
 
-    Summed per system via segment_sum. Positions in Ang, charges in e,
-    energy in eV.
+    Computed per atom and reduced with ``reduce_nodes_to_systems`` so the
+    reduction counts owned rows only under decomposition. Positions in Ang,
+    charges in e, energy in eV.
     """
-    sys_idx = inp.graph.systems.index
-    energies = (
-        -segment_sum(
-            inp.graph.particles.data.charges**2,
-            inp.graph.particles.data.system.indices,
-            inp.graph.batch_size,
-            mode="drop",
-        )
-        * inp.parameters.alpha[sys_idx]
-        / jnp.sqrt(jnp.pi)
+    particles = inp.graph.particles.data
+    alpha_per_atom = inp.parameters.alpha[particles.system]
+    per_atom = (
+        -(particles.charges**2) * alpha_per_atom / jnp.sqrt(jnp.pi) * TO_STANDARD_UNITS
     )
-    energies *= TO_STANDARD_UNITS
-    return WithPatch(Table.arange(energies, label=SystemId), IdPatch[Any]())
+    return WithPatch(inp.graph.reduce_nodes_to_systems(per_atom), IdPatch[Any]())
 
 
 def ewald_short_range_energy(
@@ -340,7 +334,7 @@ def ewald_short_range_energy(
     energies = qij * erfc / dists
     mask = dists < inp.parameters.cutoff[edge_systems]
     energies *= mask
-    total = inp.graph.edge_batch_mask.sum_over(energies) / 2 * TO_STANDARD_UNITS
+    total = inp.graph.reduce_edges_to_systems(energies) / 2 * TO_STANDARD_UNITS
     return WithPatch(total, IdPatch[Any]())
 
 

--- a/src/kups/potential/classical/harmonic.py
+++ b/src/kups/potential/classical/harmonic.py
@@ -98,7 +98,7 @@ def harmonic_bond_energy(
     x0 = inp.parameters.x0[edg_species[:, 0], edg_species[:, 1]]
     k = inp.parameters.k[edg_species[:, 0], edg_species[:, 1]]
     edge_energy = (jnp.linalg.norm(graph.edge_shifts[:, 0], axis=-1) - x0) ** 2 * k
-    total_energies = graph.edge_batch_mask.sum_over(edge_energy)
+    total_energies = graph.reduce_edges_to_systems(edge_energy)
     return WithPatch(total_energies, IdPatch[Any]())
 
 
@@ -154,7 +154,7 @@ def harmonic_angle_energy(
     )
     angle = jnp.rad2deg(angle)
     edge_energy = (angle - theta0) ** 2 * k
-    total_energies = graph.edge_batch_mask.sum_over(edge_energy)
+    total_energies = graph.reduce_edges_to_systems(edge_energy)
     return WithPatch(total_energies, IdPatch[Any]())
 
 

--- a/src/kups/potential/classical/inversion.py
+++ b/src/kups/potential/classical/inversion.py
@@ -198,7 +198,7 @@ def inversion_energy(
     )
     edge_energy = k_scaled * (c0 + c1 * cos_omega + c2 * cos_2omega)
 
-    total_energies = graph.edge_batch_mask.sum_over(edge_energy)
+    total_energies = graph.reduce_edges_to_systems(edge_energy)
     return WithPatch(total_energies, IdPatch[Any]())
 
 

--- a/src/kups/potential/classical/lennard_jones.py
+++ b/src/kups/potential/classical/lennard_jones.py
@@ -170,7 +170,7 @@ def lennard_jones_energy(
     """Compute total Lennard-Jones energy per system."""
     graph = inp.graph
     edge_energy = lennard_jones_edge_energy(inp)
-    total_energies = graph.edge_batch_mask.sum_over(edge_energy) / 2
+    total_energies = graph.reduce_edges_to_systems(edge_energy) / 2
     return WithPatch(total_energies, IdPatch[Any]())
 
 
@@ -214,7 +214,7 @@ def pair_tail_corrected_lennard_jones_energy(
         mask, edge_energy * factor1 * factor2 / div, edge_energy
     )
     corrected_edge_energy = jnp.where(remove, 0.0, corrected_edge_energy)
-    total_energies = batch.sum_over(corrected_edge_energy) / 2
+    total_energies = graph.reduce_edges_to_systems(corrected_edge_energy) / 2
     return WithPatch(total_energies, IdPatch[Any]())
 
 

--- a/src/kups/potential/classical/morse.py
+++ b/src/kups/potential/classical/morse.py
@@ -159,7 +159,7 @@ def morse_bond_energy(
     alpha = inp.parameters.alpha[edg_species[:, 0], edg_species[:, 1]]
     r = jnp.linalg.norm(graph.edge_shifts[:, 0], axis=-1)
     edge_energy = D * (1 - jnp.exp(-alpha * (r - r0))) ** 2
-    total_energies = graph.edge_batch_mask.sum_over(edge_energy)
+    total_energies = graph.reduce_edges_to_systems(edge_energy)
     return WithPatch(total_energies, IdPatch[Any]())
 
 

--- a/src/kups/potential/common/graph.py
+++ b/src/kups/potential/common/graph.py
@@ -74,9 +74,9 @@ class Decomposition[P: HasPositionsAndSystemIndex](Protocol):
     total, while gradients w.r.t. replicated inputs are already mesh-summed by
     ``shard_map``'s transpose, so only the energy output needs an explicit ``psum``.
 
-    ``P`` appears in input position only (``owned_only`` consumes the particle table), so
-    the Protocol is contravariant in ``P`` — the variance a covariant particle container
-    needs from a strategy field it holds.
+    ``P`` appears in input position only (``owned_only`` consumes the particle table), so a
+    strategy written against ``HasPositionsAndSystemIndex`` is usable for any concrete
+    particle type — which is what lets a bare ``Replicated()`` be the default here.
     """
 
     def owned_only(self, particles: Table[ParticleId, P], x: Array) -> Array:
@@ -111,6 +111,7 @@ class PointCloud(Generic[Part, Sys]):
     Attributes:
         particles: Indexed particle data with positions and system assignment.
         systems: Indexed system data with cell information.
+        decomposition: Placement policy for per-node reductions (``Replicated`` by default).
     """
 
     particles: Table[ParticleId, Part]
@@ -121,11 +122,6 @@ class PointCloud(Generic[Part, Sys]):
     def batch_size(self) -> int:
         return self.particles.data.system.num_labels
 
-    @property
-    def node_batch_mask(self) -> Index[SystemId]:
-        """Per-node system index — the segment for reducing per-node values to per-system totals."""
-        return self.particles.data.system
-
     def reduce_nodes_to_systems(self, node_value: Array) -> Table[SystemId, Array]:
         """Reduce a per-node quantity to per-system totals, counting owned rows only.
 
@@ -134,7 +130,7 @@ class PointCloud(Generic[Part, Sys]):
         the *global* value inline (e.g. the Ewald structure factor) completes it via
         ``self.decomposition.combine_across_shards``.
         """
-        return self.node_batch_mask.sum_over(
+        return self.particles.data.system.sum_over(
             self.decomposition.owned_only(self.particles, node_value)
         )
 

--- a/src/kups/potential/common/graph.py
+++ b/src/kups/potential/common/graph.py
@@ -28,6 +28,7 @@ from typing import (
     Protocol,
     TypeVar,
     overload,
+    override,
     runtime_checkable,
 )
 
@@ -59,6 +60,47 @@ Sys = TypeVar("Sys", covariant=True, bound=HasCell[AnyPeriodicity])
 Degree = TypeVar("Degree", bound=int)
 
 
+class Decomposition[P: HasPositionsAndSystemIndex](Protocol):
+    """Placement policy for per-node reductions: which rows a device counts, how partials combine.
+
+    The single seam through which domain decomposition enters the stock energy functions.
+    Every device holds the full particle table; the policy decides which rows it *counts*
+    when reducing per-node values to per-system totals (``owned_only``) and how a value
+    that must be globally complete inside the energy is combined across the mesh
+    (``combine_across_shards``). ``Replicated`` (the default) makes both the identity, so
+    single-device evaluation is unchanged. The domain-decomposed policy — mask rows to
+    the owning device, ``psum`` across the mesh — is ``Sharded`` in ``kups.core.domain``:
+    per-device energies come out as per-system partials whose mesh sum is the global
+    total, while gradients w.r.t. replicated inputs are already mesh-summed by
+    ``shard_map``'s transpose, so only the energy output needs an explicit ``psum``.
+
+    ``P`` appears in input position only (``owned_only`` consumes the particle table), so
+    the Protocol is contravariant in ``P`` — the variance a covariant particle container
+    needs from a strategy field it holds.
+    """
+
+    def owned_only(self, particles: Table[ParticleId, P], x: Array) -> Array:
+        """Mask rows this device does not own to the fold identity (identity when replicated)."""
+        ...
+
+    def combine_across_shards(self, x: Array) -> Array:
+        """Complete the pending cross-mesh reduction (identity when replicated)."""
+        ...
+
+
+@dataclass
+class Replicated[P: HasPositionsAndSystemIndex](Decomposition[P]):
+    """Whole-graph / single-device baseline: both operations are the identity (the default placement)."""
+
+    @override
+    def owned_only(self, particles: Table[ParticleId, P], x: Array) -> Array:
+        return x
+
+    @override
+    def combine_across_shards(self, x: Array) -> Array:
+        return x
+
+
 @dataclass
 class PointCloud(Generic[Part, Sys]):
     """Indexed particles and systems, the base for all graph representations.
@@ -73,10 +115,28 @@ class PointCloud(Generic[Part, Sys]):
 
     particles: Table[ParticleId, Part]
     systems: Table[SystemId, Sys]
+    decomposition: Decomposition[Part] = field(default_factory=Replicated, kw_only=True)
 
     @property
     def batch_size(self) -> int:
         return self.particles.data.system.num_labels
+
+    @property
+    def node_batch_mask(self) -> Index[SystemId]:
+        """Per-node system index — the segment for reducing per-node values to per-system totals."""
+        return self.particles.data.system
+
+    def reduce_nodes_to_systems(self, node_value: Array) -> Table[SystemId, Array]:
+        """Reduce a per-node quantity to per-system totals, counting owned rows only.
+
+        A plain per-system ``segment_sum`` under ``Replicated``; see ``Decomposition`` for
+        how the sharded policy makes the result a per-device partial. A caller that needs
+        the *global* value inline (e.g. the Ewald structure factor) completes it via
+        ``self.decomposition.combine_across_shards``.
+        """
+        return self.node_batch_mask.sum_over(
+            self.decomposition.owned_only(self.particles, node_value)
+        )
 
 
 @dataclass
@@ -105,6 +165,22 @@ class HyperGraph(PointCloud[Part, Sys], Generic[Part, Sys, Degree]):
     @property
     def edge_batch_mask(self) -> Index[SystemId]:
         return self.particles[self.edges.indices[:, 0]].system
+
+    def aggregate_edges_to_nodes(self, edge_value: Array) -> Array:
+        """Sum each edge's value onto its first participant node → per-node array (length N).
+
+        Degree-agnostic: an edge of any degree is attributed to ``edges.indices[:, 0]``.
+        """
+        return self.edges.indices[:, 0].sum_over(edge_value).data
+
+    def reduce_edges_to_systems(self, edge_value: Array) -> Table[SystemId, Array]:
+        """Reduce a per-edge quantity to per-system totals through its first-node attribution.
+
+        Composes ``aggregate_edges_to_nodes`` with ``reduce_nodes_to_systems``, so the
+        reduction counts owned rows only under decomposition. Any multiplicity (the
+        symmetric pairwise ``/2``) stays an explicit factor at the call site.
+        """
+        return self.reduce_nodes_to_systems(self.aggregate_edges_to_nodes(edge_value))
 
     @overload
     def sorted_by_system(
@@ -159,7 +235,12 @@ class HyperGraph(PointCloud[Part, Sys], Generic[Part, Sys, Degree]):
                 indices=remapped_indices[edge_order],
                 shifts=sorted_edges.shifts[edge_order],
             )
-        result = HyperGraph(sorted_particles, self.systems, sorted_edges)
+        result = HyperGraph(
+            sorted_particles,
+            self.systems,
+            sorted_edges,
+            decomposition=self.decomposition,
+        )
         if return_sort_order:
             return result, sort_order
         return result

--- a/test/core/test_decomposition.py
+++ b/test/core/test_decomposition.py
@@ -1,0 +1,74 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral pins for the `Decomposition` placement strategy.
+
+`Replicated` is the whole-graph null object: `owned_only` and
+`combine_across_shards` must both be the identity, and `owned_only` must be
+shape-preserving for non-scalar per-node payloads. The domain-decomposed
+implementation (`Sharded`) is pinned by its own tests next to
+`kups.core.domain`.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from kups.core.cell import PeriodicCell, TriclinicFrame
+from kups.core.data import Index, Table
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass
+from kups.potential.common.graph import PointCloud, Replicated
+
+
+@dataclass
+class _P:
+    positions: jax.Array
+    system: Index[SystemId]
+
+
+@dataclass
+class _S:
+    cell: PeriodicCell
+
+
+def _particles(n: int, system_ids: np.ndarray | None = None) -> Table[ParticleId, _P]:
+    if system_ids is None:
+        system_ids = np.zeros(n, dtype=int)
+    n_sys = int(system_ids.max()) + 1
+    return Table.arange(
+        _P(
+            positions=jnp.zeros((n, 3)),
+            system=Index.integer(system_ids, n=n_sys, label=SystemId),
+        ),
+        label=ParticleId,
+    )
+
+
+def test_replicated_owned_only_and_combine_are_identity() -> None:
+    parts = _particles(4)
+    x = jnp.arange(4.0)
+    d = Replicated[_P]()
+    assert jnp.array_equal(d.owned_only(parts, x), x)
+    assert jnp.array_equal(d.combine_across_shards(x), x)
+
+
+def test_replicated_owned_only_broadcasts_over_trailing_axes() -> None:
+    # owned_only must be shape-preserving for non-scalar per-node payloads
+    # (e.g. the Ewald per-atom frequency response of shape (N, K, 2)).
+    parts = _particles(4)
+    x = jnp.arange(4 * 3 * 2.0).reshape(4, 3, 2)
+    assert jnp.array_equal(Replicated[_P]().owned_only(parts, x), x)
+
+
+def test_replicated_reduce_matches_direct_segment_sum() -> None:
+    # reduce_nodes_to_systems under the default Replicated placement must be a
+    # plain per-system segment sum.
+    system_ids = np.array([0, 0, 1, 1, 1, 0])
+    parts = _particles(len(system_ids), system_ids)
+    cell = PeriodicCell(TriclinicFrame.from_matrix(4.0 * jnp.eye(3)[None].repeat(2, 0)))
+    systems = Table((SystemId(0), SystemId(1)), _S(cell))
+    x = jnp.arange(float(len(system_ids)))
+    reduced = PointCloud(parts, systems).reduce_nodes_to_systems(x)
+    expected = jax.ops.segment_sum(x, jnp.asarray(system_ids), 2)
+    assert jnp.array_equal(reduced.data, expected)

--- a/test/potential/test_decomposition.py
+++ b/test/potential/test_decomposition.py
@@ -4,8 +4,7 @@
 """Behavioral pins for the `Decomposition` placement strategy.
 
 `Replicated` is the whole-graph null object: `owned_only` and
-`combine_across_shards` must both be the identity, and `owned_only` must be
-shape-preserving for non-scalar per-node payloads. The domain-decomposed
+`combine_across_shards` must both be the identity. The domain-decomposed
 implementation (`Sharded`) is pinned by its own tests next to
 `kups.core.domain`.
 """
@@ -51,14 +50,6 @@ def test_replicated_owned_only_and_combine_are_identity() -> None:
     d = Replicated[_P]()
     assert jnp.array_equal(d.owned_only(parts, x), x)
     assert jnp.array_equal(d.combine_across_shards(x), x)
-
-
-def test_replicated_owned_only_broadcasts_over_trailing_axes() -> None:
-    # owned_only must be shape-preserving for non-scalar per-node payloads
-    # (e.g. the Ewald per-atom frequency response of shape (N, K, 2)).
-    parts = _particles(4)
-    x = jnp.arange(4 * 3 * 2.0).reshape(4, 3, 2)
-    assert jnp.array_equal(Replicated[_P]().owned_only(parts, x), x)
 
 
 def test_replicated_reduce_matches_direct_segment_sum() -> None:


### PR DESCRIPTION
Introduces the placement seam through which domain decomposition (#225) will enter the stock energy functions, and converts every classical potential to it. No new behavior: on a single device every reduction is the identity placement.

- `Decomposition` protocol (`owned_only` + `combine_across_shards`) carried by `PointCloud` as a `kw_only` field defaulting to the identity `Replicated`. (`kw_only` is load-bearing: it keeps every positional `HyperGraph(particles, systems, edges)` call site valid.)
- `reduce_nodes_to_systems`, `aggregate_edges_to_nodes`, and the composed `reduce_edges_to_systems`, so call sites stay one-liners.
- Mechanical sweep of LJ (+ tail-corrected), Coulomb, harmonic bond/angle, cosine angle, dihedral, inversion, Morse, and the Ewald real-space + self terms from `edge_batch_mask.sum_over(e)` to `reduce_edges_to_systems(e)` (first-node attribution; the symmetric `/2` stays explicit).

**Disclosed deltas (review here, not in the DD PR):**
- Float reassociation only: the two-step reduction changes summation order; measured 1.78e-15 relative difference on a 64-atom LJ box. No test asserts bitwise energies.
- The Ewald self term's per-system keys now derive from the particle table's system `Index` rather than `Table.arange` — identical for the contiguous keys the repo enforces (#250).
- Padding rows are dropped by a different mechanism (the OOB edge sentinel feeds `segment_sum(mode="drop")` directly, instead of the OOB *system* gather) — same result, and a regression in either direction turns energies NaN rather than subtly wrong.

Part of the domain-decomposition stack, below #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
