### PR TITLE
feat: FFT-based smooth-PME reciprocal energy module

### DIFF
--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -358,11 +358,23 @@ def long_range(inp: EwaldLongRangeInput[Any], structure_factor: Array) -> Energy
     )
 
 
+def reciprocal_prefactor(k_squared: Array, volume: Array, alpha: Array) -> Array:
+    """``P(k) = 2*pi/V * exp(-k^2 / (4*alpha^2)) / k^2`` for k != 0, zero at k = 0.
+
+    ``volume`` and ``alpha`` must be broadcastable against ``k_squared`` (any
+    k-grid shape). Shared by direct Ewald and PME so both sample the same
+    influence function.
+    """
+    mask = k_squared > 0
+    k_squared = jnp.where(mask, k_squared, 1)
+    result = (2 * jnp.pi) / volume * jnp.exp(-k_squared / (4 * alpha**2)) / k_squared
+    return jnp.where(mask, result, 0.0)
+
+
 def prefactor(inp: EwaldLongRangeInput[Any]) -> Array:
     """Reciprocal-space prefactor for each k-vector.
 
-    Math: ``P(k) = 2*pi/V * exp(-k^2 / (4*alpha^2)) / k^2`` for k != 0,
-    zero for k = 0. The ``(2 - leading_zero)`` factor accounts for the
+    ``reciprocal_prefactor`` with the ``(2 - leading_zero)`` factor for the
     Hermitian symmetry optimization: only half the k-vectors are stored
     (k and -k give conjugate contributions).
 
@@ -376,17 +388,9 @@ def prefactor(inp: EwaldLongRangeInput[Any]) -> Array:
     k_squared = einops.einsum(
         kv, kv, "batch_size kvecs dim, batch_size kvecs dim -> batch_size kvecs"
     )
-    mask = k_squared > 0
-    k_squared = jnp.where(mask, k_squared, 1)
-    result = (
-        (2 * jnp.pi)
-        / inp.volume[:, None]
-        * jnp.exp(-k_squared / (4 * alpha[:, None] ** 2))
-        / k_squared
-    )
+    result = reciprocal_prefactor(k_squared, inp.volume[:, None], alpha[:, None])
     leading_zero = rls[..., 0] == 0
-    result = (2 - leading_zero) * result  # correct for half the k-vectors being dropped
-    return jnp.where(mask, result, 0.0)
+    return (2 - leading_zero) * result  # correct for half the k-vectors being dropped
 
 
 def _frequency_response(
@@ -609,6 +613,20 @@ def ewald_net_charge_energy(inp: EwaldLongRangeInput[Any]) -> Table[SystemId, En
     return Table.arange(energies, label=SystemId)
 
 
+def reciprocal_total_energy(
+    inp: EwaldLongRangeInput[Any], energy: Array
+) -> Table[SystemId, Energy]:
+    """Scale a per-system reciprocal-space ``energy`` (atomic units) to standard
+    units and add the neutralizing-background term for the omitted ``k = 0`` mode
+    (``ewald_net_charge_energy``). Shared tail of direct Ewald and PME."""
+    assert energy.shape == (inp.point_cloud.batch_size,), (
+        f"Expected energy shape {(inp.point_cloud.batch_size,)} but got {energy.shape}."
+    )
+    return ewald_net_charge_energy(inp).map_data(
+        lambda e_net: e_net + energy * TO_STANDARD_UNITS
+    )
+
+
 def ewald_long_range_energy[State](
     inp: EwaldLongRangeInput[State],
 ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
@@ -623,12 +641,7 @@ def ewald_long_range_energy[State](
     """
     structure_out, patch = structure_factor(inp)
     energy = long_range(inp, structure_out.total)
-    assert energy.shape == (inp.point_cloud.batch_size,), (
-        f"Expected energy shape {(inp.point_cloud.batch_size,)} but got {energy.shape}."
-    )
-    energy = energy * TO_STANDARD_UNITS
-    total = ewald_net_charge_energy(inp).map_data(lambda e_net: e_net + energy)
-    return WithPatch(total, patch)
+    return WithPatch(reciprocal_total_energy(inp, energy), patch)
 
 
 @dataclass
@@ -770,10 +783,17 @@ def make_ewald_long_range_potential[
     hessian_lens: Lens[Gradients, Hessians] = EMPTY_LENS,
     hessian_idx_view: View[State, Hessians] = EMPTY_LENS,
     patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
+    energy_fn: EnergyFunction[
+        State, EwaldLongRangeInput[State]
+    ] = ewald_long_range_energy,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
-    """Create the Ewald reciprocal-space (long-range) potential."""
+    """Create the Ewald reciprocal-space (long-range) potential.
+
+    ``energy_fn`` swaps the reciprocal-space term (e.g. PME) without duplicating
+    the composer and lens wiring.
+    """
     return PotentialFromEnergy(
-        energy_fn=ewald_long_range_energy,
+        energy_fn=energy_fn,
         composer=EwaldLongRangeComposer(
             particles=particles_view,
             systems=systems_view,

--- a/src/kups/potential/classical/pme.py
+++ b/src/kups/potential/classical/pme.py
@@ -32,7 +32,7 @@ import numpy as np
 from jax import Array
 from jax.typing import DTypeLike
 
-from kups.core.cell import Periodic3D
+from kups.core.cell import Cell, Periodic3D
 from kups.core.data import Table, WithIndices
 from kups.core.lens import Lens, View, lens
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
@@ -62,8 +62,12 @@ class PMESettings:
     those ``None`` keeps the direct-Ewald reciprocal sum.
 
     Attributes:
-        mesh: Static FFT grid dimensions, held fixed across a trajectory (see
-            `pme_mesh_for_cell`).
+        mesh: Static FFT grid dimensions. Settings rather than state because FFT
+            shapes must be known at trace time, and shared by all systems in a
+            batch — one FFT over a ``(n_sys, *mesh)`` charge grid
+            (`pme_mesh_for_cell` sizes the mesh for the largest cell per axis).
+            Held fixed across a trajectory even as an NPT box fluctuates, as in
+            standard PME codes.
         order: Cardinal B-spline order.
     """
 
@@ -72,25 +76,23 @@ class PMESettings:
 
 
 def pme_mesh_for_cell(
-    cell_vectors: Array, spacing: float = 1.0, multiple_of: int = 2
+    cell: Cell[Periodic3D], spacing: float = 1.0, multiple_of: int = 2
 ) -> tuple[int, int, int]:
     """Pick static PME mesh dimensions for a reference cell (~``spacing`` Angstrom).
 
-    Resolution is measured across opposing faces, not along the lattice vectors, so
-    the spacing holds for sheared cells too. Dims are rounded up to a multiple of
-    ``multiple_of`` (cheaper FFTs). Use the *initial* cell; the mesh is held fixed
-    across an NPT trajectory.
+    Resolution is measured across opposing faces (``cell.perpendicular_lengths``),
+    not along the lattice vectors, so the spacing holds for sheared cells too. A
+    batched cell is reduced with a per-axis max, sizing the shared mesh for the
+    largest system. Dims are rounded up to a multiple of ``multiple_of`` (cheaper
+    FFTs). Runs on the host and returns Python ints because FFT shapes must be
+    static: call it at setup time with the *initial* cell; the mesh is then held
+    fixed across an NPT trajectory.
 
     Note the heuristic is purely geometric: the resolution PME actually needs also
     grows with the Ewald splitting parameter ``alpha``, so verify the accuracy of a
     chosen mesh against direct Ewald rather than trusting ``spacing`` alone.
     """
-    v = np.asarray(cell_vectors)
-    volume = abs(float(np.linalg.det(v)))
-    lengths = [
-        volume / float(np.linalg.norm(np.cross(v[b], v[c])))
-        for b, c in ((1, 2), (0, 2), (0, 1))
-    ]
+    lengths = np.asarray(cell.perpendicular_lengths).reshape(-1, 3).max(axis=0)
     dims: list[int] = []
     for length in lengths:
         m = int(np.ceil(float(length) / spacing))
@@ -110,6 +112,9 @@ def _bspline_weights(frac: Array, order: int) -> Array:
     """
     j = jnp.arange(order)
     x = frac[..., None] + j  # M_n evaluated at f, f+1, ..., f+(p-1)
+    # M_1 is the indicator of [0, 1), so at this point only j = 0 is nonzero; each
+    # Cox-de Boor pass below widens the support by one grid point, so after the
+    # p - 1 passes all p offsets carry weight.
     w = jnp.where((x >= 0) & (x < 1), 1.0, 0.0)  # M_1
     for k in range(2, order + 1):
         # M_k(x) = x/(k-1) M_{k-1}(x) + (k-x)/(k-1) M_{k-1}(x-1); shift gives M_{k-1}(x-1)
@@ -134,29 +139,28 @@ def _euler_modulus_sq(m_size: int, order: int, dtype: DTypeLike) -> Array:
     return jnp.where(denom2 < 1e-10, 1.0, 1.0 / denom2)
 
 
-def _pme_reciprocal_energy_batched(
-    positions: Array,  # (N, 3) Cartesian, Angstrom
-    charges: Array,  # (N,)
-    sys_idx: Array,  # (N,) per-particle system index
-    n_sys: int,  # number of systems (static)
-    inverse_vectors: Array,  # (n_sys, 3, 3)
-    volume: Array,  # (n_sys,)
-    alpha: Array,  # (n_sys,)
-    mesh: tuple[int, int, int],
-    order: int,
+def _pme_reciprocal_energy(
+    inp: EwaldLongRangeInput[Any], settings: PMESettings
 ) -> Array:
-    """Per-system smooth-PME reciprocal energy, in atomic units (the caller scales
-    by ``TO_STANDARD_UNITS``)."""
+    """Per-system smooth-PME reciprocal energy, shape ``(n_sys,)``, in atomic
+    units (the caller scales by ``TO_STANDARD_UNITS``)."""
+    pc = inp.point_cloud
+    positions = pc.particles.data.positions
+    charges = pc.particles.data.charges
+    sys_idx = pc.particles.data.system.indices
+    n_sys = pc.batch_size
+    cell = pc.systems.data.cell
+    # Key-based lookup (as in `prefactor`), not raw .data: the parameter and
+    # system tables need not be keyed in the same order.
+    alpha = inp.parameters.alpha[pc.systems.index]
+    order = settings.order
     dtype = positions.dtype
-    Mx, My, Mz = mesh
-    Mvec = jnp.asarray(mesh, dtype=dtype)
+    Mx, My, Mz = settings.mesh
+    Mvec = jnp.asarray(settings.mesh, dtype=dtype)
 
-    # Fractional coords in each particle's own cell. The contraction must match
-    # Frame.to_fractional (inverse_vectors contracted on its *first* axis); the
-    # transpose cancels against kvec below, so getting it wrong is invisible for
-    # orthorhombic cells but shears the effective lattice.
-    inv_p = inverse_vectors[sys_idx]  # (N, 3, 3)
-    frac = jnp.einsum("nba,nb->na", inv_p, positions) % 1.0  # (N, 3) in [0, 1)
+    # Fractional coords in each particle's own cell, folded into [0, 1).
+    cell_p = cell[sys_idx]
+    frac, _ = cell_p.fold(cell_p.frame.to_fractional(positions))  # (N, 3)
     u = frac * Mvec
     base = jnp.floor(u).astype(jnp.int32)
     f = u - base
@@ -196,7 +200,7 @@ def _pme_reciprocal_energy_batched(
     nz = jnp.fft.fftfreq(Mz) * Mz
     nX, nY, nZ = jnp.meshgrid(nx, ny, nz, indexing="ij")
     n_idx = jnp.stack([nX, nY, nZ], axis=-1).astype(dtype)  # (Mx,My,Mz,3)
-    kvec = 2.0 * jnp.pi * jnp.einsum("sab,xyzb->sxyza", inverse_vectors, n_idx)
+    kvec = 2.0 * jnp.pi * jnp.einsum("sab,xyzb->sxyza", cell.inverse_vectors, n_idx)
     k2 = jnp.sum(kvec**2, axis=-1)  # (n_sys, Mx, My, Mz)
 
     bsq = (
@@ -209,7 +213,7 @@ def _pme_reciprocal_energy_batched(
     k2_safe = jnp.where(nonzero, k2, 1.0)
     pref = (
         (2.0 * jnp.pi)
-        / volume[:, None, None, None]
+        / inp.volume[:, None, None, None]
         * jnp.exp(-k2_safe / (4.0 * alpha[:, None, None, None] ** 2))
         / k2_safe
     )
@@ -217,29 +221,15 @@ def _pme_reciprocal_energy_batched(
     return jnp.sum(influence * (jnp.abs(Fq) ** 2), axis=(1, 2, 3))  # (n_sys,)
 
 
-def make_pme_long_range_energy(mesh: tuple[int, int, int], order: int):
-    """Build the PME long-range energy fn for a fixed static ``mesh`` and ``order``."""
+def make_pme_long_range_energy(settings: PMESettings):
+    """Build the PME long-range energy fn for fixed static ``settings``."""
 
     def pme_long_range_energy[State](
         inp: EwaldLongRangeInput[State],
     ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
         """Reciprocal-space (long-range) PME energy. Drop-in for ``ewald_long_range_energy``."""
-        pc = inp.point_cloud
-        cell = pc.systems.data.cell
-        n_sys = pc.batch_size
-        energy = _pme_reciprocal_energy_batched(
-            positions=pc.particles.data.positions,
-            charges=pc.particles.data.charges,
-            sys_idx=pc.particles.data.system.indices,
-            n_sys=n_sys,
-            inverse_vectors=cell.inverse_vectors,
-            volume=cell.volume,
-            # Key-based lookup (as in `prefactor`), not raw .data: the parameter and
-            # system tables need not be keyed in the same order.
-            alpha=inp.parameters.alpha[pc.systems.index],
-            mesh=mesh,
-            order=order,
-        )
+        n_sys = inp.point_cloud.batch_size
+        energy = _pme_reciprocal_energy(inp, settings)
         assert energy.shape == (n_sys,), (
             f"Expected energy shape {(n_sys,)} but got {energy.shape}."
         )
@@ -283,7 +273,7 @@ def make_pme_long_range_potential[
     """
     assert cache_lens is None, "PME has no structure-factor cache to update."
     return PotentialFromEnergy(
-        energy_fn=make_pme_long_range_energy(settings.mesh, settings.order),
+        energy_fn=make_pme_long_range_energy(settings),
         composer=EwaldLongRangeComposer(
             particles=particles_view,
             systems=systems_view,

--- a/src/kups/potential/classical/pme.py
+++ b/src/kups/potential/classical/pme.py
@@ -8,18 +8,15 @@ An ``O(N log N)`` FFT-based replacement for the direct-Ewald reciprocal term
 runs out of memory at large ``N``. It is a drop-in at the long-range seam, so
 forces and the NPT stress still come from autodiff.
 
-Convention matches ``ewald.py`` so PME converges to the same number::
+The influence function ``P(k)`` (``reciprocal_prefactor``), the neutralizing
+background (``reciprocal_total_energy``), and ``alpha`` / the real-space cutoff
+are shared with ``ewald.py``, so the short-range / self / exclusion terms are
+unchanged, the splitting is consistent, and PME converges to the same number::
 
-    P(k) = (2*pi/V) * exp(-k^2 / (4*alpha^2)) / k^2 ,   k = 2*pi * inverse_vectors @ n
     E_recip = sum_{k != 0} P(k) * B(m) * |FFT(Q)(m)|^2 * TO_STANDARD_UNITS
 
 where ``Q`` is the order-``p`` cardinal B-spline charge mesh and ``B(m)`` is the
-Euler exponential-spline aliasing correction (Essmann et al. 1995). ``alpha`` and
-the real-space cutoff are reused verbatim from ``EwaldParameters`` so the
-short-range / self / exclusion terms are unchanged and the splitting is
-consistent. The FFT mesh dimensions are static (chosen once at construction);
-under NPT the box fluctuates but the mesh stays fixed, as in standard PME.
-
+Euler exponential-spline aliasing correction (Essmann et al. 1995).
 """
 
 from __future__ import annotations
@@ -34,20 +31,20 @@ from jax.typing import DTypeLike
 
 from kups.core.cell import Cell, Periodic3D
 from kups.core.data import Table, WithIndices
-from kups.core.lens import Lens, View, lens
+from kups.core.lens import Lens, View
 from kups.core.patch import IdPatch, Patch, Probe, WithPatch
 from kups.core.potential import EMPTY_LENS, Energy, Potential, PotentialOut
 from kups.core.typing import HasCell, ParticleId, SystemId
+from kups.core.utils.math import triangular_3x3_matmul
 from kups.potential.classical.ewald import (
-    TO_STANDARD_UNITS,
     EwaldCache,
-    EwaldLongRangeComposer,
     EwaldLongRangeInput,
     EwaldParameters,
     IsEwaldPointData,
-    ewald_net_charge_energy,
+    make_ewald_long_range_potential,
+    reciprocal_prefactor,
+    reciprocal_total_energy,
 )
-from kups.potential.common.energy import PotentialFromEnergy
 from kups.potential.common.graph import PointCloud
 
 DEFAULT_SPLINE_ORDER = 6
@@ -62,12 +59,9 @@ class PMESettings:
     those ``None`` keeps the direct-Ewald reciprocal sum.
 
     Attributes:
-        mesh: Static FFT grid dimensions. Settings rather than state because FFT
-            shapes must be known at trace time, and shared by all systems in a
-            batch — one FFT over a ``(n_sys, *mesh)`` charge grid
-            (`pme_mesh_for_cell` sizes the mesh for the largest cell per axis).
-            Held fixed across a trajectory even as an NPT box fluctuates, as in
-            standard PME codes.
+        mesh: FFT grid dimensions, shared by every system in a batch and held
+            fixed across a trajectory (size with `pme_mesh_for_cell`). Settings
+            rather than traced state because FFT shapes must be static.
         order: Cardinal B-spline order.
     """
 
@@ -80,17 +74,15 @@ def pme_mesh_for_cell(
 ) -> tuple[int, int, int]:
     """Pick static PME mesh dimensions for a reference cell (~``spacing`` Angstrom).
 
-    Resolution is measured across opposing faces (``cell.perpendicular_lengths``),
-    not along the lattice vectors, so the spacing holds for sheared cells too. A
-    batched cell is reduced with a per-axis max, sizing the shared mesh for the
-    largest system. Dims are rounded up to a multiple of ``multiple_of`` (cheaper
-    FFTs). Runs on the host and returns Python ints because FFT shapes must be
-    static: call it at setup time with the *initial* cell; the mesh is then held
-    fixed across an NPT trajectory.
+    Resolution is measured across opposing faces (``cell.perpendicular_lengths``)
+    so the spacing holds for sheared cells; a batched cell is reduced with a
+    per-axis max. Dims are rounded up to a multiple of ``multiple_of`` (cheaper
+    FFTs). Host-side by construction — FFT shapes must be static — so call it at
+    setup time with the initial cell.
 
-    Note the heuristic is purely geometric: the resolution PME actually needs also
-    grows with the Ewald splitting parameter ``alpha``, so verify the accuracy of a
-    chosen mesh against direct Ewald rather than trusting ``spacing`` alone.
+    The heuristic is purely geometric: the resolution PME needs also grows with
+    the splitting parameter ``alpha``, so verify a chosen mesh against direct
+    Ewald rather than trusting ``spacing`` alone.
     """
     lengths = np.asarray(cell.perpendicular_lengths).reshape(-1, 3).max(axis=0)
     dims: list[int] = []
@@ -112,12 +104,11 @@ def _bspline_weights(frac: Array, order: int) -> Array:
     """
     j = jnp.arange(order)
     x = frac[..., None] + j  # M_n evaluated at f, f+1, ..., f+(p-1)
-    # M_1 is the indicator of [0, 1), so at this point only j = 0 is nonzero; each
-    # Cox-de Boor pass below widens the support by one grid point, so after the
-    # p - 1 passes all p offsets carry weight.
-    w = jnp.where((x >= 0) & (x < 1), 1.0, 0.0)  # M_1
+    w = jnp.where((x >= 0) & (x < 1), 1.0, 0.0)  # M_1 = indicator of [0, 1)
     for k in range(2, order + 1):
-        # M_k(x) = x/(k-1) M_{k-1}(x) + (k-x)/(k-1) M_{k-1}(x-1); shift gives M_{k-1}(x-1)
+        # Cox-de Boor: M_k(x) = [x M_{k-1}(x) + (k-x) M_{k-1}(x-1)] / (k-1); the
+        # shift gives M_{k-1}(x-1). Each pass widens the support by one point, so
+        # only j = 0 is nonzero above but all p offsets carry weight at the end.
         w_shift = jnp.concatenate([jnp.zeros_like(w[..., :1]), w[..., :-1]], axis=-1)
         w = (x * w + (k - x) * w_shift) / (k - 1)
     return w
@@ -142,26 +133,22 @@ def _euler_modulus_sq(m_size: int, order: int, dtype: DTypeLike) -> Array:
 def _pme_reciprocal_energy(
     inp: EwaldLongRangeInput[Any], settings: PMESettings
 ) -> Array:
-    """Per-system smooth-PME reciprocal energy, shape ``(n_sys,)``, in atomic
-    units (the caller scales by ``TO_STANDARD_UNITS``)."""
+    """Per-system smooth-PME reciprocal energy, shape ``(n_sys,)``, atomic units."""
     pc = inp.point_cloud
     positions = pc.particles.data.positions
     charges = pc.particles.data.charges
     sys_idx = pc.particles.data.system.indices
     n_sys = pc.batch_size
     cell = pc.systems.data.cell
-    # Key-based lookup (as in `prefactor`), not raw .data: the parameter and
-    # system tables need not be keyed in the same order.
     alpha = inp.parameters.alpha[pc.systems.index]
     order = settings.order
     dtype = positions.dtype
     Mx, My, Mz = settings.mesh
-    Mvec = jnp.asarray(settings.mesh, dtype=dtype)
 
     # Fractional coords in each particle's own cell, folded into [0, 1).
     cell_p = cell[sys_idx]
     frac, _ = cell_p.fold(cell_p.frame.to_fractional(positions))  # (N, 3)
-    u = frac * Mvec
+    u = frac * jnp.asarray(settings.mesh, dtype=dtype)
     base = jnp.floor(u).astype(jnp.int32)
     f = u - base
 
@@ -179,46 +166,36 @@ def _pme_reciprocal_energy(
         * wx[:, :, None, None]
         * wy[:, None, :, None]
         * wz[:, None, None, :]
-    )
-    flat = (
-        sys_idx[:, None, None, None] * (Mx * My * Mz)
-        + gx[:, :, None, None] * (My * Mz)
-        + gy[:, None, :, None] * Mz
-        + gz[:, None, None, :]
     )  # (N, p, p, p)
     Q = (
-        jnp.zeros((n_sys * Mx * My * Mz,), dtype=dtype)
-        .at[flat.reshape(-1)]
-        .add(w3.reshape(-1))
+        jnp.zeros((n_sys, Mx, My, Mz), dtype=dtype)
+        .at[
+            sys_idx[:, None, None, None],
+            gx[:, :, None, None],
+            gy[:, None, :, None],
+            gz[:, None, None, :],
+        ]
+        .add(w3)
     )
-    Q = Q.reshape(n_sys, Mx, My, Mz)
     Fq = jnp.fft.fftn(Q, axes=(1, 2, 3))  # (n_sys, Mx, My, Mz) complex
 
-    # Per-system k-vectors, matching EwaldLongRangeInput.kvecs.
-    nx = jnp.fft.fftfreq(Mx) * Mx
-    ny = jnp.fft.fftfreq(My) * My
-    nz = jnp.fft.fftfreq(Mz) * Mz
-    nX, nY, nZ = jnp.meshgrid(nx, ny, nz, indexing="ij")
-    n_idx = jnp.stack([nX, nY, nZ], axis=-1).astype(dtype)  # (Mx,My,Mz,3)
-    kvec = 2.0 * jnp.pi * jnp.einsum("sab,xyzb->sxyza", cell.inverse_vectors, n_idx)
-    k2 = jnp.sum(kvec**2, axis=-1)  # (n_sys, Mx, My, Mz)
+    # Per-system k-vectors on the FFT frequency grid, as in EwaldLongRangeInput.kvecs.
+    n_axes = [jnp.fft.fftfreq(m) * m for m in settings.mesh]  # integer mode numbers
+    n_idx = jnp.stack(jnp.meshgrid(*n_axes, indexing="ij"), axis=-1).astype(dtype)
+    kvec = triangular_3x3_matmul(
+        cell.inverse_vectors.mT[:, None] * 2 * jnp.pi, n_idx.reshape(-1, 3), lower=False
+    )
+    k2 = jnp.sum(kvec**2, axis=-1).reshape(n_sys, Mx, My, Mz)
 
     bsq = (
         _euler_modulus_sq(Mx, order, dtype)[:, None, None]
         * _euler_modulus_sq(My, order, dtype)[None, :, None]
         * _euler_modulus_sq(Mz, order, dtype)[None, None, :]
     )  # (Mx,My,Mz)
-
-    nonzero = k2 > 0
-    k2_safe = jnp.where(nonzero, k2, 1.0)
-    pref = (
-        (2.0 * jnp.pi)
-        / inp.volume[:, None, None, None]
-        * jnp.exp(-k2_safe / (4.0 * alpha[:, None, None, None] ** 2))
-        / k2_safe
+    pref = reciprocal_prefactor(
+        k2, inp.volume[:, None, None, None], alpha[:, None, None, None]
     )
-    influence = jnp.where(nonzero, pref * bsq[None], 0.0)
-    return jnp.sum(influence * (jnp.abs(Fq) ** 2), axis=(1, 2, 3))  # (n_sys,)
+    return jnp.sum(pref * bsq * jnp.abs(Fq) ** 2, axis=(1, 2, 3))  # (n_sys,)
 
 
 def make_pme_long_range_energy(settings: PMESettings):
@@ -228,15 +205,7 @@ def make_pme_long_range_energy(settings: PMESettings):
         inp: EwaldLongRangeInput[State],
     ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
         """Reciprocal-space (long-range) PME energy. Drop-in for ``ewald_long_range_energy``."""
-        n_sys = inp.point_cloud.batch_size
-        energy = _pme_reciprocal_energy(inp, settings)
-        assert energy.shape == (n_sys,), (
-            f"Expected energy shape {(n_sys,)} but got {energy.shape}."
-        )
-        energy = energy * TO_STANDARD_UNITS
-        # The mesh sum omits k = 0 just as the direct-Ewald sum does, so it needs the
-        # same neutralizing-background term to stay correct for a net-charged system.
-        total = ewald_net_charge_energy(inp).map_data(lambda e_net: e_net + energy)
+        total = reciprocal_total_energy(inp, _pme_reciprocal_energy(inp, settings))
         return WithPatch(total, IdPatch())
 
     return pme_long_range_energy
@@ -264,26 +233,21 @@ def make_pme_long_range_potential[
 ) -> Potential[State, Gradients, Hessians, Ptch]:
     """Create the PME reciprocal-space (long-range) potential.
 
-    Mirrors ``make_ewald_long_range_potential`` exactly (same composer, same
-    point-cloud gradient lens) so forces and NPT stress come from autodiff.
-
-    ``cache_lens`` is accepted for signature parity with
-    ``make_ewald_long_range_potential`` but must be ``None``: PME needs no
-    structure-factor cache, and ``PotentialFromEnergy`` emits an ``IdPatch``.
+    ``make_ewald_long_range_potential`` with the PME energy fn, so forces and NPT
+    stress come from autodiff through the same composer. ``cache_lens`` is
+    accepted for signature parity but must be ``None``: one moved particle still
+    changes the whole FFT, so there is no incremental structure-factor cache.
     """
     assert cache_lens is None, "PME has no structure-factor cache to update."
-    return PotentialFromEnergy(
-        energy_fn=make_pme_long_range_energy(settings),
-        composer=EwaldLongRangeComposer(
-            particles=particles_view,
-            systems=systems_view,
-            probe=probe,
-            parameters=parameter_lens,
-            cache=None,
-        ),
-        gradient_lens=lens(lambda x: x.point_cloud).nest(gradient_lens),
-        hessian_lens=hessian_lens,
+    return make_ewald_long_range_potential(
+        particles_view=particles_view,
+        systems_view=systems_view,
+        parameter_lens=parameter_lens,
         cache_lens=None,
+        probe=probe,
+        gradient_lens=gradient_lens,
+        hessian_lens=hessian_lens,
         hessian_idx_view=hessian_idx_view,
         patch_idx_view=patch_idx_view,
+        energy_fn=make_pme_long_range_energy(settings),
     )

--- a/src/kups/potential/classical/pme.py
+++ b/src/kups/potential/classical/pme.py
@@ -1,0 +1,299 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smooth Particle-Mesh Ewald (PME) reciprocal-space potential.
+
+An ``O(N log N)`` FFT-based replacement for the direct-Ewald reciprocal term
+``ewald_long_range_energy``, whose dense ``(N, N_k, 2)`` structure-factor tensor
+runs out of memory at large ``N``. It is a drop-in at the long-range seam, so
+forces and the NPT stress still come from autodiff.
+
+Convention matches ``ewald.py`` so PME converges to the same number::
+
+    P(k) = (2*pi/V) * exp(-k^2 / (4*alpha^2)) / k^2 ,   k = 2*pi * inverse_vectors @ n
+    E_recip = sum_{k != 0} P(k) * B(m) * |FFT(Q)(m)|^2 * TO_STANDARD_UNITS
+
+where ``Q`` is the order-``p`` cardinal B-spline charge mesh and ``B(m)`` is the
+Euler exponential-spline aliasing correction (Essmann et al. 1995). ``alpha`` and
+the real-space cutoff are reused verbatim from ``EwaldParameters`` so the
+short-range / self / exclusion terms are unchanged and the splitting is
+consistent. The FFT mesh dimensions are static (chosen once at construction);
+under NPT the box fluctuates but the mesh stays fixed, as in standard PME.
+
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+from jax.typing import DTypeLike
+
+from kups.core.cell import Periodic3D
+from kups.core.data import Table, WithIndices
+from kups.core.lens import Lens, View, lens
+from kups.core.patch import IdPatch, Patch, Probe, WithPatch
+from kups.core.potential import EMPTY_LENS, Energy, Potential, PotentialOut
+from kups.core.typing import HasCell, ParticleId, SystemId
+from kups.potential.classical.ewald import (
+    TO_STANDARD_UNITS,
+    EwaldCache,
+    EwaldLongRangeComposer,
+    EwaldLongRangeInput,
+    EwaldParameters,
+    IsEwaldPointData,
+    ewald_net_charge_energy,
+)
+from kups.potential.common.energy import PotentialFromEnergy
+from kups.potential.common.graph import PointCloud
+
+DEFAULT_SPLINE_ORDER = 6
+"""Default cardinal B-spline order."""
+
+
+@dataclasses.dataclass(frozen=True)
+class PMESettings:
+    """Select FFT-based PME for the reciprocal term instead of direct Ewald.
+
+    Passed to `make_ewald_potential` / `make_ewald_from_state` as ``pme=``; leaving
+    those ``None`` keeps the direct-Ewald reciprocal sum.
+
+    Attributes:
+        mesh: Static FFT grid dimensions, held fixed across a trajectory (see
+            `pme_mesh_for_cell`).
+        order: Cardinal B-spline order.
+    """
+
+    mesh: tuple[int, int, int]
+    order: int = DEFAULT_SPLINE_ORDER
+
+
+def pme_mesh_for_cell(
+    cell_vectors: Array, spacing: float = 1.0, multiple_of: int = 2
+) -> tuple[int, int, int]:
+    """Pick static PME mesh dimensions for a reference cell (~``spacing`` Angstrom).
+
+    Resolution is measured across opposing faces, not along the lattice vectors, so
+    the spacing holds for sheared cells too. Dims are rounded up to a multiple of
+    ``multiple_of`` (cheaper FFTs). Use the *initial* cell; the mesh is held fixed
+    across an NPT trajectory.
+
+    Note the heuristic is purely geometric: the resolution PME actually needs also
+    grows with the Ewald splitting parameter ``alpha``, so verify the accuracy of a
+    chosen mesh against direct Ewald rather than trusting ``spacing`` alone.
+    """
+    v = np.asarray(cell_vectors)
+    volume = abs(float(np.linalg.det(v)))
+    lengths = [
+        volume / float(np.linalg.norm(np.cross(v[b], v[c])))
+        for b, c in ((1, 2), (0, 2), (0, 1))
+    ]
+    dims: list[int] = []
+    for length in lengths:
+        m = int(np.ceil(float(length) / spacing))
+        if multiple_of > 1:
+            m = ((m + multiple_of - 1) // multiple_of) * multiple_of
+        dims.append(max(m, multiple_of))
+    return (dims[0], dims[1], dims[2])
+
+
+def _bspline_weights(frac: Array, order: int) -> Array:
+    """Order-``p`` cardinal B-spline weights for the ``p`` nearest grid points.
+
+    ``frac`` is the fractional part (``[0, 1)``) of the scaled grid coordinate.
+    Returns ``frac.shape + (order,)`` weights for offsets ``j = 0..order-1`` (grid
+    point ``floor(u) - j``). Weights are smooth in ``frac`` (so gradients flow) and
+    form a partition of unity (sum to 1).
+    """
+    j = jnp.arange(order)
+    x = frac[..., None] + j  # M_n evaluated at f, f+1, ..., f+(p-1)
+    w = jnp.where((x >= 0) & (x < 1), 1.0, 0.0)  # M_1
+    for k in range(2, order + 1):
+        # M_k(x) = x/(k-1) M_{k-1}(x) + (k-x)/(k-1) M_{k-1}(x-1); shift gives M_{k-1}(x-1)
+        w_shift = jnp.concatenate([jnp.zeros_like(w[..., :1]), w[..., :-1]], axis=-1)
+        w = (x * w + (k - x) * w_shift) / (k - 1)
+    return w
+
+
+def _euler_modulus_sq(m_size: int, order: int, dtype: DTypeLike) -> Array:
+    """``|b(m)|^2`` Euler exponential-spline aliasing factor for one axis.
+
+    For odd ``order`` the denominator vanishes on the Nyquist plane, where the true
+    factor diverges; those modes are damped to 1 rather than left as inf. Even
+    orders (the default) have no such plane.
+    """
+    mvals = _bspline_weights(jnp.zeros((), dtype=dtype), order)  # [M_n(0..p-1)]
+    m = jnp.arange(m_size)
+    k = jnp.arange(order - 1)
+    phase = jnp.exp(2j * jnp.pi * m[:, None] * k[None, :] / m_size)
+    denom = jnp.sum(mvals[1:order][None, :] * phase, axis=-1)
+    denom2 = jnp.abs(denom) ** 2
+    return jnp.where(denom2 < 1e-10, 1.0, 1.0 / denom2)
+
+
+def _pme_reciprocal_energy_batched(
+    positions: Array,  # (N, 3) Cartesian, Angstrom
+    charges: Array,  # (N,)
+    sys_idx: Array,  # (N,) per-particle system index
+    n_sys: int,  # number of systems (static)
+    inverse_vectors: Array,  # (n_sys, 3, 3)
+    volume: Array,  # (n_sys,)
+    alpha: Array,  # (n_sys,)
+    mesh: tuple[int, int, int],
+    order: int,
+) -> Array:
+    """Per-system smooth-PME reciprocal energy, in atomic units (the caller scales
+    by ``TO_STANDARD_UNITS``)."""
+    dtype = positions.dtype
+    Mx, My, Mz = mesh
+    Mvec = jnp.asarray(mesh, dtype=dtype)
+
+    # Fractional coords in each particle's own cell. The contraction must match
+    # Frame.to_fractional (inverse_vectors contracted on its *first* axis); the
+    # transpose cancels against kvec below, so getting it wrong is invisible for
+    # orthorhombic cells but shears the effective lattice.
+    inv_p = inverse_vectors[sys_idx]  # (N, 3, 3)
+    frac = jnp.einsum("nba,nb->na", inv_p, positions) % 1.0  # (N, 3) in [0, 1)
+    u = frac * Mvec
+    base = jnp.floor(u).astype(jnp.int32)
+    f = u - base
+
+    wx = _bspline_weights(f[:, 0], order)  # (N, p)
+    wy = _bspline_weights(f[:, 1], order)
+    wz = _bspline_weights(f[:, 2], order)
+    j = jnp.arange(order)
+    gx = (base[:, 0:1] - j) % Mx  # (N, p)
+    gy = (base[:, 1:2] - j) % My
+    gz = (base[:, 2:3] - j) % Mz
+
+    # Scatter charges onto a per-system mesh Q of shape (n_sys, Mx, My, Mz).
+    w3 = (
+        charges[:, None, None, None]
+        * wx[:, :, None, None]
+        * wy[:, None, :, None]
+        * wz[:, None, None, :]
+    )
+    flat = (
+        sys_idx[:, None, None, None] * (Mx * My * Mz)
+        + gx[:, :, None, None] * (My * Mz)
+        + gy[:, None, :, None] * Mz
+        + gz[:, None, None, :]
+    )  # (N, p, p, p)
+    Q = (
+        jnp.zeros((n_sys * Mx * My * Mz,), dtype=dtype)
+        .at[flat.reshape(-1)]
+        .add(w3.reshape(-1))
+    )
+    Q = Q.reshape(n_sys, Mx, My, Mz)
+    Fq = jnp.fft.fftn(Q, axes=(1, 2, 3))  # (n_sys, Mx, My, Mz) complex
+
+    # Per-system k-vectors, matching EwaldLongRangeInput.kvecs.
+    nx = jnp.fft.fftfreq(Mx) * Mx
+    ny = jnp.fft.fftfreq(My) * My
+    nz = jnp.fft.fftfreq(Mz) * Mz
+    nX, nY, nZ = jnp.meshgrid(nx, ny, nz, indexing="ij")
+    n_idx = jnp.stack([nX, nY, nZ], axis=-1).astype(dtype)  # (Mx,My,Mz,3)
+    kvec = 2.0 * jnp.pi * jnp.einsum("sab,xyzb->sxyza", inverse_vectors, n_idx)
+    k2 = jnp.sum(kvec**2, axis=-1)  # (n_sys, Mx, My, Mz)
+
+    bsq = (
+        _euler_modulus_sq(Mx, order, dtype)[:, None, None]
+        * _euler_modulus_sq(My, order, dtype)[None, :, None]
+        * _euler_modulus_sq(Mz, order, dtype)[None, None, :]
+    )  # (Mx,My,Mz)
+
+    nonzero = k2 > 0
+    k2_safe = jnp.where(nonzero, k2, 1.0)
+    pref = (
+        (2.0 * jnp.pi)
+        / volume[:, None, None, None]
+        * jnp.exp(-k2_safe / (4.0 * alpha[:, None, None, None] ** 2))
+        / k2_safe
+    )
+    influence = jnp.where(nonzero, pref * bsq[None], 0.0)
+    return jnp.sum(influence * (jnp.abs(Fq) ** 2), axis=(1, 2, 3))  # (n_sys,)
+
+
+def make_pme_long_range_energy(mesh: tuple[int, int, int], order: int):
+    """Build the PME long-range energy fn for a fixed static ``mesh`` and ``order``."""
+
+    def pme_long_range_energy[State](
+        inp: EwaldLongRangeInput[State],
+    ) -> WithPatch[Table[SystemId, Energy], Patch[State]]:
+        """Reciprocal-space (long-range) PME energy. Drop-in for ``ewald_long_range_energy``."""
+        pc = inp.point_cloud
+        cell = pc.systems.data.cell
+        n_sys = pc.batch_size
+        energy = _pme_reciprocal_energy_batched(
+            positions=pc.particles.data.positions,
+            charges=pc.particles.data.charges,
+            sys_idx=pc.particles.data.system.indices,
+            n_sys=n_sys,
+            inverse_vectors=cell.inverse_vectors,
+            volume=cell.volume,
+            # Key-based lookup (as in `prefactor`), not raw .data: the parameter and
+            # system tables need not be keyed in the same order.
+            alpha=inp.parameters.alpha[pc.systems.index],
+            mesh=mesh,
+            order=order,
+        )
+        assert energy.shape == (n_sys,), (
+            f"Expected energy shape {(n_sys,)} but got {energy.shape}."
+        )
+        energy = energy * TO_STANDARD_UNITS
+        # The mesh sum omits k = 0 just as the direct-Ewald sum does, so it needs the
+        # same neutralizing-background term to stay correct for a net-charged system.
+        total = ewald_net_charge_energy(inp).map_data(lambda e_net: e_net + energy)
+        return WithPatch(total, IdPatch())
+
+    return pme_long_range_energy
+
+
+def make_pme_long_range_potential[
+    State,
+    Ptch: Patch[Any],
+    Gradients,
+    Hessians,
+](
+    particles_view: View[State, Table[ParticleId, IsEwaldPointData]],
+    systems_view: View[State, Table[SystemId, HasCell[Periodic3D]]],
+    parameter_lens: Lens[State, EwaldParameters],
+    cache_lens: Lens[State, EwaldCache[Gradients, Hessians]] | None,
+    probe: Probe[State, Ptch, WithIndices[ParticleId, IsEwaldPointData]] | None = None,
+    gradient_lens: Lens[
+        PointCloud[IsEwaldPointData, HasCell[Periodic3D]], Gradients
+    ] = EMPTY_LENS,
+    hessian_lens: Lens[Gradients, Hessians] = EMPTY_LENS,
+    hessian_idx_view: View[State, Hessians] = EMPTY_LENS,
+    patch_idx_view: View[State, PotentialOut[Gradients, Hessians]] | None = None,
+    *,
+    settings: PMESettings,
+) -> Potential[State, Gradients, Hessians, Ptch]:
+    """Create the PME reciprocal-space (long-range) potential.
+
+    Mirrors ``make_ewald_long_range_potential`` exactly (same composer, same
+    point-cloud gradient lens) so forces and NPT stress come from autodiff.
+
+    ``cache_lens`` is accepted for signature parity with
+    ``make_ewald_long_range_potential`` but must be ``None``: PME needs no
+    structure-factor cache, and ``PotentialFromEnergy`` emits an ``IdPatch``.
+    """
+    assert cache_lens is None, "PME has no structure-factor cache to update."
+    return PotentialFromEnergy(
+        energy_fn=make_pme_long_range_energy(settings.mesh, settings.order),
+        composer=EwaldLongRangeComposer(
+            particles=particles_view,
+            systems=systems_view,
+            probe=probe,
+            parameters=parameter_lens,
+            cache=None,
+        ),
+        gradient_lens=lens(lambda x: x.point_cloud).nest(gradient_lens),
+        hessian_lens=hessian_lens,
+        cache_lens=None,
+        hessian_idx_view=hessian_idx_view,
+        patch_idx_view=patch_idx_view,
+    )

--- a/test/potential/test_pme.py
+++ b/test/potential/test_pme.py
@@ -28,6 +28,7 @@ from kups.potential.classical.ewald import (
     kvecs_from_kmax,
 )
 from kups.potential.classical.pme import (
+    PMESettings,
     make_pme_long_range_energy,
     pme_mesh_for_cell,
 )
@@ -36,6 +37,29 @@ from kups.potential.common.graph import PointCloud
 from .test_ewald import _make_particle_data, _make_systems
 
 ORDER = 8
+"""B-spline order used throughout: above the default (6) so the interpolation
+error stays well below the tight tolerances these tests pin, which are chosen
+to expose convention bugs (transposed lattices, missing background terms)
+rather than to measure spline accuracy. At order 6 the energy/force tests fail
+at these tolerances."""
+
+
+def _pme_settings(cell_vectors: Array, spacing: float) -> PMESettings:
+    """PMESettings with a mesh sized for ``cell_vectors`` at ``spacing`` Angstrom."""
+    cell = PeriodicCell(TriclinicFrame.from_matrix(cell_vectors))
+    return PMESettings(pme_mesh_for_cell(cell, spacing=spacing), ORDER)
+
+
+def _single_system_params(charges: Array, cell: PeriodicCell, eps: float):
+    """Estimated single-system ``EwaldParameters`` keyed by ``SystemId(0)``."""
+    est = estimate_ewald_parameters(charges, cell, epsilon_total=eps)
+    return EwaldParameters(
+        alpha=Table((SystemId(0),), jnp.asarray([est.alpha])),
+        cutoff=Table((SystemId(0),), jnp.asarray([est.real_cutoff])),
+        reciprocal_lattice_shifts=Table(
+            (SystemId(0),), kvecs_from_kmax(cell, est.k_max)[None]
+        ),
+    )
 
 
 def _nacl(repeats: int = 5, eps: float = 5e-5, jitter: float = 0.3):
@@ -68,15 +92,7 @@ def _nacl(repeats: int = 5, eps: float = 5e-5, jitter: float = 0.3):
         positions = positions + jitter * jax.random.normal(
             jax.random.key(7), positions.shape
         )
-    est = estimate_ewald_parameters(charges, cell, epsilon_total=eps)
-    params = EwaldParameters(
-        alpha=Table((SystemId(0),), jnp.asarray([est.alpha])),
-        cutoff=Table((SystemId(0),), jnp.asarray([est.real_cutoff])),
-        reciprocal_lattice_shifts=Table(
-            (SystemId(0),), kvecs_from_kmax(cell, est.k_max)[None]
-        ),
-    )
-    return positions, charges, cell, params
+    return positions, charges, cell, _single_system_params(charges, cell, eps)
 
 
 def _lr_input(positions: Array, cell_vectors: Array, charges: Array, params, cutoff):
@@ -95,16 +111,16 @@ class TestPMEvsEwald:
     def test_recip_energy_matches_ewald(self):
         positions, charges, cell, params = _nacl()
         cellv = cell.vectors  # (3,3)
-        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+        settings = _pme_settings(cellv, spacing=0.5)
         inp = _lr_input(positions, cellv, charges, params, params.cutoff.data)
         e_ewald = float(ewald_long_range_energy(inp).data.data[0])
-        e_pme = float(make_pme_long_range_energy(mesh, ORDER)(inp).data.data[0])
+        e_pme = float(make_pme_long_range_energy(settings)(inp).data.data[0])
         npt.assert_allclose(e_pme, e_ewald, rtol=1e-5)
 
     def test_forces_match_ewald(self):
         positions, charges, cell, params = _nacl()
         cellv = cell.vectors
-        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+        settings = _pme_settings(cellv, spacing=0.5)
 
         def e_ewald(p):
             return ewald_long_range_energy(
@@ -112,12 +128,39 @@ class TestPMEvsEwald:
             ).data.data.sum()
 
         def e_pme(p):
-            return make_pme_long_range_energy(mesh, ORDER)(
+            return make_pme_long_range_energy(settings)(
                 _lr_input(p, cellv, charges, params, params.cutoff.data)
             ).data.data.sum()
 
         f_ewald = jax.grad(e_ewald)(positions)
         f_pme = jax.grad(e_pme)(positions)
+        npt.assert_allclose(f_pme, f_ewald, atol=3e-4)
+
+    def test_random_disordered_system_matches_ewald(self):
+        """Uniform-random positions and random (neutralized) charges: no lattice
+        symmetry left to mask a convention error, unlike the NaCl fixtures."""
+        key_r, key_q = jax.random.split(jax.random.key(11))
+        n, box = 200, 12.0
+        cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3, dtype=float) * box))
+        positions = box * jax.random.uniform(key_r, (n, 3), dtype=float)
+        charges = jax.random.normal(key_q, (n,), dtype=float)
+        charges = charges - charges.mean()  # neutral; net charge covered elsewhere
+        params = _single_system_params(charges, cell, eps=5e-5)
+        cellv = cell.vectors
+        settings = _pme_settings(cellv, spacing=0.5)
+
+        def total_energy(energy_fn, p):
+            return energy_fn(
+                _lr_input(p, cellv, charges, params, params.cutoff.data)
+            ).data.data.sum()
+
+        e_ewald, f_ewald = jax.value_and_grad(
+            lambda p: total_energy(ewald_long_range_energy, p)
+        )(positions)
+        e_pme, f_pme = jax.value_and_grad(
+            lambda p: total_energy(make_pme_long_range_energy(settings), p)
+        )(positions)
+        npt.assert_allclose(float(e_pme), float(e_ewald), rtol=1e-5)
         npt.assert_allclose(f_pme, f_ewald, atol=3e-4)
 
     @pytest.mark.parametrize("shear", [0.0, 0.5])
@@ -132,10 +175,10 @@ class TestPMEvsEwald:
         """
         positions, charges, cell, params = _nacl()
         cellv = cell.vectors.at[1, 0].add(shear * float(cell.vectors[0, 0]))
-        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.4)
+        settings = _pme_settings(cellv, spacing=0.4)
         inp = _lr_input(positions, cellv, charges, params, params.cutoff.data)
         e_ewald = float(ewald_long_range_energy(inp).data.data[0])
-        e_pme = float(make_pme_long_range_energy(mesh, ORDER)(inp).data.data[0])
+        e_pme = float(make_pme_long_range_energy(settings)(inp).data.data[0])
         npt.assert_allclose(e_pme, e_ewald, rtol=1e-3)
 
     def test_full_cell_gradient_matches_ewald(self):
@@ -144,7 +187,7 @@ class TestPMEvsEwald:
         transposed fractional transform corrupts exactly those."""
         positions, charges, cell, params = _nacl()
         cellv = cell.vectors
-        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.4)
+        settings = _pme_settings(cellv, spacing=0.4)
 
         def grad_cell(energy_fn):
             return np.asarray(
@@ -156,7 +199,7 @@ class TestPMEvsEwald:
             )
 
         g_ewald = grad_cell(ewald_long_range_energy)
-        g_pme = grad_cell(make_pme_long_range_energy(mesh, ORDER))
+        g_pme = grad_cell(make_pme_long_range_energy(settings))
         scale = float(np.abs(g_ewald).max())
         npt.assert_allclose(g_pme, g_ewald, rtol=1e-3, atol=1e-3 * scale)
 
@@ -164,7 +207,6 @@ class TestPMEvsEwald:
         """A 2-system batch returns correct per-SystemId energies (flat batch_idx)."""
         positions, charges, cell, params = _nacl()
         cellv = cell.vectors
-        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
 
         # tile two identical replicas onto one SystemId axis
         pos2 = jnp.concatenate([positions, positions])
@@ -173,6 +215,9 @@ class TestPMEvsEwald:
         sys_ids = jnp.concatenate([jnp.zeros(n, int), jnp.ones(n, int)])
         cell2 = cell[None]
         cell2 = jax.tree.map(lambda a: jnp.concatenate([a, a]), cell2)
+        # size the shared mesh from the batched cell (per-axis max over systems)
+        settings = PMESettings(pme_mesh_for_cell(cell2, spacing=0.5), ORDER)
+        assert settings.mesh == _pme_settings(cellv, spacing=0.5).mesh
         params2 = EwaldParameters(
             alpha=Table(
                 (SystemId(0), SystemId(1)),
@@ -198,7 +243,7 @@ class TestPMEvsEwald:
         )
         systems = _make_systems(cell2, params2.cutoff.data)
         inp = EwaldLongRangeInput(PointCloud(particles, systems), params2, None)
-        e_pme = np.asarray(make_pme_long_range_energy(mesh, ORDER)(inp).data.data)
+        e_pme = np.asarray(make_pme_long_range_energy(settings)(inp).data.data)
         e_ewald = np.asarray(ewald_long_range_energy(inp).data.data)
         assert e_pme.shape == (2,)
         npt.assert_allclose(e_pme[0], e_pme[1], rtol=1e-10)  # identical replicas
@@ -211,8 +256,8 @@ class TestPMEvsEwald:
         charges = charges.at[0].set(charges[0] + 1.0)  # break neutrality
         assert abs(float(jnp.sum(charges))) > 0.5
         cellv = cell.vectors
-        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+        settings = _pme_settings(cellv, spacing=0.5)
         inp = _lr_input(positions, cellv, charges, params, params.cutoff.data)
         e_ewald = float(ewald_long_range_energy(inp).data.data[0])
-        e_pme = float(make_pme_long_range_energy(mesh, ORDER)(inp).data.data[0])
+        e_pme = float(make_pme_long_range_energy(settings)(inp).data.data[0])
         npt.assert_allclose(e_pme, e_ewald, rtol=1e-4)

--- a/test/potential/test_pme.py
+++ b/test/potential/test_pme.py
@@ -37,11 +37,9 @@ from kups.potential.common.graph import PointCloud
 from .test_ewald import _make_particle_data, _make_systems
 
 ORDER = 8
-"""B-spline order used throughout: above the default (6) so the interpolation
-error stays well below the tight tolerances these tests pin, which are chosen
-to expose convention bugs (transposed lattices, missing background terms)
-rather than to measure spline accuracy. At order 6 the energy/force tests fail
-at these tolerances."""
+"""Above the default (6) so spline interpolation error sits well below the pinned
+tolerances, which are tight to catch convention bugs rather than to measure
+spline accuracy; order 6 fails them."""
 
 
 def _pme_settings(cell_vectors: Array, spacing: float) -> PMESettings:
@@ -218,24 +216,14 @@ class TestPMEvsEwald:
         # size the shared mesh from the batched cell (per-axis max over systems)
         settings = PMESettings(pme_mesh_for_cell(cell2, spacing=0.5), ORDER)
         assert settings.mesh == _pme_settings(cellv, spacing=0.5).mesh
+
+        def tile2(t: Table) -> Table:
+            return Table((SystemId(0), SystemId(1)), jnp.concatenate([t.data, t.data]))
+
         params2 = EwaldParameters(
-            alpha=Table(
-                (SystemId(0), SystemId(1)),
-                jnp.concatenate([params.alpha.data, params.alpha.data]),
-            ),
-            cutoff=Table(
-                (SystemId(0), SystemId(1)),
-                jnp.concatenate([params.cutoff.data, params.cutoff.data]),
-            ),
-            reciprocal_lattice_shifts=Table(
-                (SystemId(0), SystemId(1)),
-                jnp.concatenate(
-                    [
-                        params.reciprocal_lattice_shifts.data,
-                        params.reciprocal_lattice_shifts.data,
-                    ]
-                ),
-            ),
+            alpha=tile2(params.alpha),
+            cutoff=tile2(params.cutoff),
+            reciprocal_lattice_shifts=tile2(params.reciprocal_lattice_shifts),
         )
         particles = Table.arange(
             _make_particle_data(pos2, q2, n_systems=2, system_ids=sys_ids),

--- a/test/potential/test_pme.py
+++ b/test/potential/test_pme.py
@@ -1,0 +1,218 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the smooth-PME reciprocal-space potential (``kups.potential.classical.pme``).
+
+PME must reproduce the direct-Ewald reciprocal term (``ewald_long_range_energy``)
+for energy, forces (``dE/dr``) and the NPT stress (``dE/dcell``), and handle a
+batched multi-system axis. The trusted oracle is the existing direct-Ewald path
+(validated against the NaCl Madelung constant in ``test_ewald.py``).
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+from jax import Array
+
+from kups.core.cell import PeriodicCell, TriclinicFrame, make_supercell
+from kups.core.data.table import Table
+from kups.core.lens import lens
+from kups.core.typing import ParticleId, SystemId
+from kups.potential.classical.ewald import (
+    EwaldLongRangeInput,
+    EwaldParameters,
+    estimate_ewald_parameters,
+    ewald_long_range_energy,
+    kvecs_from_kmax,
+)
+from kups.potential.classical.pme import (
+    make_pme_long_range_energy,
+    pme_mesh_for_cell,
+)
+from kups.potential.common.graph import PointCloud
+
+from .test_ewald import _make_particle_data, _make_systems
+
+ORDER = 8
+
+
+def _nacl(repeats: int = 5, eps: float = 5e-5, jitter: float = 0.3):
+    """Build a NaCl rocksalt supercell + estimated single-system EwaldParameters.
+
+    A small thermal ``jitter`` (Angstrom) is applied so the reciprocal-space
+    energy is genuinely nonzero — a pristine lattice has a near-zero direct-Ewald
+    reciprocal term (the k-vector set misses the Bragg peaks), which makes a
+    reciprocal-only rtol comparison degenerate.
+    """
+    positions = jnp.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [1.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+    charges = jnp.array([-1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0], dtype=float)
+    cell = PeriodicCell(TriclinicFrame.from_matrix(jnp.eye(3, dtype=float) * 2))
+    cell, (positions, charges) = make_supercell(
+        cell, repeats, (positions, charges), lens(lambda x: x[0])
+    )
+    if jitter:
+        positions = positions + jitter * jax.random.normal(
+            jax.random.key(7), positions.shape
+        )
+    est = estimate_ewald_parameters(charges, cell, epsilon_total=eps)
+    params = EwaldParameters(
+        alpha=Table((SystemId(0),), jnp.asarray([est.alpha])),
+        cutoff=Table((SystemId(0),), jnp.asarray([est.real_cutoff])),
+        reciprocal_lattice_shifts=Table(
+            (SystemId(0),), kvecs_from_kmax(cell, est.k_max)[None]
+        ),
+    )
+    return positions, charges, cell, params
+
+
+def _lr_input(positions: Array, cell_vectors: Array, charges: Array, params, cutoff):
+    """Rebuild an ``EwaldLongRangeInput`` from raw positions + cell matrix (differentiable)."""
+    cell = PeriodicCell(TriclinicFrame.from_matrix(cell_vectors))
+    particles = Table.arange(
+        _make_particle_data(positions, charges, n_systems=1), label=ParticleId
+    )
+    systems = _make_systems(cell[None], cutoff)
+    return EwaldLongRangeInput(PointCloud(particles, systems), params, None)
+
+
+class TestPMEvsEwald:
+    """PME reciprocal term must match the direct-Ewald oracle."""
+
+    def test_recip_energy_matches_ewald(self):
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors  # (3,3)
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+        inp = _lr_input(positions, cellv, charges, params, params.cutoff.data)
+        e_ewald = float(ewald_long_range_energy(inp).data.data[0])
+        e_pme = float(make_pme_long_range_energy(mesh, ORDER)(inp).data.data[0])
+        npt.assert_allclose(e_pme, e_ewald, rtol=1e-5)
+
+    def test_forces_match_ewald(self):
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+
+        def e_ewald(p):
+            return ewald_long_range_energy(
+                _lr_input(p, cellv, charges, params, params.cutoff.data)
+            ).data.data.sum()
+
+        def e_pme(p):
+            return make_pme_long_range_energy(mesh, ORDER)(
+                _lr_input(p, cellv, charges, params, params.cutoff.data)
+            ).data.data.sum()
+
+        f_ewald = jax.grad(e_ewald)(positions)
+        f_pme = jax.grad(e_pme)(positions)
+        npt.assert_allclose(f_pme, f_ewald, atol=3e-4)
+
+    @pytest.mark.parametrize("shear", [0.0, 0.5])
+    def test_energy_matches_ewald_under_shear(self, shear: float):
+        """PME must use the same fractional-coordinate convention as the rest of the
+        codebase. A transposed transform is invisible for orthorhombic cells (it
+        cancels in k.r) but gives the reciprocal energy of the transposed lattice.
+
+        Shears are kept below one lattice unit: an integer shear is a unimodular
+        re-basis of the same lattice, and direct Ewald's truncated (and then
+        sheared) k-set is not invariant under it, so it stops being a valid oracle.
+        """
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors.at[1, 0].add(shear * float(cell.vectors[0, 0]))
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.4)
+        inp = _lr_input(positions, cellv, charges, params, params.cutoff.data)
+        e_ewald = float(ewald_long_range_energy(inp).data.data[0])
+        e_pme = float(make_pme_long_range_energy(mesh, ORDER)(inp).data.data[0])
+        npt.assert_allclose(e_pme, e_ewald, rtol=1e-3)
+
+    def test_full_cell_gradient_matches_ewald(self):
+        """Every dE/dcell entry must match direct Ewald, not just the diagonal: the
+        off-diagonals are the shear virial an anisotropic barostat integrates, and a
+        transposed fractional transform corrupts exactly those."""
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.4)
+
+        def grad_cell(energy_fn):
+            return np.asarray(
+                jax.grad(
+                    lambda v: energy_fn(
+                        _lr_input(positions, v, charges, params, params.cutoff.data)
+                    ).data.data.sum()
+                )(cellv)
+            )
+
+        g_ewald = grad_cell(ewald_long_range_energy)
+        g_pme = grad_cell(make_pme_long_range_energy(mesh, ORDER))
+        scale = float(np.abs(g_ewald).max())
+        npt.assert_allclose(g_pme, g_ewald, rtol=1e-3, atol=1e-3 * scale)
+
+    def test_two_system_batch(self):
+        """A 2-system batch returns correct per-SystemId energies (flat batch_idx)."""
+        positions, charges, cell, params = _nacl()
+        cellv = cell.vectors
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+
+        # tile two identical replicas onto one SystemId axis
+        pos2 = jnp.concatenate([positions, positions])
+        q2 = jnp.concatenate([charges, charges])
+        n = positions.shape[0]
+        sys_ids = jnp.concatenate([jnp.zeros(n, int), jnp.ones(n, int)])
+        cell2 = cell[None]
+        cell2 = jax.tree.map(lambda a: jnp.concatenate([a, a]), cell2)
+        params2 = EwaldParameters(
+            alpha=Table(
+                (SystemId(0), SystemId(1)),
+                jnp.concatenate([params.alpha.data, params.alpha.data]),
+            ),
+            cutoff=Table(
+                (SystemId(0), SystemId(1)),
+                jnp.concatenate([params.cutoff.data, params.cutoff.data]),
+            ),
+            reciprocal_lattice_shifts=Table(
+                (SystemId(0), SystemId(1)),
+                jnp.concatenate(
+                    [
+                        params.reciprocal_lattice_shifts.data,
+                        params.reciprocal_lattice_shifts.data,
+                    ]
+                ),
+            ),
+        )
+        particles = Table.arange(
+            _make_particle_data(pos2, q2, n_systems=2, system_ids=sys_ids),
+            label=ParticleId,
+        )
+        systems = _make_systems(cell2, params2.cutoff.data)
+        inp = EwaldLongRangeInput(PointCloud(particles, systems), params2, None)
+        e_pme = np.asarray(make_pme_long_range_energy(mesh, ORDER)(inp).data.data)
+        e_ewald = np.asarray(ewald_long_range_energy(inp).data.data)
+        assert e_pme.shape == (2,)
+        npt.assert_allclose(e_pme[0], e_pme[1], rtol=1e-10)  # identical replicas
+        npt.assert_allclose(e_pme, e_ewald, rtol=1e-5)
+
+    def test_net_charged_system_matches_ewald(self):
+        """A net-charged cell needs the same neutralizing-background term as direct
+        Ewald; without it the mesh sum (which also omits k=0) is off by E_net."""
+        positions, charges, cell, params = _nacl()
+        charges = charges.at[0].set(charges[0] + 1.0)  # break neutrality
+        assert abs(float(jnp.sum(charges))) > 0.5
+        cellv = cell.vectors
+        mesh = pme_mesh_for_cell(np.asarray(cellv), spacing=0.5)
+        inp = _lr_input(positions, cellv, charges, params, params.cutoff.data)
+        e_ewald = float(ewald_long_range_energy(inp).data.data[0])
+        e_pme = float(make_pme_long_range_energy(mesh, ORDER)(inp).data.data[0])
+        npt.assert_allclose(e_pme, e_ewald, rtol=1e-4)


### PR DESCRIPTION
**Stack (bottom → top):** #265 → #196

Bottom of the **PME stack** (this PR → PMESettings wiring).

## What

An **O(N log N) FFT-based smooth-PME reciprocal term** (Essmann et al. 1995) as a drop-in for `ewald_long_range_energy`, whose dense `(N, N_k, 2)` structure-factor tensor runs out of memory at large N. Charge spreading with cardinal B-splines, the Euler exponential-spline aliasing correction, and the same neutralizing-background term as direct Ewald so net-charged cells stay correct. Forces and the NPT stress come from autodiff, as for direct Ewald.

## Correctness fixes found while preparing this PR

Each verified test-first (fails against the previous code):

1. **Transposed fractional-coordinate / k-vector convention.** `frac = inv @ r` and `k = 2π·invᵀ·n` were both the transpose of this codebase's convention. The errors cancel in `k·r`, so PME matched Ewald on cubic cells — while computing the reciprocal energy of the *transposed lattice*: wrong energy for any triclinic cell, wrong off-diagonal `dE/dcell` for every cell (silently broken anisotropic NPT; `g[1,0] = -10.08` vs the correct `+0.42` on a cubic cell). Tests: `test_energy_matches_ewald_under_shear` (parametrized), `test_full_cell_gradient_matches_ewald` (full 3×3).
2. **Missing neutralizing-background term** for net-charged cells (all previous fixtures were neutral NaCl). Test: `test_net_charged_system_matches_ewald`.
3. **Per-system `alpha` via keyed lookup** (`alpha[pc.systems.index]`), so a batch whose parameter and system tables are keyed in different orders can't pick up the wrong splitting parameter.

## Removed relative to the original submission

The `fp32_reciprocal`/`pme_fp32` pipeline (zero callers/tests/benchmarks, threaded through 9 signatures) — re-add with a benchmark and a test pinning the accuracy claim if wanted.

## Validation

Tested against the direct-Ewald oracle for energy, forces, the full `dE/dcell` tensor, sheared cells, a net-charged cell, and a two-system batch. Tolerances `1e-5` (energy) / `atol=3e-4` (forces) — the old looser ones had 20–1500× headroom. Known open (documented in docstrings): `pme_mesh_for_cell` ignores `alpha`; deriving the mesh from `alpha` as standard PME codes do is future work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
