### PR TITLE
feat: add the deformation-aware Verlet-skin margin bound

### DIFF
--- a/src/kups/core/neighborlist/__init__.py
+++ b/src/kups/core/neighborlist/__init__.py
@@ -137,6 +137,10 @@ from kups.core.neighborlist.types import (
     PipelineContext,
     Postprocessor,
 )
+from kups.core.neighborlist.verlet import (
+    effective_build_radii,
+    skin_margin,
+)
 
 __all__ = [
     "AdaptiveNeighborList",
@@ -186,5 +190,7 @@ __all__ = [
     "all_dense_cost",
     "cell_list_cost",
     "dense_cost",
+    "effective_build_radii",
     "neighborlist_changes",
+    "skin_margin",
 ]

--- a/src/kups/core/neighborlist/__init__.py
+++ b/src/kups/core/neighborlist/__init__.py
@@ -138,6 +138,8 @@ from kups.core.neighborlist.types import (
     Postprocessor,
 )
 from kups.core.neighborlist.verlet import (
+    SkinMargin,
+    SkinReference,
     effective_build_radii,
     skin_margin,
 )
@@ -185,6 +187,8 @@ __all__ = [
     "RefineCutoffNeighborList",
     "RefineMaskNeighborList",
     "QueriedKeysDedupMask",
+    "SkinMargin",
+    "SkinReference",
     "UniversalNeighborlistParameters",
     "all_connected_neighborlist",
     "all_dense_cost",

--- a/src/kups/core/neighborlist/verlet.py
+++ b/src/kups/core/neighborlist/verlet.py
@@ -1,48 +1,18 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
-"""Verlet neighbor list with a skin.
+"""Verlet neighbor list with a skin: the margin accounting.
 
-Builds a *conservative* neighbor list at ``cutoff + skin`` once, stores its edges
-in the simulation state, and reuses them for many steps via
-[`RefineCutoffNeighborList`][kups.core.neighborlist.refine.RefineCutoffNeighborList]
-(which re-masks to the true cutoff and recomputes minimum-image shifts for the
-current — possibly deformed — cell). The expensive build then runs only when the
-margin bookkeeping below demands it, amortizing it over the rebuild window.
-
-## Completeness bound
-
-A pair absent from the stored skin list had build-time minimum-image distance
-``> r_build`` (and every periodic image of it was farther still). Decompose the
-change since the build into the affine cell deformation ``F = h_ref⁻¹ h_now``
-(row convention: pair vectors map as ``d ↦ d @ F``, and so do the image lattice
-vectors) and the per-atom *non-affine* residual ``u_i = x_i - x_i_ref @ F``. Then
-every image of a non-listed pair now sits at distance at least
-``σ_min(F) * r_build - 2 * max|u|``, with ``σ_min`` the smallest singular value
-of ``F``. The stored list therefore still contains every pair within ``cutoff``
-while
-
-    2 * max|u| + r_build * max(0, 1 - σ_min(F))  <=  r_build - cutoff
-
-The left side is the *consumed* margin and the right side the *budget*
-(:func:`skin_margin` computes both; the difference is the *headroom*). Because
-``σ_min`` sees the full deformation, pure shear consumes margin like any other
-strain — the trigger is not blind to off-diagonal cell moves. Residuals are
-minimum-image wrapped in the current cell (honoring per-axis periodicity), so an
-atom crossing a boundary along a sheared lattice vector is undone exactly; only
-a genuine non-affine drift beyond half a cell between rebuilds (impossible in
-practice, since rebuilds fire at skin scale) would be under-measured.
-
-## Single-image clamp
-
-Refine-based reuse can only represent one periodic image per stored pair, so the
-build radius is clamped to half the smallest perpendicular length over periodic
-axes (:func:`effective_build_radii`). A cell that compresses mid-run therefore
-degrades to a thinner effective skin — more frequent rebuilds — instead of
-failing. Only when the *cutoff itself* no longer fits (no skin can help; the
-refine path would drop images) does the rebuild raise, telling the user to set
-``verlet_skin = 0``.
-
+A Verlet-skin scheme builds one conservative neighbor list at an enlarged
+radius ``r_build ≈ cutoff + skin``, stores its edges, and reuses them over many
+steps via
+[`RefineCutoffNeighborList`][kups.core.neighborlist.refine.RefineCutoffNeighborList],
+amortizing the expensive build over the rebuild window. This module holds the
+pure geometry underneath such a scheme:
+[`skin_margin`][kups.core.neighborlist.verlet.skin_margin] decides how long the
+stored list remains complete, and
+[`effective_build_radii`][kups.core.neighborlist.verlet.effective_build_radii]
+keeps the build radius inside the single-image regime that edge reuse requires.
 """
 
 from __future__ import annotations
@@ -50,78 +20,145 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 from jax import Array
+from jax.typing import ArrayLike
 
 from kups.core.cell import AnyPeriodicity, Cell
-
-# Above this ratio of build radius to a cell's perpendicular length, a build needs
-# more than one periodic image per pair and the refine-based reuse path is incomplete.
-_SINGLE_IMAGE_LIMIT = 0.5
+from kups.core.data import Table
+from kups.core.neighborlist.types import NeighborListSystems
+from kups.core.typing import HasPositionsAndSystemIndex, ParticleId, SystemId
+from kups.core.utils.jax import dataclass
 
 
 def effective_build_radii(
-    cutoffs: Array, skin: float, cell: Cell[AnyPeriodicity]
+    cutoffs: Array, skin: ArrayLike, cell: Cell[AnyPeriodicity]
 ) -> Array:
-    """Per-system build radius: ``cutoff + skin`` clamped to the single-image limit.
+    """Per-system build radius: ``cutoff + skin``, clamped to a single image.
 
-    The refine-based reuse path collapses each stored pair to one minimum image,
-    so the build must not replicate images: the radius is capped at half the
-    cell's smallest perpendicular length over periodic axes (no cap in vacuum).
+    Reusing stored edges keeps exactly one periodic image per pair, so the
+    build radius must stay below half the cell's smallest perpendicular length
+    on every periodic axis — beyond that, second images enter the build sphere
+    and the reuse path would drop them. A cell that compresses mid-run thus
+    degrades to a thinner effective skin (more frequent rebuilds) instead of an
+    incomplete list. No clamp applies in vacuum.
 
     Args:
-        cutoffs: true cutoffs (Å), ``(n_sys,)``.
-        skin: requested skin width (Å).
+        cutoffs: True cutoffs (Å), ``(n_sys,)``.
+        skin: Requested skin width (Å).
         cell: ``(n_sys,)``-batched cell the build runs in.
 
     Returns:
         Build radii (Å), ``(n_sys,)``. ``radii - cutoffs`` is the effective skin.
     """
     perp = cell.perpendicular_lengths
-    limit = _SINGLE_IMAGE_LIMIT * jnp.min(
-        jnp.where(jnp.array(cell.periodic), perp, jnp.inf), axis=-1
-    )
+    limit = 0.5 * jnp.min(jnp.where(jnp.array(cell.periodic), perp, jnp.inf), axis=-1)
     return jnp.minimum(cutoffs + skin, limit)
 
 
-def skin_margin(
-    positions: Array,
-    reference_positions: Array,
-    cell_now: Cell[AnyPeriodicity],
-    cell_ref: Cell[AnyPeriodicity],
-    system: Array,
-    cutoffs: Array,
-    skin: float,
-) -> tuple[Array, Array]:
-    """Consumed and budgeted completeness margin of the stored skin list.
+@dataclass
+class SkinReference:
+    """Geometry snapshot taken when the skin list was built.
 
-    Implements the bound from the module docstring: the deformation term uses
-    the smallest singular value of ``F = h_ref⁻¹ h_now`` per system, the motion
-    term the largest minimum-image *non-affine* residual per system. Pairs
-    never span systems, so the accounting is fully per system — one hot system
-    neither charges nor rebuilds the others.
+    [`skin_margin`][kups.core.neighborlist.verlet.skin_margin] measures the
+    drift of the current geometry relative to this snapshot. The arrays must
+    not alias the live position/cell buffers (donated jitted steps would then
+    receive the same buffer twice).
+
+    Attributes:
+        positions: Cartesian positions at the build, ``(N, 3)``.
+        cell: ``(n_sys,)``-batched cell at the build.
+    """
+
+    positions: Array
+    cell: Cell[AnyPeriodicity]
+
+
+@dataclass
+class SkinMargin:
+    """Per-system completeness accounting of a stored skin list.
+
+    Attributes:
+        consumed: Worst-case distance (Å) by which atom motion and cell
+            deformation since the build can have pulled a non-listed pair
+            inward, ``(n_sys,)``.
+        budget: Distance (Å) such a pair had to spare at build time — the
+            effective skin ``r_build - cutoff``, ``(n_sys,)``.
+    """
+
+    consumed: Array
+    budget: Array
+
+    @property
+    def headroom(self) -> Array:
+        """``budget - consumed``; the stored list is complete while ``>= 0``."""
+        return self.budget - self.consumed
+
+
+def skin_margin(
+    particles: Table[ParticleId, HasPositionsAndSystemIndex],
+    systems: Table[SystemId, NeighborListSystems],
+    reference: SkinReference,
+    cutoffs: Table[SystemId, Array],
+    skin: ArrayLike,
+) -> Table[SystemId, SkinMargin]:
+    """How much of the skin list's safety margin the geometry has used up.
+
+    A skin list built at radius ``r_build`` stays complete for the true
+    ``cutoff`` as long as no pair that was *outside* ``r_build`` at build time
+    has come *inside* ``cutoff`` since. Two things move pairs inward:
+
+    1. **Cell deformation.** Between the build and now the cell changed by the
+       linear map ``F = h_ref⁻¹ h_now`` (row-vector convention), which maps
+       every build-time pair vector ``d`` — including those to periodic images —
+       to ``d @ F``. A linear map cannot shrink any vector by more than its
+       smallest singular value: ``|d @ F| >= σ_min(F) |d|`` for all ``d``. So
+       the affine part of the motion leaves every non-listed pair at distance
+       at least ``σ_min(F) r_build``, an inward move of at most
+       ``r_build (1 - σ_min(F))`` — and none at all if the cell only expanded
+       (``σ_min >= 1``). Because ``σ_min`` sees the whole map, pure shear
+       counts like any other strain, unlike per-axis length ratios.
+    2. **Atom motion on top of the deformation.** Each atom's *non-affine*
+       displacement is ``u_i = x_i - x_i_ref @ F`` — what remains after riding
+       the cell — minimum-image wrapped in the current cell so that a boundary
+       crossing (even along a sheared lattice vector) is undone exactly. A pair
+       distance changes by at most the two endpoint displacements,
+       ``2 max|u|``.
+
+    The stored list is therefore complete while, per system,
+
+        consumed := 2 max|u| + r_build max(0, 1 - σ_min(F))  <=  r_build - cutoff =: budget
+
+    i.e. while the worst-case inward motion of a non-listed pair (*consumed*)
+    has not eaten the extra radius the build added on top of the cutoff
+    (*budget*). Pairs never span systems, so the accounting is fully per
+    system: one hot system neither charges nor rebuilds the others.
 
     Args:
-        positions: current cartesian positions, ``(N, 3)``.
-        reference_positions: positions at the last rebuild, ``(N, 3)``.
-        cell_now: current cells, ``(n_sys,)``-batched.
-        cell_ref: cells at the last rebuild, ``(n_sys,)``-batched.
-        system: particle → system index array, ``(N,)``.
-        cutoffs: true cutoffs (Å), ``(n_sys,)``.
-        skin: requested skin width (Å).
+        particles: Current particle table (positions and system index).
+        systems: Current system table (cells).
+        reference: Positions and cell snapshot taken at the last build.
+        cutoffs: True cutoffs (Å) per system.
+        skin: Requested skin width (Å) the list was built with.
 
     Returns:
-        ``(consumed, budget)``, both ``(n_sys,)``. The stored list is complete
-        while ``consumed <= budget`` in every system; ``budget - consumed`` is
-        the headroom.
+        Per-system [`SkinMargin`][kups.core.neighborlist.verlet.SkinMargin]
+        table (``consumed`` and ``budget``, both in Å).
     """
-    deform = cell_ref.inverse_vectors @ cell_now.vectors  # d_now = d_ref @ F
-    co_moved = jnp.einsum("ni,nij->nj", reference_positions, deform[system])
-    residual = cell_now[system].wrap(positions - co_moved)
+    cell_now = systems.data.cell
+    system = particles.data.system.indices
+    cutoff_values = Table.broadcast_to(cutoffs, systems).data
+    deform = reference.cell.inverse_vectors @ cell_now.vectors  # d_now = d_ref @ F
+    # Non-affine residual u_i: subtract each atom's cell-riding motion, then
+    # minimum-image wrap so a boundary crossing does not read as a large move.
+    co_moved = jnp.einsum("ni,nij->nj", reference.positions, deform[system])
+    residual = cell_now[system].wrap(particles.data.positions - co_moved)
     u_max = jax.ops.segment_max(
-        jnp.linalg.norm(residual, axis=-1), system, num_segments=cutoffs.shape[0]
+        jnp.linalg.norm(residual, axis=-1), system, num_segments=systems.size
     )
     u_max = jnp.maximum(u_max, 0.0)  # empty segments reduce to -inf
+    # σ_min(F) from the smallest eigenvalue of the 3x3 Gram matrix F Fᵀ
+    # (cheaper than an SVD; the clamp guards eigvalsh's tiny negative noise).
     gram = deform @ jnp.swapaxes(deform, -1, -2)
     sigma_min = jnp.sqrt(jnp.maximum(jnp.linalg.eigvalsh(gram)[..., 0], 0.0))
-    r_build = effective_build_radii(cutoffs, skin, cell_ref)
+    r_build = effective_build_radii(cutoff_values, skin, reference.cell)
     consumed = 2.0 * u_max + r_build * jnp.maximum(0.0, 1.0 - sigma_min)
-    return consumed, r_build - cutoffs
+    return Table(systems.keys, SkinMargin(consumed, r_build - cutoff_values))

--- a/src/kups/core/neighborlist/verlet.py
+++ b/src/kups/core/neighborlist/verlet.py
@@ -17,7 +17,6 @@ keeps the build radius inside the single-image regime that edge reuse requires.
 
 from __future__ import annotations
 
-import jax
 import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
@@ -119,9 +118,10 @@ def skin_margin(
     2. **Atom motion on top of the deformation.** Each atom's *non-affine*
        displacement is ``u_i = x_i - x_i_ref @ F`` — what remains after riding
        the cell — minimum-image wrapped in the current cell so that a boundary
-       crossing (even along a sheared lattice vector) is undone exactly. A pair
-       distance changes by at most the two endpoint displacements,
-       ``2 max|u|``.
+       crossing (even along a sheared lattice vector) is undone exactly (a
+       genuine non-affine drift beyond half a cell would be under-measured, but
+       rebuilds fire at skin scale long before that). A pair distance changes
+       by at most the two endpoint displacements, ``2 max|u|``.
 
     The stored list is therefore complete while, per system,
 
@@ -147,13 +147,10 @@ def skin_margin(
     system = particles.data.system.indices
     cutoff_values = Table.broadcast_to(cutoffs, systems).data
     deform = reference.cell.inverse_vectors @ cell_now.vectors  # d_now = d_ref @ F
-    # Non-affine residual u_i: subtract each atom's cell-riding motion, then
-    # minimum-image wrap so a boundary crossing does not read as a large move.
+    # u_i = x_i - x_i_ref @ F, min-image wrapped
     co_moved = jnp.einsum("ni,nij->nj", reference.positions, deform[system])
     residual = cell_now[system].wrap(particles.data.positions - co_moved)
-    u_max = jax.ops.segment_max(
-        jnp.linalg.norm(residual, axis=-1), system, num_segments=systems.size
-    )
+    u_max = particles.data.system.max_over(jnp.linalg.norm(residual, axis=-1)).data
     u_max = jnp.maximum(u_max, 0.0)  # empty segments reduce to -inf
     # σ_min(F) from the smallest eigenvalue of the 3x3 Gram matrix F Fᵀ
     # (cheaper than an SVD; the clamp guards eigvalsh's tiny negative noise).

--- a/src/kups/core/neighborlist/verlet.py
+++ b/src/kups/core/neighborlist/verlet.py
@@ -1,0 +1,127 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verlet neighbor list with a skin.
+
+Builds a *conservative* neighbor list at ``cutoff + skin`` once, stores its edges
+in the simulation state, and reuses them for many steps via
+[`RefineCutoffNeighborList`][kups.core.neighborlist.refine.RefineCutoffNeighborList]
+(which re-masks to the true cutoff and recomputes minimum-image shifts for the
+current — possibly deformed — cell). The expensive build then runs only when the
+margin bookkeeping below demands it, amortizing it over the rebuild window.
+
+## Completeness bound
+
+A pair absent from the stored skin list had build-time minimum-image distance
+``> r_build`` (and every periodic image of it was farther still). Decompose the
+change since the build into the affine cell deformation ``F = h_ref⁻¹ h_now``
+(row convention: pair vectors map as ``d ↦ d @ F``, and so do the image lattice
+vectors) and the per-atom *non-affine* residual ``u_i = x_i - x_i_ref @ F``. Then
+every image of a non-listed pair now sits at distance at least
+``σ_min(F) * r_build - 2 * max|u|``, with ``σ_min`` the smallest singular value
+of ``F``. The stored list therefore still contains every pair within ``cutoff``
+while
+
+    2 * max|u| + r_build * max(0, 1 - σ_min(F))  <=  r_build - cutoff
+
+The left side is the *consumed* margin and the right side the *budget*
+(:func:`skin_margin` computes both; the difference is the *headroom*). Because
+``σ_min`` sees the full deformation, pure shear consumes margin like any other
+strain — the trigger is not blind to off-diagonal cell moves. Residuals are
+minimum-image wrapped in the current cell (honoring per-axis periodicity), so an
+atom crossing a boundary along a sheared lattice vector is undone exactly; only
+a genuine non-affine drift beyond half a cell between rebuilds (impossible in
+practice, since rebuilds fire at skin scale) would be under-measured.
+
+## Single-image clamp
+
+Refine-based reuse can only represent one periodic image per stored pair, so the
+build radius is clamped to half the smallest perpendicular length over periodic
+axes (:func:`effective_build_radii`). A cell that compresses mid-run therefore
+degrades to a thinner effective skin — more frequent rebuilds — instead of
+failing. Only when the *cutoff itself* no longer fits (no skin can help; the
+refine path would drop images) does the rebuild raise, telling the user to set
+``verlet_skin = 0``.
+
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.cell import AnyPeriodicity, Cell
+
+# Above this ratio of build radius to a cell's perpendicular length, a build needs
+# more than one periodic image per pair and the refine-based reuse path is incomplete.
+_SINGLE_IMAGE_LIMIT = 0.5
+
+
+def effective_build_radii(
+    cutoffs: Array, skin: float, cell: Cell[AnyPeriodicity]
+) -> Array:
+    """Per-system build radius: ``cutoff + skin`` clamped to the single-image limit.
+
+    The refine-based reuse path collapses each stored pair to one minimum image,
+    so the build must not replicate images: the radius is capped at half the
+    cell's smallest perpendicular length over periodic axes (no cap in vacuum).
+
+    Args:
+        cutoffs: true cutoffs (Å), ``(n_sys,)``.
+        skin: requested skin width (Å).
+        cell: ``(n_sys,)``-batched cell the build runs in.
+
+    Returns:
+        Build radii (Å), ``(n_sys,)``. ``radii - cutoffs`` is the effective skin.
+    """
+    perp = cell.perpendicular_lengths
+    limit = _SINGLE_IMAGE_LIMIT * jnp.min(
+        jnp.where(jnp.array(cell.periodic), perp, jnp.inf), axis=-1
+    )
+    return jnp.minimum(cutoffs + skin, limit)
+
+
+def skin_margin(
+    positions: Array,
+    reference_positions: Array,
+    cell_now: Cell[AnyPeriodicity],
+    cell_ref: Cell[AnyPeriodicity],
+    system: Array,
+    cutoffs: Array,
+    skin: float,
+) -> tuple[Array, Array]:
+    """Consumed and budgeted completeness margin of the stored skin list.
+
+    Implements the bound from the module docstring: the deformation term uses
+    the smallest singular value of ``F = h_ref⁻¹ h_now`` per system, the motion
+    term the largest minimum-image *non-affine* residual per system. Pairs
+    never span systems, so the accounting is fully per system — one hot system
+    neither charges nor rebuilds the others.
+
+    Args:
+        positions: current cartesian positions, ``(N, 3)``.
+        reference_positions: positions at the last rebuild, ``(N, 3)``.
+        cell_now: current cells, ``(n_sys,)``-batched.
+        cell_ref: cells at the last rebuild, ``(n_sys,)``-batched.
+        system: particle → system index array, ``(N,)``.
+        cutoffs: true cutoffs (Å), ``(n_sys,)``.
+        skin: requested skin width (Å).
+
+    Returns:
+        ``(consumed, budget)``, both ``(n_sys,)``. The stored list is complete
+        while ``consumed <= budget`` in every system; ``budget - consumed`` is
+        the headroom.
+    """
+    deform = cell_ref.inverse_vectors @ cell_now.vectors  # d_now = d_ref @ F
+    co_moved = jnp.einsum("ni,nij->nj", reference_positions, deform[system])
+    residual = cell_now[system].wrap(positions - co_moved)
+    u_max = jax.ops.segment_max(
+        jnp.linalg.norm(residual, axis=-1), system, num_segments=cutoffs.shape[0]
+    )
+    u_max = jnp.maximum(u_max, 0.0)  # empty segments reduce to -inf
+    gram = deform @ jnp.swapaxes(deform, -1, -2)
+    sigma_min = jnp.sqrt(jnp.maximum(jnp.linalg.eigvalsh(gram)[..., 0], 0.0))
+    r_build = effective_build_radii(cutoffs, skin, cell_ref)
+    consumed = 2.0 * u_max + r_build * jnp.maximum(0.0, 1.0 - sigma_min)
+    return consumed, r_build - cutoffs

--- a/test/core/neighborlist/test_verlet.py
+++ b/test/core/neighborlist/test_verlet.py
@@ -15,7 +15,7 @@ import jax.numpy as jnp
 import pytest
 from jax import Array
 
-from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
+from kups.core.cell import Cell, TriclinicFrame
 from kups.core.data import Table
 from kups.core.neighborlist import (
     SkinMargin,
@@ -147,12 +147,12 @@ class TestSkinMargin:
 class TestEffectiveBuildRadii:
     def test_unclamped_below_the_limit(self):
         """A radius inside the single-image regime passes through untouched."""
-        cell = PeriodicCell(TriclinicFrame.from_matrix(8.0 * jnp.eye(3)[None]))
+        cell = _cell(8.0 * jnp.eye(3))
         radii = effective_build_radii(jnp.array([2.0]), 1.5, cell)
         assert float(radii[0]) == pytest.approx(3.5)  # 2 + 1.5 < 8 / 2
 
     def test_clamped_to_half_perpendicular_length(self):
-        cell = PeriodicCell(TriclinicFrame.from_matrix(8.0 * jnp.eye(3)[None]))
+        cell = _cell(8.0 * jnp.eye(3))
         radii = effective_build_radii(jnp.array([3.0]), 2.0, cell)
         assert float(radii[0]) == pytest.approx(4.0)  # min(3+2, 8/2)
 

--- a/test/core/neighborlist/test_verlet.py
+++ b/test/core/neighborlist/test_verlet.py
@@ -15,47 +15,55 @@ import jax.numpy as jnp
 import pytest
 from jax import Array
 
-from kups.core.cell import Cell, TriclinicFrame
+from kups.core.cell import Cell, PeriodicCell, TriclinicFrame
+from kups.core.data import Table
 from kups.core.neighborlist import (
+    SkinMargin,
+    SkinReference,
     effective_build_radii,
     skin_margin,
 )
+from kups.core.typing import SystemId
 
-
-def _system_cell(lvecs: Array, periodic=(True, True, True)) -> Cell:
-    """A ``(1,)``-batched cell."""
-    frame = TriclinicFrame.from_matrix(jnp.asarray(lvecs)[None])
-    return Cell.from_pbc(frame, periodic)
-
+from ._builders import make_lh, make_systems
 
 CUTOFF, SKIN = 3.5, 1.0
 
 
-def _margin_fires(
+def _cell(lvecs: Array, periodic=(True, True, True), n_sys: int = 1) -> Cell:
+    """An ``(n_sys,)``-batched cell."""
+    lv = jnp.asarray(lvecs)
+    if lv.ndim == 2:
+        lv = jnp.repeat(lv[None], n_sys, axis=0)
+    return Cell.from_pbc(TriclinicFrame.from_matrix(lv), periodic)
+
+
+def _margins(
     positions: Array,
     reference_positions: Array,
     cell_now: Cell,
     cell_ref: Cell,
+    system: Array | None = None,
     cutoff: float = CUTOFF,
     skin: float = SKIN,
-) -> bool:
-    n = positions.shape[0]
-    consumed, budget = skin_margin(
-        positions,
-        reference_positions,
-        cell_now,
-        cell_ref,
-        jnp.zeros(n, dtype=int),
-        jnp.array([cutoff]),
-        skin,
-    )
-    return bool(jnp.min(budget - consumed) < 0.0)
+) -> Table[SystemId, SkinMargin]:
+    if system is None:
+        system = jnp.zeros(positions.shape[0], dtype=int)
+    n_sys = int(jnp.max(system)) + 1
+    particles = make_lh(positions, system)
+    systems, cutoffs = make_systems(cell_now, jnp.full((n_sys,), cutoff))
+    reference = SkinReference(reference_positions, cell_ref)
+    return skin_margin(particles, systems, reference, cutoffs, skin)
+
+
+def _margin_fires(*args, **kwargs) -> bool:
+    return bool(jnp.min(_margins(*args, **kwargs).data.headroom) < 0.0)
 
 
 class TestSkinMargin:
     def test_motion_threshold_at_half_skin(self):
         """One atom moving just under/over ``skin/2`` sits on the margin boundary."""
-        cell = _system_cell(20.0 * jnp.eye(3))
+        cell = _cell(20.0 * jnp.eye(3))
         pos = jnp.array([[1.0, 1.0, 1.0], [5.0, 5.0, 5.0]])
         for factor, expected in [(0.99, False), (1.01, True)]:
             moved = pos.at[0, 0].add(factor * SKIN / 2)
@@ -63,30 +71,30 @@ class TestSkinMargin:
 
     def test_compression_consumes_margin(self):
         """Isotropic compression consumes ``r_build * (1 - sigma_min)``."""
-        ref = _system_cell(20.0 * jnp.eye(3))
+        ref = _cell(20.0 * jnp.eye(3))
         pos = jnp.array([[1.0, 1.0, 1.0], [5.0, 5.0, 5.0]])
         for factor, expected in [(0.99, False), (1.01, True)]:
             f = 1.0 - factor * SKIN / (CUTOFF + SKIN)
-            now = _system_cell(20.0 * f * jnp.eye(3))
+            now = _cell(20.0 * f * jnp.eye(3))
             # Atoms ride the cell (pure affine motion): zero residual, all
             # margin consumption comes from the deformation term.
             assert _margin_fires(pos * f, pos, now, ref) is expected
 
     def test_expansion_consumes_no_margin(self):
         """Expansion moves non-listed pairs farther away; sigma_min > 1 is free."""
-        ref = _system_cell(20.0 * jnp.eye(3))
-        now = _system_cell(30.0 * jnp.eye(3))
+        ref = _cell(20.0 * jnp.eye(3))
+        now = _cell(30.0 * jnp.eye(3))
         pos = jnp.array([[1.0, 1.0, 1.0], [5.0, 5.0, 5.0]])
         assert _margin_fires(pos * 1.5, pos, now, ref) is False
 
     def test_pure_shear_consumes_margin(self):
         """An off-diagonal cell move must consume margin (sigma_min < 1) even
         though it is invisible to any per-axis length ratio."""
-        ref = _system_cell(20.0 * jnp.eye(3))
+        ref = _cell(20.0 * jnp.eye(3))
         pos = jnp.array([[1.0, 1.0, 1.0], [5.0, 5.0, 5.0]])
         for gamma, expected in [(1.0, False), (12.0, True)]:
             lvecs = jnp.array([[20.0, 0.0, 0.0], [gamma, 20.0, 0.0], [0.0, 0.0, 20.0]])
-            now = _system_cell(lvecs)
+            now = _cell(lvecs)
             # Atoms at fixed fractional coordinates: pure affine, zero residual.
             frac = ref.frame.to_fractional(pos)
             assert _margin_fires(now.frame.to_real(frac), pos, now, ref) is expected
@@ -101,7 +109,7 @@ class TestSkinMargin:
         minimum-image residual through the cell stays exact.
         """
         lvecs = jnp.array([[10.0, 0.0, 0.0], [5.0, 8.66, 0.0], [0.0, 0.0, 10.0]])
-        cell = _system_cell(lvecs)
+        cell = _cell(lvecs)
         f_ref = jnp.array([[0.5, 0.98, 0.5]])
         pos_ref = cell.frame.to_real(f_ref)
         for df, expected in [(0.04, False), (0.07, True)]:
@@ -114,25 +122,22 @@ class TestSkinMargin:
     def test_per_system_accounting(self):
         """One hot system must not charge a cold system's margin: pairs never
         span systems, so the motion term reduces per system."""
-        frame = TriclinicFrame.from_matrix(jnp.repeat(20.0 * jnp.eye(3)[None], 2, 0))
-        cell = Cell.from_pbc(frame, (True, True, True))
+        cell = _cell(20.0 * jnp.eye(3), n_sys=2)
         pos = jnp.array(
             [[1.0, 1.0, 1.0], [5.0, 5.0, 5.0], [1.0, 1.0, 1.0], [5.0, 5.0, 5.0]]
         )
         system = jnp.array([0, 0, 1, 1])
         moved = pos.at[2, 0].add(0.6)  # only system 1 moves
-        consumed, budget = skin_margin(
-            moved, pos, cell, cell, system, jnp.full((2,), CUTOFF), SKIN
-        )
-        assert float(consumed[0]) == pytest.approx(0.0)
-        assert float(consumed[1]) == pytest.approx(1.2)
-        assert bool(consumed[0] <= budget[0]) and bool(consumed[1] > budget[1])
+        margin = _margins(moved, pos, cell, cell, system=system).data
+        assert float(margin.consumed[0]) == pytest.approx(0.0)
+        assert float(margin.consumed[1]) == pytest.approx(1.2)
+        assert bool(margin.headroom[0] >= 0.0) and bool(margin.headroom[1] < 0.0)
 
     def test_nonperiodic_axes_are_not_unwrapped(self):
         """In a vacuum cell nothing wraps, so a large real move must trigger even
         when a periodic un-wrap of the bounding box would shrink it below the
         threshold (6 A move, 10 A box: un-wrapping would misread it as 4 A)."""
-        cell = _system_cell(10.0 * jnp.eye(3), periodic=(False, False, False))
+        cell = _cell(10.0 * jnp.eye(3), periodic=(False, False, False))
         pos_ref = jnp.array([[2.0, 5.0, 5.0]])
         pos_new = pos_ref + jnp.array([[6.0, 0.0, 0.0]])
         # 2 * 6 >= 10 triggers; the misread 2 * 4 would not.
@@ -140,12 +145,18 @@ class TestSkinMargin:
 
 
 class TestEffectiveBuildRadii:
+    def test_unclamped_below_the_limit(self):
+        """A radius inside the single-image regime passes through untouched."""
+        cell = PeriodicCell(TriclinicFrame.from_matrix(8.0 * jnp.eye(3)[None]))
+        radii = effective_build_radii(jnp.array([2.0]), 1.5, cell)
+        assert float(radii[0]) == pytest.approx(3.5)  # 2 + 1.5 < 8 / 2
+
     def test_clamped_to_half_perpendicular_length(self):
-        cell = _system_cell(8.0 * jnp.eye(3))
+        cell = PeriodicCell(TriclinicFrame.from_matrix(8.0 * jnp.eye(3)[None]))
         radii = effective_build_radii(jnp.array([3.0]), 2.0, cell)
         assert float(radii[0]) == pytest.approx(4.0)  # min(3+2, 8/2)
 
     def test_unclamped_in_vacuum(self):
-        cell = _system_cell(8.0 * jnp.eye(3), periodic=(False, False, False))
+        cell = _cell(8.0 * jnp.eye(3), periodic=(False, False, False))
         radii = effective_build_radii(jnp.array([3.0]), 2.0, cell)
         assert float(radii[0]) == pytest.approx(5.0)

--- a/test/core/neighborlist/test_verlet.py
+++ b/test/core/neighborlist/test_verlet.py
@@ -1,0 +1,151 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Verlet-skin margin bound (kups.core.neighborlist.verlet).
+
+Covers the pure pieces: the deformation-aware ``skin_margin`` bound (motion
+threshold, compression, expansion, pure shear, triclinic boundary crossing,
+non-periodic axes, per-system accounting) and the single-image clamp on the
+build radius (``effective_build_radii``).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+from jax import Array
+
+from kups.core.cell import Cell, TriclinicFrame
+from kups.core.neighborlist import (
+    effective_build_radii,
+    skin_margin,
+)
+
+
+def _system_cell(lvecs: Array, periodic=(True, True, True)) -> Cell:
+    """A ``(1,)``-batched cell."""
+    frame = TriclinicFrame.from_matrix(jnp.asarray(lvecs)[None])
+    return Cell.from_pbc(frame, periodic)
+
+
+CUTOFF, SKIN = 3.5, 1.0
+
+
+def _margin_fires(
+    positions: Array,
+    reference_positions: Array,
+    cell_now: Cell,
+    cell_ref: Cell,
+    cutoff: float = CUTOFF,
+    skin: float = SKIN,
+) -> bool:
+    n = positions.shape[0]
+    consumed, budget = skin_margin(
+        positions,
+        reference_positions,
+        cell_now,
+        cell_ref,
+        jnp.zeros(n, dtype=int),
+        jnp.array([cutoff]),
+        skin,
+    )
+    return bool(jnp.min(budget - consumed) < 0.0)
+
+
+class TestSkinMargin:
+    def test_motion_threshold_at_half_skin(self):
+        """One atom moving just under/over ``skin/2`` sits on the margin boundary."""
+        cell = _system_cell(20.0 * jnp.eye(3))
+        pos = jnp.array([[1.0, 1.0, 1.0], [5.0, 5.0, 5.0]])
+        for factor, expected in [(0.99, False), (1.01, True)]:
+            moved = pos.at[0, 0].add(factor * SKIN / 2)
+            assert _margin_fires(moved, pos, cell, cell) is expected
+
+    def test_compression_consumes_margin(self):
+        """Isotropic compression consumes ``r_build * (1 - sigma_min)``."""
+        ref = _system_cell(20.0 * jnp.eye(3))
+        pos = jnp.array([[1.0, 1.0, 1.0], [5.0, 5.0, 5.0]])
+        for factor, expected in [(0.99, False), (1.01, True)]:
+            f = 1.0 - factor * SKIN / (CUTOFF + SKIN)
+            now = _system_cell(20.0 * f * jnp.eye(3))
+            # Atoms ride the cell (pure affine motion): zero residual, all
+            # margin consumption comes from the deformation term.
+            assert _margin_fires(pos * f, pos, now, ref) is expected
+
+    def test_expansion_consumes_no_margin(self):
+        """Expansion moves non-listed pairs farther away; sigma_min > 1 is free."""
+        ref = _system_cell(20.0 * jnp.eye(3))
+        now = _system_cell(30.0 * jnp.eye(3))
+        pos = jnp.array([[1.0, 1.0, 1.0], [5.0, 5.0, 5.0]])
+        assert _margin_fires(pos * 1.5, pos, now, ref) is False
+
+    def test_pure_shear_consumes_margin(self):
+        """An off-diagonal cell move must consume margin (sigma_min < 1) even
+        though it is invisible to any per-axis length ratio."""
+        ref = _system_cell(20.0 * jnp.eye(3))
+        pos = jnp.array([[1.0, 1.0, 1.0], [5.0, 5.0, 5.0]])
+        for gamma, expected in [(1.0, False), (12.0, True)]:
+            lvecs = jnp.array([[20.0, 0.0, 0.0], [gamma, 20.0, 0.0], [0.0, 0.0, 20.0]])
+            now = _system_cell(lvecs)
+            # Atoms at fixed fractional coordinates: pure affine, zero residual.
+            frac = ref.frame.to_fractional(pos)
+            assert _margin_fires(now.frame.to_real(frac), pos, now, ref) is expected
+
+    def test_triclinic_boundary_crossing(self):
+        """A wrap along a sheared lattice vector must not distort the residual.
+
+        The atom crosses the ``a2`` boundary, so its stored (wrapped) position
+        jumps by a lattice vector with off-diagonal Cartesian components. Undoing
+        that per axis with the perpendicular lengths (the old formula) misreads
+        the ~0.4 A true displacement as ~3.9 A and rebuilds spuriously; the
+        minimum-image residual through the cell stays exact.
+        """
+        lvecs = jnp.array([[10.0, 0.0, 0.0], [5.0, 8.66, 0.0], [0.0, 0.0, 10.0]])
+        cell = _system_cell(lvecs)
+        f_ref = jnp.array([[0.5, 0.98, 0.5]])
+        pos_ref = cell.frame.to_real(f_ref)
+        for df, expected in [(0.04, False), (0.07, True)]:
+            # |a2| = 10, so a fractional move of df along a2 is a 10*df true step.
+            pos_new = cell.wrap(cell.frame.to_real(f_ref + jnp.array([[0, df, 0]])))
+            raw = jnp.linalg.norm(pos_new - pos_ref)
+            assert float(raw) > 5.0  # the raw difference jumped by ~a lattice vector
+            assert _margin_fires(pos_new, pos_ref, cell, cell) is expected
+
+    def test_per_system_accounting(self):
+        """One hot system must not charge a cold system's margin: pairs never
+        span systems, so the motion term reduces per system."""
+        frame = TriclinicFrame.from_matrix(jnp.repeat(20.0 * jnp.eye(3)[None], 2, 0))
+        cell = Cell.from_pbc(frame, (True, True, True))
+        pos = jnp.array(
+            [[1.0, 1.0, 1.0], [5.0, 5.0, 5.0], [1.0, 1.0, 1.0], [5.0, 5.0, 5.0]]
+        )
+        system = jnp.array([0, 0, 1, 1])
+        moved = pos.at[2, 0].add(0.6)  # only system 1 moves
+        consumed, budget = skin_margin(
+            moved, pos, cell, cell, system, jnp.full((2,), CUTOFF), SKIN
+        )
+        assert float(consumed[0]) == pytest.approx(0.0)
+        assert float(consumed[1]) == pytest.approx(1.2)
+        assert bool(consumed[0] <= budget[0]) and bool(consumed[1] > budget[1])
+
+    def test_nonperiodic_axes_are_not_unwrapped(self):
+        """In a vacuum cell nothing wraps, so a large real move must trigger even
+        when a periodic un-wrap of the bounding box would shrink it below the
+        threshold (6 A move, 10 A box: un-wrapping would misread it as 4 A)."""
+        cell = _system_cell(10.0 * jnp.eye(3), periodic=(False, False, False))
+        pos_ref = jnp.array([[2.0, 5.0, 5.0]])
+        pos_new = pos_ref + jnp.array([[6.0, 0.0, 0.0]])
+        # 2 * 6 >= 10 triggers; the misread 2 * 4 would not.
+        assert _margin_fires(pos_new, pos_ref, cell, cell, cutoff=1.0, skin=10.0)
+
+
+class TestEffectiveBuildRadii:
+    def test_clamped_to_half_perpendicular_length(self):
+        cell = _system_cell(8.0 * jnp.eye(3))
+        radii = effective_build_radii(jnp.array([3.0]), 2.0, cell)
+        assert float(radii[0]) == pytest.approx(4.0)  # min(3+2, 8/2)
+
+    def test_unclamped_in_vacuum(self):
+        cell = _system_cell(8.0 * jnp.eye(3), periodic=(False, False, False))
+        radii = effective_build_radii(jnp.array([3.0]), 2.0, cell)
+        assert float(radii[0]) == pytest.approx(5.0)


### PR DESCRIPTION
**Stack (bottom → top):** #261 → #262 → #263 → #264 → #194

Part of the **Verlet-skin stack** (assert-repair tests → neighborlist_factory → this PR → skin machinery → MD wiring).

Pure functions for a Verlet-skin neighbor list — no state, no steps, just the math:

- `effective_build_radii`: per-system build radius `cutoff + skin`, clamped to the single-image limit (half the smallest perpendicular length over periodic axes; no cap in vacuum). Refine-based reuse can only represent one periodic image per stored pair, so a compressing cell degrades to a thinner effective skin instead of a hard failure.
- `skin_margin`: the completeness margin of a list built at that radius,

  ```
  2·max|u|  +  r_build · max(0, 1 − σ_min(F))   ≤   r_build − cutoff
  ```

  with `F = h_ref⁻¹·h_now` the per-system cell deformation since the build (row convention: pair vectors map as `d ↦ d·F`, and so do the image lattice vectors) and `u` the minimum-image **non-affine** residual displacement `x − x_ref·F`. Any image of a non-listed pair now sits at distance ≥ `σ_min·r_build − 2·max|u|`, so the list is complete while the margin holds. Because `σ_min` sees the full deformation, **pure shear consumes margin like any other strain** (relevant for anisotropic NPT barostats) and expansion is correctly free. Accounting is fully per system: pairs never span systems, so one hot system neither charges nor triggers the others.

Tests: motion threshold at skin/2, compression fires / expansion doesn't, pure shear fires, triclinic boundary crossing measured exactly (a per-axis un-wrap would misread a 0.4 Å step as ~3.9 Å), non-periodic axes not un-wrapped, per-system accounting, and both clamp cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
