### PR TITLE
refactor(ewald): per-atom reciprocal energy and net-charge correction

### DIFF
--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -262,22 +262,34 @@ type EwaldSelfInput = GraphPotentialInput[
 
 
 @dataclass
+class IncrementalUpdate:
+    """Cached previous structure factors + the changed particles to fold into them (MC accept/reject).
+
+    Bundling the two makes "an incremental update has a cache to update" a type fact, not a runtime
+    assert: ``inp.incremental is not None`` is exactly the cached-|S|² path, and ``.cache`` is then
+    statically present.
+    """
+
+    cache: EwaldCache[Any, Any]
+    changes: WithIndices[ParticleId, IsEwaldPointData]
+
+
+@dataclass
 class EwaldLongRangeInput[State]:
     """Input for the reciprocal-space (long-range) Ewald energy.
 
     Attributes:
         point_cloud: Particle and system data.
         parameters: Ewald convergence parameters and k-vectors.
-        cache: Cached structure factors for incremental updates; ``None`` for full computation.
         cache_lens: Lens to the ``EwaldCache`` in the state; ``None`` disables cache patching.
-        changes_from_prev: Changed particles for incremental structure factor updates.
+        incremental: Cached previous S + changed particles for the incremental MC path; ``None`` runs
+            the full (domain-decomposition-aware) recomputation.
     """
 
     point_cloud: PointCloud[IsEwaldPointData, HasCell[Periodic3D]]
     parameters: EwaldParameters
-    cache: EwaldCache[Any, Any] | None = None
     cache_lens: Lens[State, EwaldCache[Any, Any]] | None = None
-    changes_from_prev: WithIndices[ParticleId, IsEwaldPointData] | None = None
+    incremental: IncrementalUpdate | None = None
 
     @property
     def volume(self) -> Array:
@@ -408,29 +420,6 @@ def _frequency_response(
     return response
 
 
-def _structure_factor_full(
-    positions: Array,
-    charges: Array,
-    kvecs: Array,
-    batch_mask: Index[SystemId],
-) -> Array:
-    """Full structure factor computation.
-
-    Math: ``S(k) = sum_i rho_i(k)`` summed per system via segment_sum.
-
-    Returns:
-        Structure factor, shape ``(n_systems, n_kvecs, 2)``.
-    """
-    response = _frequency_response(positions, charges, kvecs, batch_mask)
-    structure_factor = segment_sum(
-        response,
-        batch_mask.indices,
-        batch_mask.num_labels,
-        mode="drop",
-    )
-    return structure_factor
-
-
 @functools.partial(
     jax.custom_jvp,
     nondiff_argnames=("batch_mask", "cache", "changes"),
@@ -540,37 +529,41 @@ def _structure_factor_update_jvp(
     return sk, KahanSummand(sk_dot, jnp.zeros_like(sk_dot))
 
 
-def structure_factor[State](
-    inp: EwaldLongRangeInput[State],
-) -> tuple[KahanSummand[Array], Patch[State]]:
-    """Compute the structure factor, dispatching between full and incremental.
+def full_structure_factor(inp: EwaldLongRangeInput[Any]) -> KahanSummand[Array]:
+    """Global structure factor recomputed from the full point cloud.
 
-    Uses ``_structure_factor_full`` when no ``changes_from_prev`` is available,
-    otherwise ``_structure_factor_update`` for incremental MC updates.
+    Math: ``S(k) = sum_i rho_i(k)``, reduced owned-only per system and completed
+    across the mesh, so the result is the GLOBAL ``S`` under domain
+    decomposition (and a plain per-system sum when replicated).
 
     Returns:
-        Tuple of the structure factor accumulator and a cache patch. A full
-        recomputation starts a fresh accumulator with zero compensation.
+        A fresh accumulator with zero compensation (nothing accumulated yet).
     """
-    if inp.changes_from_prev is None:
-        sk = KahanSummand.init(
-            _structure_factor_full(
-                inp.point_cloud.particles.data.positions,
-                inp.point_cloud.particles.data.charges,
-                inp.kvecs,
-                inp.point_cloud.particles.data.system,
-            )
-        )
-    else:
-        assert inp.cache is not None, "Cache required for structure factor update"
-        sk = _structure_factor_update(
-            inp.point_cloud.particles.data.positions,
-            inp.point_cloud.particles.data.charges,
-            inp.kvecs,
-            inp.point_cloud.particles.data.system,
-            inp.cache,
-            inp.changes_from_prev,
-        )
+    pc = inp.point_cloud
+    p = pc.particles.data
+    rho = _frequency_response(p.positions, p.charges, inp.kvecs, p.system)
+    return KahanSummand.init(
+        pc.decomposition.combine_across_shards(pc.reduce_nodes_to_systems(rho).data)
+    )
+
+
+def incremental_structure_factor[State](
+    inp: EwaldLongRangeInput[State], update: IncrementalUpdate
+) -> tuple[KahanSummand[Array], Patch[State]]:
+    """Fold changed particles into the cached structure factor (MC accept/reject).
+
+    Math: ``S'(k) = S(k) + Σ_changed [ρ_new(k) − ρ_old(k)]`` from the cached ``S`` in
+    ``update.cache``. The full (non-incremental) path recomputes ``S`` via
+    ``full_structure_factor`` instead.
+
+    Returns:
+        Tuple of the structure factor accumulator and a cache patch. The delta
+        is folded in with Kahan compensation carried in the accumulator.
+    """
+    p = inp.point_cloud.particles.data
+    sk = _structure_factor_update(
+        p.positions, p.charges, inp.kvecs, p.system, update.cache, update.changes
+    )
     patch = (
         EwaldCachePatch(sk, inp.point_cloud.systems.index, inp.cache_lens)
         if inp.cache_lens is not None
@@ -589,18 +582,23 @@ def ewald_net_charge_energy(inp: EwaldLongRangeInput[Any]) -> Table[SystemId, En
     uniform neutralizing background, restoring independence of the total energy
     from ``alpha``. Vanishes for charge-neutral systems. Position-independent (no
     forces) but volume-dependent, so it contributes to the virial/pressure.
+
+    Computed in per-atom form ``E_net,i = -(pi / (2 * V * alpha^2)) * Q * q_i`` (which sums to
+    ``E_net``) so the owned-only reduction makes each device's contribution a per-system partial
+    under domain decomposition; replicated, this is identical to the closed form.
     """
-    particles = inp.point_cloud.particles.data
-    sys_idx = inp.point_cloud.systems.index
+    pc = inp.point_cloud
+    particles = pc.particles.data
     net_charge = segment_sum(
         particles.charges,
         particles.system.indices,
-        inp.point_cloud.batch_size,
+        pc.batch_size,
         mode="drop",
     )
-    alpha = inp.parameters.alpha[sys_idx]
-    energies = -jnp.pi / (2 * inp.volume * alpha**2) * net_charge**2 * TO_STANDARD_UNITS
-    return Table.arange(energies, label=SystemId)
+    alpha = inp.parameters.alpha[pc.systems.index]
+    prefac = -jnp.pi / (2 * inp.volume * alpha**2) * TO_STANDARD_UNITS
+    per_atom = (prefac * net_charge)[particles.system.indices] * particles.charges
+    return pc.reduce_nodes_to_systems(per_atom)
 
 
 def ewald_long_range_energy[State](
@@ -608,20 +606,63 @@ def ewald_long_range_energy[State](
 ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
     """Reciprocal-space (long-range) Ewald energy.
 
-    Math: ``E_lr = TO_STANDARD_UNITS * sum_k P(k) * |S(k)|^2 + E_net``.
-
-    Wraps ``structure_factor`` + ``long_range``, adds the neutralizing-background
-    correction (``ewald_net_charge_energy``) for nonzero net charge, and returns a
-    cache patch for structure factor updates on MC accept/reject. ``S(k)`` is read
-    off the accumulator with its compensation applied.
+    Math: ``E_lr = TO_STANDARD_UNITS * sum_k P(k) * |S(k)|^2 + E_net``, where ``E_net`` is
+    the neutralizing-background correction (``ewald_net_charge_energy``) for nonzero net
+    charge. Dispatches to the cached incremental update when ``inp.incremental`` is present
+    (MC accept/reject), else the full decomposition-aware recomputation.
     """
-    structure_out, patch = structure_factor(inp)
-    energy = long_range(inp, structure_out.total)
+    if inp.incremental is not None:
+        return _ewald_long_range_incremental(inp, inp.incremental)
+    return _ewald_long_range_full(inp)
+
+
+def _ewald_long_range_incremental[State](
+    inp: EwaldLongRangeInput[State], update: IncrementalUpdate
+) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
+    """Incremental (MC accept/reject) path: cached ``|S|²`` form. Single-device only — DD-MC is out of
+    scope, so no owned masking here. ``S(k)`` is read off the accumulator with its compensation
+    applied."""
+    structure, patch = incremental_structure_factor(inp, update)
+    energy = long_range(inp, structure.total)
     assert energy.shape == (inp.point_cloud.batch_size,), (
         f"Expected energy shape {(inp.point_cloud.batch_size,)} but got {energy.shape}."
     )
     energy = energy * TO_STANDARD_UNITS
     total = ewald_net_charge_energy(inp).map_data(lambda e_net: e_net + energy)
+    return WithPatch(total, patch)
+
+
+def _ewald_long_range_full[State](
+    inp: EwaldLongRangeInput[State],
+) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
+    """Full, domain-decomposition-aware path: owned partial structure factor -> global S (combined live,
+    inside the differentiated energy) -> per-atom reciprocal energy ``e_i = Σ_k P ρ_i·S`` -> owned-atom
+    per-system partial. ``Σ_i e_i = Σ_k P|S|²`` reproduces the standard energy; under a ``shard_map`` the
+    partials sum (energy psummed by the wrapper, forces auto-summed through the transpose)."""
+    pc = inp.point_cloud
+    p = pc.particles.data
+    rho = _frequency_response(p.positions, p.charges, inp.kvecs, p.system)  # (N, K, 2)
+    # Owned partial structure factor per system, then combined across the mesh to the
+    # GLOBAL S (live, inside the differentiated energy): S must be global before |S|²
+    # is formed. A full recomputation starts a fresh accumulator with zero
+    # compensation; the cache patch commits the accumulator, not just its value.
+    sk = full_structure_factor(inp)
+    structure = sk.value
+    patch = (
+        EwaldCachePatch(sk, pc.systems.index, inp.cache_lens)
+        if inp.cache_lens is not None
+        else IdPatch[State]()
+    )
+    e_per_atom = einops.einsum(
+        prefactor(inp)[p.system.indices],
+        rho,
+        structure[p.system.indices],
+        "n k, n k t, n k t -> n",
+    )
+    e_net = ewald_net_charge_energy(inp)
+    total = pc.reduce_nodes_to_systems(e_per_atom).map_data(
+        lambda e: e * TO_STANDARD_UNITS + e_net.data
+    )
     return WithPatch(total, patch)
 
 
@@ -652,33 +693,29 @@ class EwaldLongRangeComposer[
         ewald_parameters = self.parameters(state)
         particles = self.particles(state)
         systems = self.systems(state)
-        cache = self.cache.get(state) if self.cache else None
-
-        # Build PointCloud from separate components
         point_cloud = PointCloud(particles=particles, systems=systems)
-
-        inp = EwaldLongRangeInput(
-            point_cloud,
-            ewald_parameters,
-            cache,
-            self.cache,
-        )
+        incremental = None
         if patch is not None and self.probe is not None:
             particle_updates = self.probe(state, patch)
             indices = particle_updates.indices
-            previous_values = (
-                bind(particle_updates).focus(lambda x: x.data).set(particles[indices])
-            )
             patched_particles = particles.update(indices, particle_updates.data)
             point_cloud = PointCloud(patched_particles, systems)
-            inp = EwaldLongRangeInput(
-                point_cloud,
-                ewald_parameters,
-                cache,
-                self.cache,
-                previous_values,
+            # Incremental update needs a cache to fold the change into; without one, fall through to
+            # the (always-correct) full recomputation of the patched configuration.
+            if self.cache is not None:
+                previous_values = (
+                    bind(particle_updates)
+                    .focus(lambda x: x.data)
+                    .set(particles[indices])
+                )
+                incremental = IncrementalUpdate(self.cache.get(state), previous_values)
+        return Sum(
+            Summand(
+                EwaldLongRangeInput(
+                    point_cloud, ewald_parameters, self.cache, incremental
+                )
             )
-        return Sum(Summand(inp))
+        )
 
 
 @dataclass

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -265,9 +265,12 @@ type EwaldSelfInput = GraphPotentialInput[
 class IncrementalUpdate:
     """Cached previous structure factors + the changed particles to fold into them (MC accept/reject).
 
-    Bundling the two makes "an incremental update has a cache to update" a type fact, not a runtime
-    assert: ``inp.incremental is not None`` is exactly the cached-|S|² path, and ``.cache`` is then
-    statically present.
+    Bundling the two keeps the cache statically present on the incremental path.
+
+    Attributes:
+        cache: Structure factors and per-component outputs from the previous step.
+        changes: Previous data of the changed particles, whose contribution is replaced by
+            their current data in the point cloud.
     """
 
     cache: EwaldCache[Any, Any]
@@ -529,21 +532,45 @@ def _structure_factor_update_jvp(
     return sk, KahanSummand(sk_dot, jnp.zeros_like(sk_dot))
 
 
-def full_structure_factor(inp: EwaldLongRangeInput[Any]) -> KahanSummand[Array]:
-    """Global structure factor recomputed from the full point cloud.
+def _reduce_structure_factor(
+    inp: EwaldLongRangeInput[Any], rho: Array
+) -> KahanSummand[Array]:
+    """Global structure factor of an already-computed per-particle frequency response.
 
     Math: ``S(k) = sum_i rho_i(k)``, reduced owned-only per system and completed
-    across the mesh, so the result is the GLOBAL ``S`` under domain
-    decomposition (and a plain per-system sum when replicated).
+    across the mesh, so the result is the global ``S`` under domain decomposition
+    (and a plain per-system sum when replicated).
 
     Returns:
         A fresh accumulator with zero compensation (nothing accumulated yet).
     """
     pc = inp.point_cloud
-    p = pc.particles.data
-    rho = _frequency_response(p.positions, p.charges, inp.kvecs, p.system)
     return KahanSummand.init(
         pc.decomposition.combine_across_shards(pc.reduce_nodes_to_systems(rho).data)
+    )
+
+
+def _cache_patch[State](
+    inp: EwaldLongRangeInput[State], sk: KahanSummand[Array]
+) -> Patch[State]:
+    """Patch committing the structure factor accumulator — value and compensation — to the cache."""
+    if inp.cache_lens is None:
+        return IdPatch[State]()
+    return EwaldCachePatch(sk, inp.point_cloud.systems.index, inp.cache_lens)
+
+
+def full_structure_factor(inp: EwaldLongRangeInput[Any]) -> KahanSummand[Array]:
+    """Global structure factor recomputed from the full point cloud.
+
+    Math: ``S(k) = sum_i rho_i(k)`` over the whole particle table, via
+    ``_reduce_structure_factor``.
+
+    Returns:
+        A fresh accumulator with zero compensation (nothing accumulated yet).
+    """
+    p = inp.point_cloud.particles.data
+    return _reduce_structure_factor(
+        inp, _frequency_response(p.positions, p.charges, inp.kvecs, p.system)
     )
 
 
@@ -553,8 +580,7 @@ def incremental_structure_factor[State](
     """Fold changed particles into the cached structure factor (MC accept/reject).
 
     Math: ``S'(k) = S(k) + Σ_changed [ρ_new(k) − ρ_old(k)]`` from the cached ``S`` in
-    ``update.cache``. The full (non-incremental) path recomputes ``S`` via
-    ``full_structure_factor`` instead.
+    ``update.cache``.
 
     Returns:
         Tuple of the structure factor accumulator and a cache patch. The delta
@@ -564,12 +590,7 @@ def incremental_structure_factor[State](
     sk = _structure_factor_update(
         p.positions, p.charges, inp.kvecs, p.system, update.cache, update.changes
     )
-    patch = (
-        EwaldCachePatch(sk, inp.point_cloud.systems.index, inp.cache_lens)
-        if inp.cache_lens is not None
-        else IdPatch[State]()
-    )
-    return sk, patch
+    return sk, _cache_patch(inp, sk)
 
 
 def ewald_net_charge_energy(inp: EwaldLongRangeInput[Any]) -> Table[SystemId, Energy]:
@@ -619,51 +640,48 @@ def ewald_long_range_energy[State](
 def _ewald_long_range_incremental[State](
     inp: EwaldLongRangeInput[State], update: IncrementalUpdate
 ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
-    """Incremental (MC accept/reject) path: cached ``|S|²`` form. Single-device only — DD-MC is out of
-    scope, so no owned masking here. ``S(k)`` is read off the accumulator with its compensation
-    applied."""
+    """Incremental (MC accept/reject) path: cached ``|S|²`` form.
+
+    Math: ``E_lr = TO_STANDARD_UNITS * sum_k P(k) |S'(k)|^2 + E_net``, with ``S'``
+    read off the accumulator with its compensation applied.
+
+    Single-device only: domain-decomposed MC is out of scope, so no owned masking here.
+    """
     structure, patch = incremental_structure_factor(inp, update)
     energy = long_range(inp, structure.total)
     assert energy.shape == (inp.point_cloud.batch_size,), (
         f"Expected energy shape {(inp.point_cloud.batch_size,)} but got {energy.shape}."
     )
-    energy = energy * TO_STANDARD_UNITS
-    total = ewald_net_charge_energy(inp).map_data(lambda e_net: e_net + energy)
+    total = ewald_net_charge_energy(inp) + energy * TO_STANDARD_UNITS
     return WithPatch(total, patch)
 
 
 def _ewald_long_range_full[State](
     inp: EwaldLongRangeInput[State],
 ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
-    """Full, domain-decomposition-aware path: owned partial structure factor -> global S (combined live,
-    inside the differentiated energy) -> per-atom reciprocal energy ``e_i = Σ_k P ρ_i·S`` -> owned-atom
-    per-system partial. ``Σ_i e_i = Σ_k P|S|²`` reproduces the standard energy; under a ``shard_map`` the
-    partials sum (energy psummed by the wrapper, forces auto-summed through the transpose)."""
+    """Full, domain-decomposition-aware path: per-atom reciprocal energy.
+
+    Math: ``e_i = sum_k P(k) rho_i(k) . S(k)``, whose sum over atoms reproduces the
+    standard ``sum_k P(k) |S(k)|^2``.
+
+    ``S`` is combined across the mesh live, inside the differentiated energy, so the
+    owned-atom reduction of ``e_i`` is each device's per-system partial: under a
+    ``shard_map`` the energy partials are summed by the wrapper's ``psum`` and the
+    gradients through the transpose.
+    """
     pc = inp.point_cloud
     p = pc.particles.data
     rho = _frequency_response(p.positions, p.charges, inp.kvecs, p.system)  # (N, K, 2)
-    # Owned partial structure factor per system, then combined across the mesh to the
-    # GLOBAL S (live, inside the differentiated energy): S must be global before |S|²
-    # is formed. A full recomputation starts a fresh accumulator with zero
-    # compensation; the cache patch commits the accumulator, not just its value.
-    sk = full_structure_factor(inp)
-    structure = sk.value
-    patch = (
-        EwaldCachePatch(sk, pc.systems.index, inp.cache_lens)
-        if inp.cache_lens is not None
-        else IdPatch[State]()
-    )
+    sk = _reduce_structure_factor(inp, rho)
     e_per_atom = einops.einsum(
         prefactor(inp)[p.system.indices],
         rho,
-        structure[p.system.indices],
+        sk.value[p.system.indices],
         "n k, n k t, n k t -> n",
     )
-    e_net = ewald_net_charge_energy(inp)
-    total = pc.reduce_nodes_to_systems(e_per_atom).map_data(
-        lambda e: e * TO_STANDARD_UNITS + e_net.data
-    )
-    return WithPatch(total, patch)
+    e_reciprocal = pc.reduce_nodes_to_systems(e_per_atom) * TO_STANDARD_UNITS
+    total = e_reciprocal + ewald_net_charge_energy(inp)
+    return WithPatch(total, _cache_patch(inp, sk))
 
 
 @dataclass

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -610,15 +610,10 @@ def ewald_net_charge_energy(inp: EwaldLongRangeInput[Any]) -> Table[SystemId, En
     """
     pc = inp.point_cloud
     particles = pc.particles.data
-    net_charge = segment_sum(
-        particles.charges,
-        particles.system.indices,
-        pc.batch_size,
-        mode="drop",
-    )
+    net_charge = particles.system.sum_over(particles.charges)
     alpha = inp.parameters.alpha[pc.systems.index]
     prefac = -jnp.pi / (2 * inp.volume * alpha**2) * TO_STANDARD_UNITS
-    per_atom = (prefac * net_charge)[particles.system.indices] * particles.charges
+    per_atom = (net_charge * prefac)[particles.system] * particles.charges
     return pc.reduce_nodes_to_systems(per_atom)
 
 

--- a/test/potential/test_ewald.py
+++ b/test/potential/test_ewald.py
@@ -524,7 +524,7 @@ class TestStructureFactorCache:
         self,
     ) -> tuple[
         Table[ParticleId, PointCloudParticles],
-        Callable[..., EwaldLongRangeInput[Any]],
+        Callable[[Array], EwaldLongRangeInput[Any]],
     ]:
         """Build a charge-ordered cubic lattice and a builder for its Ewald input.
 

--- a/test/potential/test_ewald.py
+++ b/test/potential/test_ewald.py
@@ -32,14 +32,16 @@ from kups.potential.classical.ewald import (
     EwaldCache,
     EwaldLongRangeInput,
     EwaldParameters,
+    IncrementalUpdate,
     estimate_ewald_parameters,
     ewald_long_range_energy,
     ewald_net_charge_energy,
     ewald_self_interaction_energy,
     ewald_short_range_energy,
+    full_structure_factor,
+    incremental_structure_factor,
     kvecs_from_kmax,
     prefactor,
-    structure_factor,
 )
 from kups.potential.common.graph import GraphPotentialInput, HyperGraph, PointCloud
 
@@ -253,7 +255,7 @@ class TestEwald:
         e_atomic = (
             ewald_short_range_energy(sr_inp).data.data[0]
             + ewald_long_range_energy(
-                EwaldLongRangeInput(PointCloud(all_particles, systems), params, None)
+                EwaldLongRangeInput(PointCloud(all_particles, systems), params)
             ).data.data[0]
             + ewald_self_interaction_energy(sr_inp).data.data[0]
         )
@@ -337,7 +339,7 @@ class TestEwald:
         sr_input = GraphPotentialInput(params, graph)
         sr_result = ewald_short_range_energy(sr_input)
 
-        lr_input = EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+        lr_input = EwaldLongRangeInput(PointCloud(particles, systems), params)
         lr_result = ewald_long_range_energy(lr_input)
         self_result = ewald_self_interaction_energy(sr_input)
 
@@ -366,7 +368,7 @@ class TestEwald:
         pdata = _make_particle_data(positions, charges, n_systems=1)
         particles = Table.arange(pdata, label=ParticleId)
         systems = _make_systems(cell[None], jnp.array([5.0]))
-        inp = EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+        inp = EwaldLongRangeInput(PointCloud(particles, systems), params)
 
         e_net = ewald_net_charge_energy(inp).data[0]
         Q, V = 2.5, L**3
@@ -386,7 +388,7 @@ class TestEwald:
         pdata = _make_particle_data(jnp.zeros((1, 3)), jnp.array([1.0]), n_systems=1)
         particles = Table.arange(pdata, label=ParticleId)
         systems = _make_systems(cell[None], jnp.array([5.0]))
-        inp = EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+        inp = EwaldLongRangeInput(PointCloud(particles, systems), params)
 
         pref = prefactor(inp)
         npt.assert_array_equal(pref[0, 0], jnp.asarray(0.0))
@@ -418,7 +420,7 @@ class TestEwald:
                 reciprocal_lattice_shifts=Table((SystemId(0),), kvecs[None]),
             )
             sr_inp = GraphPotentialInput(params, graph)
-            lr_inp = EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+            lr_inp = EwaldLongRangeInput(PointCloud(particles, systems), params)
             return (
                 ewald_short_range_energy(sr_inp).data.data[0]
                 + ewald_long_range_energy(lr_inp).data.data[0]
@@ -527,8 +529,8 @@ class TestStructureFactorCache:
         """Build a charge-ordered cubic lattice and a builder for its Ewald input.
 
         Returns:
-            Tuple of the particle table and a function mapping positions (plus an
-            optional cache and previous-particle data) to an Ewald input.
+            Tuple of the particle table and a function mapping positions to an
+            Ewald input.
         """
         grid = jnp.stack(
             jnp.meshgrid(*(3 * [jnp.arange(self.REPEATS)]), indexing="ij"), axis=-1
@@ -549,15 +551,9 @@ class TestStructureFactorCache:
             _make_particle_data(positions, charges), label=ParticleId
         )
 
-        def make_input(
-            pos: Array,
-            cache: EwaldCache[Any, Any] | None = None,
-            changes: WithIndices[ParticleId, PointCloudParticles] | None = None,
-        ) -> EwaldLongRangeInput[Any]:
+        def make_input(pos: Array) -> EwaldLongRangeInput[Any]:
             patched = bind(particles).focus(lambda p: p.data.positions).set(pos)
-            return EwaldLongRangeInput(
-                PointCloud(patched, systems), params, cache, None, changes
-            )
+            return EwaldLongRangeInput(PointCloud(patched, systems), params)
 
         return particles, make_input
 
@@ -603,11 +599,13 @@ class TestStructureFactorCache:
             if not compensated:
                 sk = KahanSummand.init(sk.value)
             new_pos = pos.at[idx].add(delta)
-            sk, _ = structure_factor(make_input(new_pos, self._cache(sk), previous))
+            sk, _ = incremental_structure_factor(
+                make_input(new_pos), IncrementalUpdate(self._cache(sk), previous)
+            )
             return (sk, new_pos), None
 
         positions = particles.data.positions
-        sk0, _ = structure_factor(make_input(positions))
+        sk0 = full_structure_factor(make_input(positions))
         (sk, pos), _ = jax.lax.scan(step, (sk0, positions), (moved, deltas))
         # Without compensation only the running sum survives, as before this change.
         return (sk.total if compensated else sk.value), pos


### PR DESCRIPTION
Rewrites the reciprocal-space Ewald path in per-atom form so its reductions flow through the `Decomposition` seam introduced one PR below. Single-device behavior is unchanged (the existing Ewald/MC suites are the gate); under domain decomposition (#225, one PR above) each device's reduction becomes a per-system partial.

- **Full path**: per-atom frequency response ρᵢ → owned partial structure factor, completed to the **global** S via `decomposition.combine_across_shards` *inside* the differentiated energy (S must be global before |S|²), then per-atom reciprocal energy `eᵢ = Σₖ P ρᵢ·S` reduced owned-only. `Σᵢ eᵢ = Σₖ P|S|²` reproduces the standard energy exactly.
- **Net-charge correction** in per-atom form `Eᵢ = -(π/(2Vα²)) Q qᵢ` — sums to the closed form with identical volume/cell gradients, and becomes a per-device partial under decomposition instead of being counted once per device (the closed form would psum to D·E_net).
- **Incremental MC path** moves behind an explicit `IncrementalUpdate` (cache + changed particles bundled as one type fact); `structure_factor` → `incremental_structure_factor` accordingly, and `ewald_long_range_energy` dispatches between the two paths. Both add the net-charge term exactly once.

**Disclosed deltas:** net-charge per-system keys now derive from the particle table's system `Index` (identical for contiguous keys); three stale positional `None`s in `test_ewald.py` cleaned up.

**Scope boundary:** `EwaldLongRangeComposer` and `evaluate_ewald_potential` still build `Replicated` point clouds — the decomposed Ewald path is reachable only via direct `ewald_long_range_energy` calls (gated in #225). Threading decomposition through the state-coupled composer and the GCMC evaluation path is follow-up work.

Part of the domain-decomposition stack, directly below #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
