### PR TITLE
feat: accept a neighborlist_factory in potential configs

### DIFF
--- a/src/kups/application/potential/mliap/tojax.py
+++ b/src/kups/application/potential/mliap/tojax.py
@@ -73,22 +73,22 @@ def make_tojaxed_from_state[State](
 
 
 @overload
-def make_tojaxed_from_state[State](
-    state: Lens[State, IsTojaxedGraphState],
+def make_tojaxed_from_state[State, Focus: IsTojaxedGraphState](
+    state: Lens[State, Focus],
     *,
     parameters: TojaxedMliap,
     gradient: None = None,
-    neighborlist_factory: NeighborListFactory[IsTojaxedGraphState] = ...,
+    neighborlist_factory: NeighborListFactory[Focus] = ...,
 ) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
 
 
 @overload
-def make_tojaxed_from_state[State](
-    state: Lens[State, IsTojaxedGraphState],
+def make_tojaxed_from_state[State, Focus: IsTojaxedGraphState](
+    state: Lens[State, Focus],
     *,
     parameters: TojaxedMliap,
     gradient: Lens[Geometry, PositionsAndCell],
-    neighborlist_factory: NeighborListFactory[IsTojaxedGraphState] = ...,
+    neighborlist_factory: NeighborListFactory[Focus] = ...,
 ) -> Potential[State, PositionsAndCell, EmptyType, Patch[Any]]: ...
 
 

--- a/src/kups/application/potential/mliap/tojax.py
+++ b/src/kups/application/potential/mliap/tojax.py
@@ -53,22 +53,22 @@ class IsTojaxedState(IsTojaxedGraphState, Protocol):
 
 
 @overload
-def make_tojaxed_from_state[State](
-    state: Lens[State, IsTojaxedState],
+def make_tojaxed_from_state[State, Focus: IsTojaxedState](
+    state: Lens[State, Focus],
     *,
     parameters: None = None,
     gradient: None = None,
-    neighborlist_factory: NeighborListFactory[IsTojaxedState] = ...,
+    neighborlist_factory: NeighborListFactory[Focus] = ...,
 ) -> Potential[State, EmptyType, EmptyType, Patch[Any]]: ...
 
 
 @overload
-def make_tojaxed_from_state[State](
-    state: Lens[State, IsTojaxedState],
+def make_tojaxed_from_state[State, Focus: IsTojaxedState](
+    state: Lens[State, Focus],
     *,
     parameters: None = None,
     gradient: Lens[Geometry, PositionsAndCell],
-    neighborlist_factory: NeighborListFactory[IsTojaxedState] = ...,
+    neighborlist_factory: NeighborListFactory[Focus] = ...,
 ) -> Potential[State, PositionsAndCell, EmptyType, Patch[Any]]: ...
 
 

--- a/src/kups/application/potential/mliap/torch.py
+++ b/src/kups/application/potential/mliap/torch.py
@@ -73,22 +73,22 @@ def make_torch_mliap_from_state[State](
 
 
 @overload
-def make_torch_mliap_from_state[State](
-    state: Lens[State, IsTorchMliapGraphState],
+def make_torch_mliap_from_state[State, Focus: IsTorchMliapGraphState](
+    state: Lens[State, Focus],
     *,
     parameters: TorchMliap,
     gradient: None = None,
-    neighborlist_factory: NeighborListFactory[IsTorchMliapGraphState] = ...,
+    neighborlist_factory: NeighborListFactory[Focus] = ...,
 ) -> Potential[State, PositionsAndCell, EmptyType, Patch[Any]]: ...
 
 
 @overload
-def make_torch_mliap_from_state[State](
-    state: Lens[State, IsTorchMliapGraphState],
+def make_torch_mliap_from_state[State, Focus: IsTorchMliapGraphState](
+    state: Lens[State, Focus],
     *,
     parameters: TorchMliap,
     gradient: Lens[Geometry, PositionsAndCell],
-    neighborlist_factory: NeighborListFactory[IsTorchMliapGraphState] = ...,
+    neighborlist_factory: NeighborListFactory[Focus] = ...,
 ) -> Potential[State, PositionsAndCell, EmptyType, Patch[Any]]: ...
 
 

--- a/src/kups/application/potential/mliap/torch.py
+++ b/src/kups/application/potential/mliap/torch.py
@@ -53,31 +53,11 @@ class IsTorchMliapState(IsTorchMliapGraphState, Protocol):
 
 
 @overload
-def make_torch_mliap_from_state[State](
-    state: Lens[State, IsTorchMliapState],
-    *,
-    parameters: None = None,
-    gradient: None = None,
-    neighborlist_factory: NeighborListFactory[IsTorchMliapState] = ...,
-) -> Potential[State, PositionsAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_torch_mliap_from_state[State](
-    state: Lens[State, IsTorchMliapState],
-    *,
-    parameters: None = None,
-    gradient: Lens[Geometry, PositionsAndCell],
-    neighborlist_factory: NeighborListFactory[IsTorchMliapState] = ...,
-) -> Potential[State, PositionsAndCell, EmptyType, Patch[Any]]: ...
-
-
-@overload
-def make_torch_mliap_from_state[State, Focus: IsTorchMliapGraphState](
+def make_torch_mliap_from_state[State, Focus: IsTorchMliapState](
     state: Lens[State, Focus],
     *,
-    parameters: TorchMliap,
-    gradient: None = None,
+    parameters: None = None,
+    gradient: Lens[Geometry, PositionsAndCell] | None = None,
     neighborlist_factory: NeighborListFactory[Focus] = ...,
 ) -> Potential[State, PositionsAndCell, EmptyType, Patch[Any]]: ...
 
@@ -87,7 +67,7 @@ def make_torch_mliap_from_state[State, Focus: IsTorchMliapGraphState](
     state: Lens[State, Focus],
     *,
     parameters: TorchMliap,
-    gradient: Lens[Geometry, PositionsAndCell],
+    gradient: Lens[Geometry, PositionsAndCell] | None = None,
     neighborlist_factory: NeighborListFactory[Focus] = ...,
 ) -> Potential[State, PositionsAndCell, EmptyType, Patch[Any]]: ...
 

--- a/src/kups/application/simulations/potentials.py
+++ b/src/kups/application/simulations/potentials.py
@@ -64,12 +64,12 @@ class LjPotentialConfig(BaseModel):
     parameters: dict[str, tuple[float | None, float | None]]
     mixing_rule: MixingRule
 
-    def build[State](
+    def build[State, Focus: IsLJGraphState](
         self,
-        state_lens: Lens[State, IsLJGraphState],
+        state_lens: Lens[State, Focus],
         gradient: Lens[Geometry, PositionsAndCell],
         neighborlist_factory: NeighborListFactory[
-            Any
+            Focus
         ] = AdaptiveNeighborList.from_state,
     ) -> BuiltPotential[State]:
         """Build the LJ potential with its parameters bound in."""
@@ -93,12 +93,12 @@ class TojaxPotentialConfig(BaseModel):
     backend: Literal["tojax"] = "tojax"
     model_path: str | Path
 
-    def build[State](
+    def build[State, Focus: IsTojaxedGraphState](
         self,
-        state_lens: Lens[State, IsTojaxedGraphState],
+        state_lens: Lens[State, Focus],
         gradient: Lens[Geometry, PositionsAndCell],
         neighborlist_factory: NeighborListFactory[
-            Any
+            Focus
         ] = AdaptiveNeighborList.from_state,
     ) -> BuiltPotential[State]:
         """Build the jaxified potential from the exported model."""
@@ -120,12 +120,12 @@ class MaceConfig(BaseModel):
     device: Literal["cpu", "cuda"] = "cuda"
     dtype: Literal["float32", "float64"] = "float32"
 
-    def build[State](
+    def build[State, Focus: IsTorchMliapGraphState](
         self,
-        state_lens: Lens[State, IsTorchMliapGraphState],
+        state_lens: Lens[State, Focus],
         gradient: Lens[Geometry, PositionsAndCell],
         neighborlist_factory: NeighborListFactory[
-            Any
+            Focus
         ] = AdaptiveNeighborList.from_state,
     ) -> BuiltPotential[State]:
         """Load the MACE checkpoint and build the potential (lazy torch import)."""
@@ -156,12 +156,12 @@ class UmaConfig(BaseModel):
     task_name: UMATaskName = "omat"
     inference_settings: UMAInferenceSettings = "default"
 
-    def build[State](
+    def build[State, Focus: IsTorchMliapGraphState](
         self,
-        state_lens: Lens[State, IsTorchMliapGraphState],
+        state_lens: Lens[State, Focus],
         gradient: Lens[Geometry, PositionsAndCell],
         neighborlist_factory: NeighborListFactory[
-            Any
+            Focus
         ] = AdaptiveNeighborList.from_state,
     ) -> BuiltPotential[State]:
         """Load the UMA checkpoint and build the potential (lazy torch import)."""

--- a/src/kups/application/simulations/potentials.py
+++ b/src/kups/application/simulations/potentials.py
@@ -32,6 +32,7 @@ from kups.application.potential.mliap.tojax import (
 from kups.application.utils.path import get_model_path
 from kups.core.data import Table
 from kups.core.lens import Lens
+from kups.core.neighborlist import AdaptiveNeighborList, NeighborListFactory
 from kups.core.patch import Patch
 from kups.core.potential import EmptyType, Potential
 from kups.core.typing import SystemId
@@ -67,6 +68,9 @@ class LjPotentialConfig(BaseModel):
         self,
         state_lens: Lens[State, IsLJGraphState],
         gradient: Lens[Geometry, PositionsAndCell],
+        neighborlist_factory: NeighborListFactory[
+            Any
+        ] = AdaptiveNeighborList.from_state,
     ) -> BuiltPotential[State]:
         """Build the LJ potential with its parameters bound in."""
         params = LennardJonesParameters.from_dict(
@@ -75,7 +79,10 @@ class LjPotentialConfig(BaseModel):
             mixing_rule=self.mixing_rule,
         )
         potential = make_lennard_jones_from_state(
-            state_lens, parameters=params, gradient=gradient
+            state_lens,
+            parameters=params,
+            gradient=gradient,
+            neighborlist_factory=neighborlist_factory,
         )
         return potential, params.cutoff
 
@@ -90,11 +97,17 @@ class TojaxPotentialConfig(BaseModel):
         self,
         state_lens: Lens[State, IsTojaxedGraphState],
         gradient: Lens[Geometry, PositionsAndCell],
+        neighborlist_factory: NeighborListFactory[
+            Any
+        ] = AdaptiveNeighborList.from_state,
     ) -> BuiltPotential[State]:
         """Build the jaxified potential from the exported model."""
         model = TojaxedMliap.from_zip_file(get_model_path(self.model_path))
         potential = make_tojaxed_from_state(
-            state_lens, parameters=model, gradient=gradient
+            state_lens,
+            parameters=model,
+            gradient=gradient,
+            neighborlist_factory=neighborlist_factory,
         )
         return potential, model.cutoff
 
@@ -111,6 +124,9 @@ class MaceConfig(BaseModel):
         self,
         state_lens: Lens[State, IsTorchMliapGraphState],
         gradient: Lens[Geometry, PositionsAndCell],
+        neighborlist_factory: NeighborListFactory[
+            Any
+        ] = AdaptiveNeighborList.from_state,
     ) -> BuiltPotential[State]:
         """Load the MACE checkpoint and build the potential (lazy torch import)."""
         from kups.application.potential.mliap.torch import make_torch_mliap_from_state
@@ -123,7 +139,10 @@ class MaceConfig(BaseModel):
             compute_cell_gradients=True,
         )
         potential = make_torch_mliap_from_state(
-            state_lens, parameters=model, gradient=gradient
+            state_lens,
+            parameters=model,
+            gradient=gradient,
+            neighborlist_factory=neighborlist_factory,
         )
         return potential, model.cutoff
 
@@ -141,6 +160,9 @@ class UmaConfig(BaseModel):
         self,
         state_lens: Lens[State, IsTorchMliapGraphState],
         gradient: Lens[Geometry, PositionsAndCell],
+        neighborlist_factory: NeighborListFactory[
+            Any
+        ] = AdaptiveNeighborList.from_state,
     ) -> BuiltPotential[State]:
         """Load the UMA checkpoint and build the potential (lazy torch import)."""
         from kups.application.potential.mliap.torch import make_torch_mliap_from_state
@@ -154,7 +176,10 @@ class UmaConfig(BaseModel):
             inference_settings=self.inference_settings,
         )
         potential = make_torch_mliap_from_state(
-            state_lens, parameters=model, gradient=gradient
+            state_lens,
+            parameters=model,
+            gradient=gradient,
+            neighborlist_factory=neighborlist_factory,
         )
         return potential, model.cutoff
 


### PR DESCRIPTION
**Stack (bottom → top):** #261 → #262 → #263 → #264 → #194

Part of the **Verlet-skin stack** (assert-repair tests → this PR → margin bound → skin machinery → MD wiring).

All four `PotentialConfig.build` methods forward an optional `neighborlist_factory` (default `AdaptiveNeighborList.from_state`, behaviour unchanged) to their adapters, so a caller can inject an alternative neighbor-list construction — e.g. a stored, reused list — without touching the config schema. The LJ/torch/tojax adapters already accepted the parameter; this only threads it through.

Mechanical, default-preserving; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
