### PR TITLE
perf: Apply Kahan compensation to incremental Ewald structure factor accumulation

### DIFF
--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -79,13 +79,13 @@ from kups.potential.common.geometry import (
     PositionsAndSystemIndex,
 )
 from kups.potential.common.graph import (
+    FullGraphSumComposer,
     GraphConstructor,
     GraphPotentialInput,
     IsGraphProbe,
     IsRadiusGraphPoints,
     LocalGraphSumComposer,
     PointCloud,
-    empty_graph_probe,
 )
 
 TO_STANDARD_UNITS = HARTREE * BOHR
@@ -105,14 +105,15 @@ class EwaldCache[Gradient, Hessian]:
     """Cached structure factors and per-component outputs for incremental updates.
 
     Attributes:
-        structure_factor: Complex structure factors, shape `(n_groups, n_kvecs, 2)`.
+        structure_factor: Compensated accumulator over complex structure factors,
+            each of shape `(n_groups, n_kvecs, 2)`.
         short_range: Cached real-space short-range output.
         long_range: Cached reciprocal-space long-range output.
         self_interaction: Cached self-interaction correction output.
         exclusion: Cached bonded-pair exclusion correction output.
     """
 
-    structure_factor: Array  # (n_groups, n_kvecs, 2)
+    structure_factor: KahanSummand[Array]  # (n_groups, n_kvecs, 2)
     short_range: KahanSummand[PotentialOut[Gradient, Hessian]]
     long_range: KahanSummand[PotentialOut[Gradient, Hessian]]
     self_interaction: KahanSummand[PotentialOut[Gradient, Hessian]]
@@ -129,7 +130,7 @@ class EwaldCache[Gradient, Hessian]:
             hessian,
         )
         return EwaldCache(
-            jnp.zeros((n_sys, n_kvecs, 2), dtype=float),
+            KahanSummand.init(jnp.zeros((n_sys, n_kvecs, 2), dtype=float)),
             KahanSummand.init(tree_zeros_like(out)),
             KahanSummand.init(tree_zeros_like(out)),
             KahanSummand.init(tree_zeros_like(out)),
@@ -142,11 +143,12 @@ class EwaldCachePatch[State, Gradient, Hessian](Patch[State]):
     """Patch for updating Ewald structure factors on Monte Carlo accept/reject.
 
     Attributes:
-        new_structure_factor: Updated structure factors to apply on acceptance.
+        new_structure_factor: Updated structure factor accumulator to apply on
+            acceptance; its Kahan compensation is carried over with the value.
         lens: Lens to the ``EwaldCache`` in the state.
     """
 
-    new_structure_factor: Array
+    new_structure_factor: KahanSummand[Array]
     system_idx: Index[SystemId]
     lens: Lens[State, EwaldCache[Gradient, Hessian]] = field(static=True)
 
@@ -156,8 +158,10 @@ class EwaldCachePatch[State, Gradient, Hessian](Patch[State]):
         return self.lens.apply(
             state,
             lambda cache: EwaldCache(
-                structure_factor=where_broadcast_last(
-                    mask, new_sf, cache.structure_factor
+                structure_factor=jax.tree.map(
+                    lambda new, old: where_broadcast_last(mask, new, old),
+                    new_sf,
+                    cache.structure_factor,
                 ),
                 short_range=cache.short_range,
                 long_range=cache.long_range,
@@ -443,14 +447,17 @@ def _structure_factor_update(
     batch_mask: Index[SystemId],
     cache: EwaldCache[Any, Any],
     changes: WithIndices[ParticleId, IsEwaldPointData],
-) -> Array:
+) -> KahanSummand[Array]:
     """Incremental structure factor update.
 
     Math: ``S'(k) = S(k) + dS(k)`` where
     ``dS = sum_changed [rho_new(k) - rho_old(k)]``.
 
     Adds the contribution of changed particles and subtracts their old
-    contribution, using the cached ``S(k)`` from the previous step.
+    contribution, using the cached ``S(k)`` from the previous step. The delta is
+    folded in with Kahan compensation so the low-order bits dropped when a small
+    ``dS(k)`` meets a large ``S(k)`` are carried into the next update instead of
+    accumulating as drift over a long chain of moves.
     """
     idx = changes.indices
     idx_data = idx.indices
@@ -475,8 +482,7 @@ def _structure_factor_update(
         updates.system.num_labels,
         mode="drop",
     )
-    new_sk = cache.structure_factor + sk_delta
-    return new_sk
+    return cache.structure_factor + sk_delta
 
 
 @functools.partial(_structure_factor_update.defjvp, symbolic_zeros=True)
@@ -492,7 +498,8 @@ def _structure_factor_update_jvp(
     Computes the full structure factor JVP (not incremental delta) because
     the cached structure factor is treated as a constant -- only the current
     positions/charges/kvecs contribute tangents. This ensures correct
-    gradients through the incremental update path.
+    gradients through the incremental update path. The Kahan compensation is
+    exactly zero in real arithmetic and hence carries a zero tangent.
     """
     positions, charges, kvecs = primals
     d_positions, d_charges, d_kvecs = tangents
@@ -504,7 +511,6 @@ def _structure_factor_update_jvp(
         cache,
         changes,
     )
-    sk_dot = jnp.zeros_like(sk)
     full_response = _frequency_response(positions, charges, kvecs, batch_mask)
     full_response_dot = jnp.zeros_like(full_response)
     if not isinstance(d_positions, jax.custom_derivatives.SymbolicZero):
@@ -536,26 +542,29 @@ def _structure_factor_update_jvp(
         batch_mask.num_labels,
         mode="drop",
     )
-    return sk, sk_dot
+    return sk, KahanSummand(sk_dot, jnp.zeros_like(sk_dot))
 
 
 def structure_factor[State](
     inp: EwaldLongRangeInput[State],
-) -> tuple[Array, Patch[State]]:
+) -> tuple[KahanSummand[Array], Patch[State]]:
     """Compute the structure factor, dispatching between full and incremental.
 
     Uses ``_structure_factor_full`` when no ``changes_from_prev`` is available,
     otherwise ``_structure_factor_update`` for incremental MC updates.
 
     Returns:
-        Tuple of structure factor array and a cache patch.
+        Tuple of the structure factor accumulator and a cache patch. A full
+        recomputation starts a fresh accumulator with zero compensation.
     """
     if inp.changes_from_prev is None:
-        sk = _structure_factor_full(
-            inp.point_cloud.particles.data.positions,
-            inp.point_cloud.particles.data.charges,
-            inp.kvecs,
-            inp.point_cloud.particles.data.system,
+        sk = KahanSummand.init(
+            _structure_factor_full(
+                inp.point_cloud.particles.data.positions,
+                inp.point_cloud.particles.data.charges,
+                inp.kvecs,
+                inp.point_cloud.particles.data.system,
+            )
         )
     else:
         assert inp.cache is not None, "Cache required for structure factor update"
@@ -608,10 +617,11 @@ def ewald_long_range_energy[State](
 
     Wraps ``structure_factor`` + ``long_range``, adds the neutralizing-background
     correction (``ewald_net_charge_energy``) for nonzero net charge, and returns a
-    cache patch for structure factor updates on MC accept/reject.
+    cache patch for structure factor updates on MC accept/reject. ``S(k)`` is read
+    off the accumulator with its compensation applied.
     """
     structure_out, patch = structure_factor(inp)
-    energy = long_range(inp, structure_out)
+    energy = long_range(inp, structure_out.total)
     assert energy.shape == (inp.point_cloud.batch_size,), (
         f"Expected energy shape {(inp.point_cloud.batch_size,)} but got {energy.shape}."
     )
@@ -787,7 +797,6 @@ def make_ewald_self_interaction_potential[
     particles_view: View[State, Table[ParticleId, IsEwaldPointData]],
     systems_view: View[State, Table[SystemId, HasCell[Periodic3D]]],
     parameter_view: View[State, EwaldParameters],
-    probe: Probe[State, Ptch, WithIndices[ParticleId, IsEwaldPointData]] | None = None,
     gradient_lens: Lens[
         PointCloud[IsEwaldPointData, HasCell[Periodic3D]], Gradients
     ] = EMPTY_LENS,
@@ -797,15 +806,22 @@ def make_ewald_self_interaction_potential[
     cache_lens: Lens[State, KahanSummand[PotentialOut[Gradients, Hessians]]]
     | None = None,
 ) -> Potential[State, Gradients, Hessians, Ptch]:
-    """Create the Ewald self-interaction correction potential."""
+    """Create the Ewald self-interaction correction potential.
+
+    The self energy depends only on the charges present, not on their positions,
+    and costs a single sum over particles. It is therefore recomputed in full on
+    every call rather than accumulated from per-move deltas: accumulating it
+    would form each delta as the difference of two full-system sums, whose
+    rounding error then compounds over the Monte Carlo chain.
+    """
     return PotentialFromEnergy(
         energy_fn=ewald_self_interaction_energy,
-        composer=LocalGraphSumComposer(
+        composer=FullGraphSumComposer(
             graph_constructor=GraphConstructor(
                 particles=particles_view,
                 systems=systems_view,
                 neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
-                probe=empty_graph_probe(probe),
+                probe=None,
             ),
             parameter_view=parameter_view,
         ),
@@ -989,7 +1005,6 @@ def make_ewald_potential[
         particles_view=atomic_view,
         systems_view=systems_view,
         parameter_view=parameter_lens,
-        probe=atomic_particles_probe,
         gradient_lens=gradient_lens,
         hessian_lens=hessian_lens,
         hessian_idx_view=hessian_idx_view,

--- a/src/kups/potential/common/graph.py
+++ b/src/kups/potential/common/graph.py
@@ -37,7 +37,7 @@ from jax import Array
 from kups.core.cell import AnyPeriodicity
 from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import Lens, View, bind, lens
-from kups.core.neighborlist import Edges, EmptyNeighborList, NeighborList
+from kups.core.neighborlist import Edges, NeighborList
 from kups.core.patch import Patch, Probe
 from kups.core.typing import (
     HasCell,
@@ -185,38 +185,6 @@ class IsGraphProbe[P: IsRadiusGraphPoints, Degree: int](Protocol):
     def neighborlist_after(self) -> NeighborList[Degree]: ...
     @property
     def neighborlist_before(self) -> NeighborList[Degree]: ...
-
-
-@dataclass
-class _EmptyGraphProbeResult[P: IsRadiusGraphPoints]:
-    """Unified graph probe result for point-cloud particle updates."""
-
-    particles: WithIndices[ParticleId, P]
-    neighborlist_after: NeighborList[Literal[0]]
-    neighborlist_before: NeighborList[Literal[0]]
-
-
-def empty_graph_probe[
-    State,
-    Ptch: Patch[Any],
-    P: IsRadiusGraphPoints,
-](
-    probe_particles: Probe[State, Ptch, WithIndices[ParticleId, P]] | None,
-) -> Probe[State, Ptch, IsGraphProbe[P, Literal[0]]] | None:
-    """Adapt a particle-only point-cloud probe to the unified graph probe shape."""
-
-    if probe_particles is None:
-        return None
-
-    def probe(state: State, patch: Ptch) -> IsGraphProbe[P, Literal[0]]:
-        empty = EmptyNeighborList[Literal[0]]()
-        return _EmptyGraphProbeResult(
-            particles=probe_particles(state, patch),
-            neighborlist_after=empty,
-            neighborlist_before=empty,
-        )
-
-    return probe
 
 
 @dataclass

--- a/test/potential/test_ewald.py
+++ b/test/potential/test_ewald.py
@@ -1,10 +1,13 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any, Callable
+
 import jax
 import jax.numpy as jnp
+import numpy as np
 import numpy.testing as npt
-from jax import Array
+from jax import Array, random
 
 from kups.core.capacity import FixedCapacity
 from kups.core.cell import (
@@ -16,14 +19,17 @@ from kups.core.cell import (
 )
 from kups.core.data.index import Index
 from kups.core.data.table import Table
-from kups.core.lens import lens
+from kups.core.data.wrappers import WithIndices
+from kups.core.lens import bind, lens
 from kups.core.neighborlist import AllDenseNearestNeighborList, Edges
 from kups.core.result import as_result_function
 from kups.core.typing import ExclusionId, InclusionId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
+from kups.core.utils.kahan import KahanSummand
 from kups.potential.classical.coulomb import coulomb_vacuum_energy
 from kups.potential.classical.ewald import (
     TO_STANDARD_UNITS,
+    EwaldCache,
     EwaldLongRangeInput,
     EwaldParameters,
     estimate_ewald_parameters,
@@ -33,6 +39,7 @@ from kups.potential.classical.ewald import (
     ewald_short_range_energy,
     kvecs_from_kmax,
     prefactor,
+    structure_factor,
 )
 from kups.potential.common.graph import GraphPotentialInput, HyperGraph, PointCloud
 
@@ -496,3 +503,132 @@ class TestEwaldParametersMake:
         )
         params = EwaldParameters.make(particles, systems, real_cutoff=2.0)
         npt.assert_allclose(params.cutoff.data[0], 2.0)
+
+
+class TestStructureFactorCache:
+    """Tests for the compensated structure factor cache used by incremental MC."""
+
+    REPEATS = 4
+    L = 8.0
+    N_STEPS = 1000
+    # (2, 2, 2) is the charge-ordering wavevector of the lattice below, where the
+    # structure factor peaks at |S| = N and accumulation error is largest.
+    SHIFTS = jnp.array([[2, 2, 2], [1, 0, 0], [0, 1, 2]])
+    # Single precision keeps the accumulation error well above the float64
+    # reference; the test suite otherwise runs with x64 enabled.
+    DTYPE = jnp.float32
+
+    def _setup(
+        self,
+    ) -> tuple[
+        Table[ParticleId, PointCloudParticles],
+        Callable[..., EwaldLongRangeInput[Any]],
+    ]:
+        """Build a charge-ordered cubic lattice and a builder for its Ewald input.
+
+        Returns:
+            Tuple of the particle table and a function mapping positions (plus an
+            optional cache and previous-particle data) to an Ewald input.
+        """
+        grid = jnp.stack(
+            jnp.meshgrid(*(3 * [jnp.arange(self.REPEATS)]), indexing="ij"), axis=-1
+        ).reshape(-1, 3)
+        positions = (grid * (self.L / self.REPEATS)).astype(self.DTYPE)
+        charges = ((-1.0) ** grid.sum(-1)).astype(self.DTYPE)
+        cell = PeriodicCell(
+            TriclinicFrame.from_matrix(jnp.eye(3, dtype=self.DTYPE) * self.L)
+        )
+        params = EwaldParameters(
+            alpha=Table((SystemId(0),), jnp.array([0.35], dtype=self.DTYPE)),
+            cutoff=Table((SystemId(0),), jnp.array([3.0], dtype=self.DTYPE)),
+            reciprocal_lattice_shifts=Table((SystemId(0),), self.SHIFTS[None]),
+        )
+        systems = _make_systems(cell[None], params.cutoff.data)
+        # Indices are built once outside any trace; only positions vary.
+        particles = Table.arange(
+            _make_particle_data(positions, charges), label=ParticleId
+        )
+
+        def make_input(
+            pos: Array,
+            cache: EwaldCache[Any, Any] | None = None,
+            changes: WithIndices[ParticleId, PointCloudParticles] | None = None,
+        ) -> EwaldLongRangeInput[Any]:
+            patched = bind(particles).focus(lambda p: p.data.positions).set(pos)
+            return EwaldLongRangeInput(
+                PointCloud(patched, systems), params, cache, None, changes
+            )
+
+        return particles, make_input
+
+    def _cache(self, summand: KahanSummand[Array]) -> EwaldCache[Any, Any]:
+        """Wrap a structure factor accumulator in an otherwise-zero cache."""
+        zeros = EwaldCache.make(1, len(self.SHIFTS))
+        return EwaldCache(
+            summand,
+            zeros.short_range,
+            zeros.long_range,
+            zeros.self_interaction,
+            zeros.exclusion,
+        )
+
+    def _walk(self, compensated: bool) -> tuple[Array, Array]:
+        """Run a chain of single-particle moves, returning final S(k) and positions.
+
+        Args:
+            compensated: Keep the Kahan compensation between updates; if ``False``
+                it is dropped each step, leaving the plain running sum.
+
+        Returns:
+            Tuple of the S(k) the energy would consume and the final positions.
+        """
+        particles, make_input = self._setup()
+        n = len(particles)
+        moved = random.randint(random.key(2), (self.N_STEPS,), 0, n)
+        deltas = random.normal(random.key(1), (self.N_STEPS, 3), self.DTYPE) * 1e-4
+
+        @jax.jit
+        def step(
+            carry: tuple[KahanSummand[Array], Array], move: tuple[Array, Array]
+        ) -> tuple[tuple[KahanSummand[Array], Array], None]:
+            sk, pos = carry
+            idx, delta = move
+            previous = WithIndices(
+                Index.integer(idx[None], n=n, label=ParticleId),
+                jax.tree.map(lambda x: x[idx][None], particles.data),
+            )
+            previous = (
+                bind(previous).focus(lambda p: p.data.positions).set(pos[idx][None])
+            )
+            if not compensated:
+                sk = KahanSummand.init(sk.value)
+            new_pos = pos.at[idx].add(delta)
+            sk, _ = structure_factor(make_input(new_pos, self._cache(sk), previous))
+            return (sk, new_pos), None
+
+        positions = particles.data.positions
+        sk0, _ = structure_factor(make_input(positions))
+        (sk, pos), _ = jax.lax.scan(step, (sk0, positions), (moved, deltas))
+        # Without compensation only the running sum survives, as before this change.
+        return (sk.total if compensated else sk.value), pos
+
+    def _reference(self, positions: Array) -> np.ndarray:
+        """Structure factor of `positions` in float64, shape ``(n_kvecs, 2)``."""
+        particles, make_input = self._setup()
+        kvecs = np.asarray(make_input(positions).kvecs[0], dtype=np.float64)
+        phase = np.asarray(positions, dtype=np.float64) @ kvecs.T
+        q = np.asarray(particles.data.charges, dtype=np.float64)[:, None]
+        return np.stack(
+            [(q * np.cos(phase)).sum(0), (q * np.sin(phase)).sum(0)], axis=-1
+        )
+
+    def test_compensation_reduces_drift(self):
+        """Carrying the compensation shrinks drift over a chain of moves."""
+        reference = self._reference(self._walk(compensated=True)[1])
+        errors = {
+            compensated: float(
+                np.abs(np.asarray(self._walk(compensated)[0][0]) - reference).max()
+            )
+            for compensated in (True, False)
+        }
+        assert errors[True] < errors[False] / 4, errors

--- a/test/potential/test_graph.py
+++ b/test/potential/test_graph.py
@@ -29,7 +29,6 @@ from kups.potential.common.graph import (
     HyperGraph,
     LocalGraphSumComposer,
     PointCloud,
-    empty_graph_probe,
 )
 
 
@@ -569,6 +568,20 @@ class _SimplePatch:
         return self.new_state
 
 
+@dataclass
+class _PointCloudGraphProbe:
+    """Graph probe for a point cloud: particle updates, no neighbour lists."""
+
+    particles: object
+    neighborlist_after: object = EmptyNeighborList[Literal[0]]()
+    neighborlist_before: object = EmptyNeighborList[Literal[0]]()
+
+
+def _point_cloud_probe(probe_result):
+    """Adapt a particle-only update into the unified graph probe shape."""
+    return lambda state, patch: _PointCloudGraphProbe(particles=probe_result)
+
+
 def _make_probe_update(
     particles: Table[ParticleId, _PointData],
     particle_idx: int,
@@ -649,7 +662,7 @@ class TestGraphConstructorEmptyWithPatch:
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
             neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
-            probe=empty_graph_probe(lambda s, p: probe_result),
+            probe=_point_cloud_probe(probe_result),
         )
 
         graph = constructor(state, _SimplePatch(state), old_graph=False)
@@ -669,7 +682,7 @@ class TestGraphConstructorEmptyWithPatch:
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
             neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
-            probe=empty_graph_probe(lambda s, p: probe_result),
+            probe=_point_cloud_probe(probe_result),
         )
 
         graph = constructor(state, _SimplePatch(state), old_graph=True)
@@ -903,7 +916,7 @@ class TestLocalGraphSumComposerWithPatch:
             particles=view(lambda x: x["particles"]),
             systems=view(lambda x: x["systems"]),
             neighborlist=lambda _: EmptyNeighborList[Literal[0]](),
-            probe=empty_graph_probe(lambda s, p: probe_result),
+            probe=_point_cloud_probe(probe_result),
         )
         composer = LocalGraphSumComposer(
             graph_constructor=constructor,


### PR DESCRIPTION
Kahan compensation is now applied to the structure factor accumulator (`S(k)`) used in incremental Monte Carlo updates. Previously, each accepted move added a floating-point delta directly to the running sum, causing small deltas to lose low-order bits against a large accumulated `S(k)` and producing drift over long move chains. The compensation term carries those dropped bits forward into subsequent updates.

Concretely:
- `EwaldCache.structure_factor` is now a `KahanSummand[Array]` instead of a bare `Array`, and its initializer wraps the zero array in `KahanSummand.init`.
- `EwaldCachePatch` stores and applies the full `KahanSummand` (value + compensation) on acceptance, so the compensation is not discarded between moves.
- `_structure_factor_update` returns a `KahanSummand` by delegating to the `+` operator on the cached accumulator.
- The JVP for `_structure_factor_update` returns a `KahanSummand` primal and carries a zero tangent for the compensation term, which is exactly zero in real arithmetic.
- `structure_factor` wraps full recomputations in `KahanSummand.init` (fresh compensation) and returns the accumulator; callers read `S(k)` via `.total`.
- `ewald_long_range_energy` passes `structure_out.total` to `long_range`.

A new test class `TestStructureFactorCache` verifies that carrying the compensation across 1000 single-particle moves on a charge-ordered cubic lattice (in single precision, where accumulation error is most visible) reduces the maximum absolute error in `S(k)` by more than 4× compared to dropping the compensation each step.

---

## Results

Heat of adsorption against a float64 reference, five charged frameworks labelled by mean loading:

| framework | mean loading | float64 (eV) | float32 before | float32 after |
|---|---|---|---|---|
| A | 251.7 | -0.44519 | -0.61295 (-37.7%) | -0.43612 (+2.0%) |
| B | 196.1 | -0.41887 | -0.49177 (-17.4%) | -0.42042 (-0.4%) |
| C | 10.2 | -0.34918 | -0.35486 (-1.6%) | -0.35663 (-2.1%) |
| D | 3.5 | -0.30465 | -0.30111 (+1.2%) | -0.30653 (-0.6%) |
| E | 9.4 | -0.31797 | -0.31956 (-0.5%) | -0.32221 (-1.3%) |

Both high-loading frameworks are now within replica error, the scatter on A falls from +-0.05329 to +-0.01188 eV (float64 +-0.01572), and the mean energy error drops from -13.98 to +0.35 eV on A and -18.95 to +0.27 eV on B. The cause was the position-independent self-interaction term being accumulated incrementally, so each per-move delta was the difference of two full-system sums (~710 eV on A), injecting ~1/3 ulp per accepted move and compounding to -3.2 eV over ~150k moves; recomputing it in full drops that term's drift to -1.5e-5 eV. Acceptance was never affected (~2e-5 eV, about 1e-3 kT per move), so uptake always agreed within 1.5 sigma. The float64 run is bit-identical before and after, and the suite is unchanged at 1895 passed / 7 skipped.

Setup: batched grand-canonical Monte Carlo of CO2, 328-1016 atoms per cell, 4 kPa, 313.15 K, 4 replicas per framework (20 systems), 300 warmup + 3000 production cycles, same seed in both precisions.
