### PR TITLE
chore: Bump `kups` version to `1.0.5`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kups"
-version = "1.0.4"
+version = "1.0.5"
 description = "A toolkit for building high-performance molecular simulations on JAX."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -2134,7 +2134,7 @@ wheels = [
 
 [[package]]
 name = "kups"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "ase" },


### PR DESCRIPTION
Bumps the package version from `1.0.4` to `1.0.5`.