### PR TITLE
feat: Add `segment_sum` and `segment_take` primitives with wide-float accumulation

### DIFF
--- a/src/kups/core/utils/__init__.py
+++ b/src/kups/core/utils/__init__.py
@@ -13,6 +13,7 @@ organized into the following modules:
 - **[ops][kups.core.utils.ops]**: Array operations with broadcasting utilities
 - **[position][kups.core.utils.position]**: Particle position utilities for periodic systems
 - **[quaternion][kups.core.utils.quaternion]**: 3D rotation representation and operations
+- **[segment][kups.core.utils.segment]**: Segment sums accumulated in a wider float, and their gather adjoint
 
 Most commonly used items can be imported directly from submodules.
 """

--- a/src/kups/core/utils/segment.py
+++ b/src/kups/core/utils/segment.py
@@ -1,0 +1,616 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Segment sums accumulated in a wider float, and their gather adjoint.
+
+Provides [segment_sum][kups.core.utils.segment.segment_sum], a drop-in
+``jax.ops.segment_sum`` whose scatter accumulates in a wider float, and
+[segment_take][kups.core.utils.segment.segment_take], the gather that is its
+exact adjoint.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+from typing import Any, cast
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+from jax.core import ShapedArray
+from jax.extend.core import Primitive
+from jax.extend.mlir.dialects import stablehlo
+from jax.interpreters import ad, batching, mlir, xla
+from jax.typing import ArrayLike, DTypeLike
+
+type Zero = ad.Zero
+type Undefined = ad.UndefinedPrimal
+type Mode = jax.lax.GatherScatterMode
+
+_CLIP = jax.lax.GatherScatterMode.CLIP
+
+
+def _accumulator_dtype(dtype: DTypeLike) -> np.dtype[Any]:
+    """Next float wider than `dtype`.
+
+    Args:
+        dtype: Inexact dtype of the contributions.
+
+    Returns:
+        Numpy dtype of the accumulator, equal to `dtype` when nothing wider fits.
+    """
+    if jnp.issubdtype(dtype, jnp.complexfloating):
+        return np.dtype(np.complex128)
+    if jnp.finfo(dtype).bits <= 16:
+        return np.dtype(np.float32)
+    return np.dtype(np.float64)
+
+
+def _tensor(shape: tuple[int, ...], element: Any) -> Any:
+    """Build a ranked MLIR tensor type.
+
+    Args:
+        shape: Dimensions of the tensor.
+        element: MLIR element type.
+
+    Returns:
+        Ranked tensor type of `shape` over `element`.
+    """
+    return mlir.ir.RankedTensorType.get(list(shape), element)
+
+
+def _gather(data: Array, segment_ids: Array) -> Array:
+    """Gather rows of `data`, ids outside ``[0, len(data))`` picking up zero.
+
+    Uses the scatter's own out-of-range rule, so negative ids fill rather than
+    index from the end as ``jnp.take`` would.
+
+    Args:
+        data: Rows to gather from, shape ``(num_segments, *feature_dims)``.
+        segment_ids: Row index per output, of any shape.
+
+    Returns:
+        Gathered rows of shape ``(*segment_ids.shape, *feature_dims)``.
+    """
+    features = data.shape[1:]
+    if data.shape[0] == 0:
+        return jnp.zeros((*segment_ids.shape, *features), data.dtype)
+    rows = jax.lax.gather(
+        data,
+        segment_ids.reshape(-1, 1),
+        jax.lax.GatherDimensionNumbers(
+            offset_dims=tuple(range(1, 1 + len(features))),
+            collapsed_slice_dims=(0,),
+            start_index_map=(0,),
+        ),
+        slice_sizes=(1, *features),
+        mode=jax.lax.GatherScatterMode.FILL_OR_DROP,
+        fill_value=0,
+    )
+    return rows.reshape(*segment_ids.shape, *features)
+
+
+def _resolve_mode(mode: Mode | str | None) -> Mode:
+    """Normalise an out-of-range policy to the two modes this module honours.
+
+    Args:
+        mode: Policy as a ``jax.lax.GatherScatterMode``, as one of the strings
+            ``"drop"``, ``"fill"`` or ``"clip"``, or ``None`` for the default.
+
+    Returns:
+        Either ``FILL_OR_DROP`` or ``CLIP``.
+
+    Raises:
+        ValueError: If `mode` is unknown, ``"promise_in_bounds"`` or ``"one_hot"``.
+    """
+    resolved = jax.lax.GatherScatterMode.from_any(mode)
+    if resolved is jax.lax.GatherScatterMode.PROMISE_IN_BOUNDS:
+        raise ValueError(
+            "mode='promise_in_bounds' is unsupported because XLA clamps an "
+            "out-of-range gather but drops an out-of-range scatter, so the sum and "
+            "the take would stop being adjoints and gradients would be silently "
+            "wrong; say which you mean with 'drop' or 'clip'."
+        )
+    if resolved is jax.lax.GatherScatterMode.ONE_HOT:
+        raise ValueError(
+            "mode='one_hot' is unsupported because JAX has no gather lowering for "
+            "it, only a dense one-hot matmul inside jnp.take_along_axis; use 'drop' "
+            "or 'clip', or call jnp.take_along_axis directly for the matmul."
+        )
+    return resolved
+
+
+def _clip_ids(segment_ids: Array, num_segments: int) -> Array:
+    """Clamp ids into ``[0, num_segments)``, widening narrow ids for the bound.
+
+    Args:
+        segment_ids: Ids to clamp, of any shape.
+        num_segments: Rows the ids address.
+
+    Returns:
+        Ids inside ``[0, num_segments)``, returned unchanged when `num_segments`
+        is zero and there is no row to clamp to.
+    """
+    if num_segments == 0:
+        return segment_ids
+    if jnp.iinfo(segment_ids.dtype).max < num_segments:
+        segment_ids = segment_ids.astype(jnp.int32)
+    # Bounds in the ids' own dtype, which a Python int would widen under x64.
+    limits = np.array([0, num_segments - 1], segment_ids.dtype)
+    return jnp.clip(segment_ids, limits[0], limits[1])
+
+
+def _static_fill(fill_value: ArrayLike) -> np.ndarray | None:
+    """Value of `fill_value` when trace time already knows it.
+
+    Args:
+        fill_value: Candidate fill, a scalar or a traced value.
+
+    Returns:
+        `fill_value` as a numpy array, or ``None`` when it is traced and its value
+        is unknown until run time.
+    """
+    try:
+        return np.asarray(fill_value)
+    except TypeError:
+        return None
+
+
+def _fill_out_of_range(
+    rows: Array, segment_ids: Array, num_segments: int, fill_value: ArrayLike
+) -> Array:
+    """Replace rows whose id falls outside ``[0, num_segments)`` with `fill_value`.
+
+    Args:
+        rows: Gathered rows of shape ``(*segment_ids.shape, *feature_dims)``.
+        segment_ids: Row index per output.
+        num_segments: Rows of the table the ids address.
+        fill_value: Value the out-of-range outputs take, cast to `rows`' dtype.
+
+    Returns:
+        `rows` with every out-of-range output replaced by `fill_value`.
+    """
+    valid = (segment_ids >= 0) & (segment_ids < num_segments)
+    keep = valid.reshape(*valid.shape, *(1,) * (rows.ndim - valid.ndim))
+    return jnp.where(keep, rows, jnp.asarray(fill_value, rows.dtype))
+
+
+def _flatten_batch(
+    data: Array,
+    segment_ids: Array,
+    data_dim: int | None,
+    ids_dim: int,
+    rows: int,
+) -> tuple[Array, Array, int, tuple[int, ...]]:
+    """Fold a mapped segmentation into one flat call with per-row id offsets.
+
+    Batch row ``b`` addresses ``[b * rows, (b + 1) * rows)`` of the flattened
+    output, and an id invalid in its own row is sent to ``size * rows``, out of
+    range globally so that a drop cannot land in a neighbouring row.
+
+    Args:
+        data: Batched contributions, mapped over `data_dim`.
+        segment_ids: Batched ids, mapped over `ids_dim`.
+        data_dim: Mapped axis of `data`, or ``None`` when it is unmapped.
+        ids_dim: Mapped axis of `segment_ids`.
+        rows: Rows of the unmapped operand's leading axis.
+
+    Returns:
+        Tuple of flattened contributions, flattened ids whose invalid entries
+        address no row, the batch size, and the trailing feature dims.
+    """
+    size = data.shape[data_dim] if data_dim is not None else segment_ids.shape[ids_dim]
+    ids = batching.bdim_at_front(segment_ids, ids_dim, size)
+    data = (
+        jnp.broadcast_to(data, (size, *data.shape))
+        if data_dim is None
+        else jnp.moveaxis(data, data_dim, 0)
+    )
+    if jnp.iinfo(ids.dtype).max < size * rows:
+        ids = ids.astype(jnp.int32)
+    offset = jnp.arange(size, dtype=ids.dtype)[:, None] * rows
+    valid = (ids >= 0) & (ids < rows)
+    flat_ids = jnp.where(valid, ids + offset, size * rows).reshape(-1)
+    flat_data = data.reshape(size * data.shape[1], *data.shape[2:])
+    return flat_data, flat_ids, size, data.shape[2:]
+
+
+segment_sum_p = Primitive("kups_segment_sum")
+segment_take_p = Primitive("kups_segment_take")
+
+
+@segment_sum_p.def_abstract_eval
+def _segment_sum_abstract_eval(
+    data: ShapedArray, segment_ids: ShapedArray, *, num_segments: int
+) -> ShapedArray:
+    """Bins of `data`'s dtype; the wide accumulator never reaches an aval."""
+    del segment_ids
+    return ShapedArray((num_segments, *data.shape[1:]), data.dtype)
+
+
+@segment_take_p.def_abstract_eval
+def _segment_take_abstract_eval(
+    data: ShapedArray, segment_ids: ShapedArray
+) -> ShapedArray:
+    """One gathered row per id."""
+    return ShapedArray((*segment_ids.shape, *data.shape[1:]), data.dtype)
+
+
+segment_sum_p.def_impl(partial(xla.apply_primitive, segment_sum_p))
+segment_take_p.def_impl(partial(xla.apply_primitive, segment_take_p))
+
+
+def _segment_sum_lowering(
+    ctx: mlir.LoweringRuleContext,
+    data: Any,
+    segment_ids: Any,
+    *,
+    num_segments: int,
+) -> list[Any]:
+    """Scatter-add into a wider accumulator, converted back on exit.
+
+    Args:
+        ctx: Lowering context carrying the input and output avals.
+        data: MLIR value of the contributions.
+        segment_ids: MLIR value of the non-negative ids.
+        num_segments: Number of output bins, fixed by the output aval.
+
+    Returns:
+        Single-element list holding the binned MLIR value in the input's dtype.
+    """
+    del num_segments
+    data_aval = cast(ShapedArray, ctx.avals_in[0])
+    ids_aval = cast(ShapedArray, ctx.avals_in[1])
+    out_aval = cast(ShapedArray, ctx.avals_out[0])
+    narrow_dtype = np.dtype(out_aval.dtype)
+    wide_dtype = _accumulator_dtype(narrow_dtype)
+    widen = wide_dtype != narrow_dtype
+    wide = mlir.dtype_to_ir_type(wide_dtype)
+    operand = stablehlo.broadcast_in_dim(
+        _tensor(out_aval.shape, wide),
+        mlir.ir_constant(np.zeros((), wide_dtype)),
+        mlir.dense_int_array([]),
+    )
+    updates = stablehlo.convert(_tensor(data_aval.shape, wide), data) if widen else data
+    op = stablehlo.ScatterOp(
+        [_tensor(out_aval.shape, wide)],
+        [operand],
+        segment_ids,
+        [updates],
+        stablehlo.ScatterDimensionNumbers.get(
+            update_window_dims=list(range(1, len(data_aval.shape))),
+            inserted_window_dims=[0],
+            input_batching_dims=[],
+            scatter_indices_batching_dims=[],
+            scattered_dims_to_operand_dims=[0],
+            index_vector_dim=len(ids_aval.shape),
+        ),
+        indices_are_sorted=mlir.ir.BoolAttr.get(False),
+        unique_indices=mlir.ir.BoolAttr.get(False),
+    )
+    scalar = _tensor((), wide)
+    block = op.update_computation.blocks.append(scalar, scalar)
+    with mlir.ir.InsertionPoint(block):
+        stablehlo.return_([stablehlo.add(block.arguments[0], block.arguments[1])])
+    if not widen:
+        return [op.results[0]]
+    narrow = mlir.dtype_to_ir_type(narrow_dtype)
+    return [stablehlo.convert(_tensor(out_aval.shape, narrow), op.results[0])]
+
+
+mlir.register_lowering(segment_sum_p, _segment_sum_lowering)
+mlir.register_lowering(segment_take_p, mlir.lower_fun(_gather, multiple_results=False))
+
+
+def _segment_sum_jvp(
+    tangent: Array, data: Array, segment_ids: Array, *, num_segments: int
+) -> Array:
+    """Rebind on the contribution tangent, the ids carrying none.
+
+    Args:
+        tangent: Tangent of the contributions.
+        data: Contributions, needed only to place the ids.
+        segment_ids: Bin index per contribution.
+        num_segments: Number of output bins.
+
+    Returns:
+        Tangent of the bin sums.
+    """
+    del data
+    return segment_sum_p.bind(tangent, segment_ids, num_segments=num_segments)
+
+
+def _segment_sum_transpose(
+    cotangent: Array | Zero,
+    data: Array | Undefined,
+    segment_ids: Array,
+    *,
+    num_segments: int,
+) -> list[Array | Zero | None]:
+    """Gather the cotangent back to each contribution.
+
+    Args:
+        cotangent: Cotangent of the bin sums.
+        data: Contributions, undefined when they are the linear operand.
+        segment_ids: Bin index per contribution.
+        num_segments: Number of output bins, carried by `cotangent`'s shape.
+
+    Returns:
+        Cotangent per operand, ``None`` for the non-linear ids.
+    """
+    del num_segments
+    if not ad.is_undefined_primal(data):
+        return [None, None]
+    if isinstance(cotangent, ad.Zero):
+        return [ad.Zero(data.aval), None]
+    return [segment_take_p.bind(cotangent, segment_ids), None]
+
+
+def _segment_take_jvp(tangent: Array, data: Array, segment_ids: Array) -> Array:
+    """Rebind on the row tangent, the ids carrying none.
+
+    Args:
+        tangent: Tangent of the table.
+        data: Table, needed only to place the ids.
+        segment_ids: Row index per output.
+
+    Returns:
+        Tangent of the gathered rows.
+    """
+    del data
+    return segment_take_p.bind(tangent, segment_ids)
+
+
+def _segment_take_transpose(
+    cotangent: Array | Zero, data: Array | Undefined, segment_ids: Array
+) -> list[Array | Zero | None]:
+    """Sum the cotangents landing in each row, in the wide accumulator.
+
+    Args:
+        cotangent: Cotangent of the gathered rows.
+        data: Table, undefined when it is the linear operand.
+        segment_ids: Row index per output.
+
+    Returns:
+        Cotangent per operand, ``None`` for the non-linear ids.
+    """
+    if not ad.is_undefined_primal(data):
+        return [None, None]
+    if isinstance(cotangent, ad.Zero):
+        return [ad.Zero(data.aval), None]
+    return [
+        segment_sum_p.bind(cotangent, segment_ids, num_segments=data.aval.shape[0]),
+        None,
+    ]
+
+
+def _segment_sum_batcher(
+    args: tuple[Array, Array],
+    dims: tuple[int | None, int | None],
+    *,
+    num_segments: int,
+) -> tuple[Array, int]:
+    """Map the sum, an unmapped segmentation becoming a further feature axis.
+
+    Args:
+        args: Batched contributions and ids.
+        dims: Mapped axis of each argument, ``None`` where it is unmapped.
+        num_segments: Number of output bins per batch row.
+
+    Returns:
+        Tuple of the batched bin sums and their mapped axis.
+    """
+    data, segment_ids = args
+    data_dim, ids_dim = dims
+    if ids_dim is None:
+        assert data_dim is not None
+        data = jnp.moveaxis(data, data_dim, data.ndim - 1)
+        out = segment_sum_p.bind(data, segment_ids, num_segments=num_segments)
+        return out, out.ndim - 1
+    flat_data, flat_ids, size, features = _flatten_batch(
+        data, segment_ids, data_dim, ids_dim, num_segments
+    )
+    out = segment_sum_p.bind(flat_data, flat_ids, num_segments=size * num_segments)
+    return out.reshape(size, num_segments, *features), 0
+
+
+def _segment_take_batcher(
+    args: tuple[Array, Array], dims: tuple[int | None, int | None]
+) -> tuple[Array, int]:
+    """Map the gather, an unmapped table needing only a flattened id axis.
+
+    Args:
+        args: Batched table and ids.
+        dims: Mapped axis of each argument, ``None`` where it is unmapped.
+
+    Returns:
+        Tuple of the batched gathered rows and their mapped axis.
+    """
+    data, segment_ids = args
+    data_dim, ids_dim = dims
+    if ids_dim is None:
+        assert data_dim is not None
+        data = jnp.moveaxis(data, data_dim, data.ndim - 1)
+        out = segment_take_p.bind(data, segment_ids)
+        return out, out.ndim - 1
+    if data_dim is None:
+        size = segment_ids.shape[ids_dim]
+        ids = batching.bdim_at_front(segment_ids, ids_dim, size)
+        out = segment_take_p.bind(data, ids.reshape(-1))
+        return out.reshape(size, ids.shape[1], *data.shape[1:]), 0
+    rows = data.shape[1] if data_dim == 0 else data.shape[0]
+    flat_data, flat_ids, size, features = _flatten_batch(
+        data, segment_ids, data_dim, ids_dim, rows
+    )
+    out = segment_take_p.bind(flat_data, flat_ids)
+    return out.reshape(size, flat_ids.shape[0] // size, *features), 0
+
+
+# A ``None`` rule per primitive marks the integral ids as carrying no tangent.
+ad.defjvp(segment_sum_p, _segment_sum_jvp, None)
+ad.primitive_transposes[segment_sum_p] = _segment_sum_transpose
+batching.primitive_batchers[segment_sum_p] = _segment_sum_batcher
+
+ad.defjvp(segment_take_p, _segment_take_jvp, None)
+ad.primitive_transposes[segment_take_p] = _segment_take_transpose
+batching.primitive_batchers[segment_take_p] = _segment_take_batcher
+
+
+def segment_sum(
+    data: Array,
+    segment_ids: Array,
+    num_segments: int,
+    *,
+    mode: Mode | str | None = None,
+) -> Array:
+    """Sum `data` into `num_segments` bins, accumulating in a wider float.
+
+    Drop-in replacement for ``jax.ops.segment_sum``: the same value in exact
+    arithmetic, closer to it in floating point, and the same `mode` for segment
+    ids outside ``[0, num_segments)``, dropped by default, negatives included.
+    The scatter accumulates one float wider than `data` and converts back once,
+    f32 in f64 and f16 or bf16 in f32, so a bin taking ``k`` contributions rounds
+    once rather than ``k`` times. Integer data and empty inputs fall through to
+    the plain scatter, which is already exact. `segment_ids` may additionally
+    cover several leading axes of `data` rather than only the first, which
+    ``jax.ops.segment_sum`` rejects.
+
+    Linear in `data` and non-differentiable in the integral `segment_ids`, so it
+    transforms under ``jit``, ``vmap`` over either argument, forward mode,
+    reverse mode, and repeated differentiation. The reverse pass is
+    [segment_take][kups.core.utils.segment.segment_take] under the same `mode`,
+    its exact adjoint.
+
+    Args:
+        data: Contributions of shape ``(*segment_ids.shape, *feature_dims)``.
+        segment_ids: Bin index per contribution, of any shape that is a prefix of
+            `data`'s.
+        num_segments: Number of output bins.
+        mode: How to treat ids outside ``[0, num_segments)``, as a
+            ``jax.lax.GatherScatterMode`` or as one of the strings ``"drop"``,
+            ``"fill"`` or ``"clip"``. The default ``None`` drops them so they
+            contribute nothing, negatives included; ``"clip"`` instead clamps each
+            id into range, piling negatives into bin ``0`` and ids at or above
+            `num_segments` into the last bin, which is far slower than dropping
+            when many ids are out of range because those two bins then take every
+            such update. ``"promise_in_bounds"`` and ``"one_hot"`` are rejected.
+
+    Returns:
+        Bin sums of shape ``(num_segments, *feature_dims)`` with `data`'s dtype,
+        `feature_dims` being the axes of `data` that `segment_ids` does not cover.
+
+    Raises:
+        ValueError: If `data` is scalar, `segment_ids` is scalar, not integral, or
+            its shape is not a prefix of `data`'s, or `mode` is unknown or
+            unsupported.
+
+    Example:
+        ```python
+        # Per-atom sums of float32 edge messages, accumulated in float64.
+        per_atom = segment_sum(messages, edges.indices.indices[:, 0], n_atoms)
+        ```
+    """
+    if data.ndim == 0:
+        raise ValueError(f"data must be at least 1-D, got shape {data.shape}.")
+    if segment_ids.ndim == 0:
+        raise ValueError("segment_ids must be at least 1-D, got shape ().")
+    if segment_ids.shape != data.shape[: segment_ids.ndim]:
+        raise ValueError(
+            f"segment_ids shape {segment_ids.shape} must be a prefix of data's "
+            f"{data.shape}."
+        )
+    if not jnp.issubdtype(segment_ids.dtype, jnp.integer):
+        raise ValueError(
+            f"segment_ids must be integral, got dtype {segment_ids.dtype}."
+        )
+    if _resolve_mode(mode) is _CLIP:
+        segment_ids = _clip_ids(segment_ids, num_segments)
+    if segment_ids.ndim > 1:
+        data = data.reshape(-1, *data.shape[segment_ids.ndim :])
+        segment_ids = segment_ids.reshape(-1)
+    if data.shape[0] == 0 or not jnp.issubdtype(data.dtype, jnp.inexact):
+        return jax.ops.segment_sum(data, segment_ids, num_segments, mode="drop")
+    return segment_sum_p.bind(data, segment_ids, num_segments=num_segments)
+
+
+def segment_take(
+    data: Array,
+    segment_ids: Array,
+    *,
+    mode: Mode | str | None = None,
+    fill_value: ArrayLike | None = None,
+) -> Array:
+    """Gather rows of `data` by segment id, summing the cotangents stably.
+
+    The forward pass moves rows and is exact; the accuracy is in the reverse
+    pass, which sums the cotangents landing in each row through
+    [segment_sum][kups.core.utils.segment.segment_sum] rather than the serial
+    ``jnp.zeros(...).at[segment_ids].add(...)`` that differentiating
+    ``data[segment_ids]`` gives. The two are exact adjoints under the same `mode`
+    and a zero `fill_value`, so ``(segment_take(data, ids) * cotangent).sum()``
+    equals
+    ``(data * segment_sum(cotangent, ids, len(data))).sum()``, and each is the
+    other's transpose, so differentiating either repeatedly keeps using the wide
+    accumulator instead of falling back to the plain scatter.
+
+    Args:
+        data: Rows to gather from, shape ``(num_segments, *feature_dims)``.
+        segment_ids: Row index per output, of any shape.
+        mode: How to treat ids outside ``[0, num_segments)``, spelled as for
+            [segment_sum][kups.core.utils.segment.segment_sum]. A negative id is
+            out of range here rather than an index from the end as in
+            ``jnp.take``. The default ``None`` gives every out-of-range output
+            `fill_value`, so it fills exactly the ids the sum drops; ``"clip"``
+            clamps them to the first or last row instead. An empty `data` has no
+            row to clamp to, so ``"clip"`` gives every output zero there.
+        fill_value: Value the out-of-range outputs take under the default `mode`,
+            zero so the gather stays the sum's exact adjoint. Unlike ``jnp.take``
+            a `fill_value` of ``None`` means zero rather than NaN. A nonzero fill
+            is an additive constant, so the gather becomes affine rather than
+            linear: forward and reverse mode stay correct and ignore it, but
+            ``jax.linear_transpose`` then transposes only the linear part, as
+            ``jnp.take`` does. Clamping leaves nothing out of range, so
+            ``mode="clip"`` ignores the fill as ``jnp.take`` does, except that one
+            already known to be nonzero at trace time is rejected rather than
+            silently dropped.
+
+    Returns:
+        Gathered rows of shape ``(*segment_ids.shape, *feature_dims)`` with
+        `data`'s dtype.
+
+    Raises:
+        ValueError: If `data` or `segment_ids` is scalar, `mode` is unknown or
+            unsupported, or `fill_value` is known at trace time to be nonzero
+            under ``mode="clip"``.
+
+    Example:
+        ```python
+        # Per-edge copies of atom features, whose gradient scatters back stably.
+        edge_emb = segment_take(node_emb, edges.indices.indices[:, 0])
+        ```
+    """
+    if data.ndim == 0:
+        raise ValueError(f"data must be at least 1-D, got shape {data.shape}.")
+    if segment_ids.ndim == 0:
+        raise ValueError("segment_ids must be at least 1-D, got shape ().")
+    fill_value = 0 if fill_value is None else fill_value
+    known_fill = _static_fill(fill_value)
+    clipped = _resolve_mode(mode) is _CLIP
+    if clipped:
+        if known_fill is not None and known_fill.any():
+            raise ValueError(
+                "a nonzero fill_value is meaningless under mode='clip', which "
+                "clamps every id into range instead of filling; drop it or pass "
+                "mode='fill'."
+            )
+        segment_ids = _clip_ids(segment_ids, data.shape[0])
+    if data.shape[0] == 0 or not jnp.issubdtype(data.dtype, jnp.inexact):
+        rows = _gather(data, segment_ids)
+    else:
+        flat = segment_take_p.bind(data, segment_ids.reshape(-1))
+        rows = flat.reshape(*segment_ids.shape, *data.shape[1:])
+    # Clamped ids leave nothing out of range, so only the default mode fills.
+    if clipped or (known_fill is not None and not known_fill.any()):
+        return rows
+    return _fill_out_of_range(rows, segment_ids, data.shape[0], fill_value)

--- a/test/core/test_segment.py
+++ b/test/core/test_segment.py
@@ -1,0 +1,625 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterator
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+from jax import Array
+from jax.typing import ArrayLike, DTypeLike
+
+from kups.core.utils.segment import segment_sum, segment_take
+
+type Case = tuple[Array, Array, int]
+type Loss = Callable[[Array], Array]
+type ModeArg = jax.lax.GatherScatterMode | str | None
+
+# A negative id, `num_segments` itself, and an id far above it, all dropped.
+POISON = jnp.array([0, -1, 2, 1, -7, 9, 4], jnp.int32)
+
+# Every spelling of the default policy, and of the clamping one.
+DROP_SPELLINGS: list[ModeArg] = [
+    None,
+    "fill",
+    "drop",
+    jax.lax.GatherScatterMode.FILL_OR_DROP,
+]
+CLIP_SPELLINGS: list[ModeArg] = ["clip", jax.lax.GatherScatterMode.CLIP]
+
+# The two honoured policies, as both functions and `_reference` spell them.
+MODES = ["drop", "clip"]
+
+# Rejected modes, each mapped to the phrase its error must explain itself by.
+BAD_MODES = {
+    "promise_in_bounds": r"promise_in_bounds.*adjoints",
+    "one_hot": r"one_hot.*no gather lowering",
+    "wrap": r'Unknown gather mode "wrap"',
+}
+
+
+@pytest.fixture(autouse=True)
+def _disable_x64() -> Iterator[None]:
+    """Force float32 for this module without leaking the global flag."""
+    prev = jax.config.read("jax_enable_x64")
+    jax.config.update("jax_enable_x64", False)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", prev)
+
+
+def _lognormal(features: tuple[int, ...]) -> Case:
+    """Positive contributions spanning decades, ids that include drops, eight bins."""
+    keys = jax.random.split(jax.random.key(0))
+    data = jnp.exp(3 * jax.random.normal(keys[0], (257, *features), jnp.float32))
+    return data, jax.random.randint(keys[1], (257,), -1, 9), 8
+
+
+def _reference(
+    data: ArrayLike, segment_ids: ArrayLike, num_segments: int, mode: str = "drop"
+) -> np.ndarray:
+    """Bin sums accumulated in float64 numpy, ids outside the range following `mode`.
+
+    Args:
+        data: Contributions, binned along their leading axis.
+        segment_ids: Bin index per contribution.
+        num_segments: Number of output bins.
+        mode: ``"clip"`` to clamp out-of-range ids into range, anything else to drop
+            them.
+
+    Returns:
+        Bin sums of shape ``(num_segments, *data.shape[1:])`` in float64.
+    """
+    values = np.asarray(data, np.float64)
+    ids = np.asarray(segment_ids)
+    out = np.zeros((num_segments, *values.shape[1:]), np.float64)
+    if mode == "clip":
+        ids = np.clip(ids, 0, num_segments - 1)
+    keep = (ids >= 0) & (ids < num_segments)
+    np.add.at(out, ids[keep], values[keep])
+    return out
+
+
+def _masked_take(
+    data: Array, segment_ids: Array, mode: str = "drop", fill_value: ArrayLike = 0
+) -> Array:
+    """Gather following `mode`, built from `jnp.take` and differentiable.
+
+    Args:
+        data: Rows to gather from.
+        segment_ids: Row index per output.
+        mode: ``"clip"`` to clamp out-of-range ids into range, anything else to give
+            them `fill_value`.
+        fill_value: Value the out-of-range outputs take when they are not clamped.
+
+    Returns:
+        Gathered rows of shape ``(*segment_ids.shape, *data.shape[1:])``.
+    """
+    if mode == "clip":
+        return jnp.take(data, jnp.clip(segment_ids, 0, data.shape[0] - 1), axis=0)
+    keep = (segment_ids >= 0) & (segment_ids < data.shape[0])
+    rows = jnp.take(data, jnp.where(keep, segment_ids, 0), axis=0)
+    return jnp.where(
+        keep.reshape(*keep.shape, *(1,) * (data.ndim - 1)), rows, fill_value
+    )
+
+
+def _mapped(rows: Array, axis: int | None) -> Array:
+    """`rows`' leading axis moved to `axis`, or its first row when unmapped.
+
+    Args:
+        rows: Stack of per-batch-row arguments.
+        axis: Axis the mapped argument is to be passed along, ``None`` to pass a
+            single unmapped row.
+
+    Returns:
+        The argument as `vmap` at `in_axes=axis` expects it.
+    """
+    return rows[0] if axis is None else jnp.moveaxis(rows, 0, axis)
+
+
+def _hvp(loss: Loss, tangent: Array) -> Loss:
+    """Hessian-vector product of `loss` along `tangent`, reverse over reverse."""
+
+    def directional(x: Array) -> Array:
+        return jnp.sum(jax.grad(loss)(x) * tangent)
+
+    return jax.grad(directional)
+
+
+def _max_ulp_error(out: ArrayLike, exact: np.ndarray) -> float:
+    """Largest deviation from `exact` in ulp of its float32 rounding."""
+    ulp = np.maximum(
+        np.spacing(np.asarray(exact, np.float32)).astype(np.float64), 1e-38
+    )
+    return float(np.max(np.abs(np.asarray(out, np.float64) - exact) / ulp))
+
+
+class TestSegmentSum:
+    @pytest.mark.parametrize("features", [(), (3,), (2, 2)])
+    def test_matches_float64_reference(self, features: tuple[int, ...]) -> None:
+        """Rounds the float64 sum once, identically eager and under `jit`."""
+        data, ids, num_segments = _lognormal(features)
+        out = segment_sum(data, ids, num_segments)
+        assert out.dtype == jnp.float32
+        assert _max_ulp_error(out, _reference(data, ids, num_segments)) <= 0.5
+        jitted = jax.jit(segment_sum, static_argnums=2)(data, ids, num_segments)
+        npt.assert_array_equal(out, jitted)
+
+    def test_out_of_range_dropped(self) -> None:
+        """Negative ids, `num_segments` itself, and larger ids contribute nothing."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        for mode in DROP_SPELLINGS:
+            out = segment_sum(data, POISON, 4, mode=mode)
+            npt.assert_array_equal(out, [1.0, 4.0, 3.0, 0.0])
+            npt.assert_array_equal(out, jax.ops.segment_sum(data, POISON, 4))
+
+    def test_clip_clamps_out_of_range_ids(self) -> None:
+        """Clip piles negatives into bin zero and ids past the range into the last."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        for mode in CLIP_SPELLINGS:
+            out = segment_sum(data, POISON, 4, mode=mode)
+            npt.assert_array_equal(out, [8.0, 4.0, 3.0, 13.0])
+            npt.assert_array_equal(
+                out, jax.ops.segment_sum(data, POISON, 4, mode="clip")
+            )
+        # With no bin to clamp to the ids are dropped and nothing is observable.
+        npt.assert_array_equal(
+            segment_sum(data, POISON, 0, mode="clip"), jnp.zeros((0,))
+        )
+
+    @pytest.mark.parametrize(
+        ("dtype", "spike", "addends"),
+        [
+            (jnp.float16, 4096.0, 4),
+            (jnp.bfloat16, 4096.0, 32),
+            (jnp.float32, 1e8, 8),
+            (jnp.complex64, 1e8, 8),
+        ],
+    )
+    def test_accumulates_in_a_wider_float(
+        self, dtype: DTypeLike, spike: float, addends: int
+    ) -> None:
+        """A cancelling spike leaves the addends that `data`'s own dtype rounds away."""
+        data = jnp.asarray([spike, *[1.0] * addends, -spike], dtype)
+        ids = jnp.zeros(addends + 2, jnp.int32)
+        out = segment_sum(data, ids, 1)
+        assert out.dtype == dtype
+        npt.assert_array_equal(out, jnp.asarray([addends], dtype))
+        # Accumulating in `dtype` rounds the addends away against the spike; how much
+        # of them survives is a backend detail, but none of it is the exact sum.
+        assert np.asarray(jax.ops.segment_sum(data, ids, 1))[0] != addends
+
+    @pytest.mark.parametrize(
+        ("mode", "expected"),
+        [
+            ("drop", [10.0, 0.0, 1000.0, 100.0, 0.0, 0.0, 0.0]),
+            ("clip", [10.0, 10.0, 1000.0, 100.0, 10.0, 10000.0, 10000.0]),
+        ],
+    )
+    def test_grad_is_gather(self, mode: str, expected: list[float]) -> None:
+        """Reverse mode gathers the cotangent under the same `mode`."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        cotangent = jnp.array([10.0, 100.0, 1000.0, 10000.0], jnp.float32)
+
+        def loss(x: Array) -> Array:
+            return jnp.sum(segment_sum(x, POISON, 4, mode=mode) * cotangent)
+
+        grad = jax.grad(loss)(data)
+        npt.assert_array_equal(grad, expected)
+        npt.assert_array_equal(grad, _masked_take(cotangent, POISON, mode))
+        npt.assert_array_equal(grad, segment_take(cotangent, POISON, mode=mode))
+
+    @pytest.mark.parametrize("mode", MODES)
+    def test_forward_mode_and_transpose(self, mode: str) -> None:
+        """Forward mode pushes the tangent through and the transpose is the gather."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        tangent = jnp.arange(8.0, 15.0, dtype=jnp.float32)
+        summed = partial(segment_sum, segment_ids=POISON, num_segments=4, mode=mode)
+        primal, out_tangent = jax.jvp(summed, (data,), (tangent,))
+        npt.assert_array_equal(primal, segment_sum(data, POISON, 4, mode=mode))
+        npt.assert_array_equal(out_tangent, segment_sum(tangent, POISON, 4, mode=mode))
+        cotangent = jnp.arange(1.0, 5.0, dtype=jnp.float32)
+        (transposed,) = jax.linear_transpose(summed, data)(cotangent)
+        npt.assert_array_equal(transposed, _masked_take(cotangent, POISON, mode))
+
+    @pytest.mark.parametrize("mode", MODES)
+    def test_second_order(self, mode: str) -> None:
+        """Forward-over-reverse and reverse-over-reverse match the plain scatter."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        tangent = jnp.ones(7, jnp.float32)
+
+        def ours(x: Array) -> Array:
+            return jnp.sum(segment_sum(x, POISON, 4, mode=mode) ** 3)
+
+        def ref(x: Array) -> Array:
+            return jnp.sum(jax.ops.segment_sum(x, POISON, 4, mode=mode) ** 3)
+
+        npt.assert_allclose(jax.grad(ours)(data), jax.grad(ref)(data), rtol=1e-6)
+        npt.assert_allclose(
+            jax.jvp(jax.grad(ours), (data,), (tangent,))[1],
+            jax.jvp(jax.grad(ref), (data,), (tangent,))[1],
+            rtol=1e-6,
+        )
+        npt.assert_allclose(
+            _hvp(ours, tangent)(data), _hvp(ref, tangent)(data), rtol=1e-6
+        )
+
+    def test_second_order_stays_on_the_wide_primitives(self) -> None:
+        """Repeated differentiation never falls back to a plain scatter."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+
+        def loss(x: Array) -> Array:
+            return jnp.sum(segment_sum(x, POISON, 4) ** 3)
+
+        jaxpr = jax.make_jaxpr(_hvp(loss, data))(data)
+        primitives = {str(eqn.primitive) for eqn in jaxpr.jaxpr.eqns}
+        assert not any("scatter" in name for name in primitives)
+        assert {"kups_segment_sum", "kups_segment_take"} <= primitives
+
+    @pytest.mark.parametrize("mode", MODES)
+    @pytest.mark.parametrize("in_axes", [(0, None), (None, 0), (0, 0), (1, 1)])
+    def test_jit_and_vmap(
+        self, in_axes: tuple[int | None, int | None], mode: str
+    ) -> None:
+        """Maps over contributions, ids, or both, each row resolving its own ids."""
+        data = jnp.arange(1.0, 15.0, dtype=jnp.float32).reshape(2, 7)
+        ids = jnp.stack([POISON, jnp.full((7,), -1, jnp.int32)])
+        args = (_mapped(data, in_axes[0]), _mapped(ids, in_axes[1]))
+        rows = [
+            (
+                data[b if in_axes[0] is not None else 0],
+                ids[b if in_axes[1] is not None else 0],
+            )
+            for b in range(2)
+        ]
+        summed = partial(segment_sum, num_segments=4, mode=mode)
+        out = jax.jit(jax.vmap(summed, in_axes=in_axes))(*args)
+        npt.assert_array_equal(out, [_reference(d, i, 4, mode) for d, i in rows])
+
+    @pytest.mark.parametrize("mode", MODES)
+    def test_nested_vmap(self, mode: str) -> None:
+        """Two mapped axes keep every innermost segmentation to its own bins."""
+        data = jnp.arange(1.0, 43.0, dtype=jnp.float32).reshape(2, 3, 7)
+        inner = jnp.stack([POISON, jnp.roll(POISON, 2), jnp.full((7,), -1, jnp.int32)])
+        ids = jnp.stack([inner, inner[::-1]])
+        summed = partial(segment_sum, num_segments=4, mode=mode)
+        out = jax.vmap(jax.vmap(summed))(data, ids)
+        npt.assert_array_equal(
+            out,
+            [
+                [_reference(d, i, 4, mode) for d, i in zip(rows, row_ids)]
+                for rows, row_ids in zip(data, ids)
+            ],
+        )
+
+    @pytest.mark.parametrize("mode", MODES)
+    def test_vmap_of_grad(self, mode: str) -> None:
+        """Differentiating under a mapped segmentation gathers per row."""
+        data = jnp.arange(1.0, 15.0, dtype=jnp.float32).reshape(2, 7)
+        ids = jnp.stack([POISON, POISON + 1])
+        cotangent = jnp.array([10.0, 100.0, 1000.0, 10000.0], jnp.float32)
+
+        def loss(x: Array, segment_ids: Array) -> Array:
+            return jnp.sum(segment_sum(x, segment_ids, 4, mode=mode) * cotangent)
+
+        npt.assert_array_equal(
+            jax.vmap(jax.grad(loss))(data, ids),
+            jax.vmap(partial(_masked_take, mode=mode), in_axes=(None, 0))(
+                cotangent, ids
+            ),
+        )
+
+    def test_integer_data_falls_through(self) -> None:
+        """Integer contributions defer to the already exact plain scatter."""
+        data = jnp.arange(1, 8, dtype=jnp.int32)
+        out = segment_sum(data, POISON, 4)
+        assert out.dtype == jnp.int32
+        npt.assert_array_equal(out, [1, 4, 3, 0])
+        npt.assert_array_equal(out, jax.ops.segment_sum(data, POISON, 4, mode="drop"))
+        npt.assert_array_equal(
+            segment_sum(data, POISON, 4, mode="clip"),
+            jax.ops.segment_sum(data, POISON, 4, mode="clip"),
+        )
+
+    def test_empty_and_degenerate_shapes(self) -> None:
+        """No contributions, no segments, and zero-width features stay well shaped."""
+        empty = jnp.zeros((0, 2), jnp.float32)
+        npt.assert_array_equal(
+            segment_sum(empty, jnp.zeros((0,), jnp.int32), 3), jnp.zeros((3, 2))
+        )
+        npt.assert_array_equal(
+            segment_sum(empty, jnp.zeros((0,), jnp.int32), 3, mode="clip"),
+            jnp.zeros((3, 2)),
+        )
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        npt.assert_array_equal(segment_sum(data, POISON, 0), jnp.zeros((0,)))
+
+        def binless(x: Array) -> Array:
+            return jnp.sum(segment_sum(x, POISON, 0))
+
+        npt.assert_array_equal(jax.grad(binless)(data), jnp.zeros(7))
+        npt.assert_array_equal(
+            segment_sum(jnp.zeros((7, 0), jnp.float32), POISON, 4), jnp.zeros((4, 0))
+        )
+
+    def test_narrow_index_dtype(self) -> None:
+        """int8 ids widen for the sentinel, the batched offsets, and the clip bound."""
+        ids = jnp.array([0, 1, 1, 2, 2, 2], jnp.int8)
+        data = jnp.arange(6.0, dtype=jnp.float32)
+        npt.assert_array_equal(segment_sum(data, ids, 200)[:3], [0.0, 3.0, 12.0])
+        npt.assert_array_equal(
+            segment_sum(data, ids, 200, mode="clip")[:3], [0.0, 3.0, 12.0]
+        )
+        mapped = jax.vmap(partial(segment_sum, num_segments=100), in_axes=(None, 0))(
+            data, jnp.stack([ids, ids])
+        )
+        npt.assert_array_equal(mapped[:, :3], [[0.0, 3.0, 12.0]] * 2)
+
+    def test_no_wide_dtype_reaches_an_aval(self) -> None:
+        """The accumulator lives in the lowering, never in a jaxpr."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+
+        def loss(x: Array) -> Array:
+            return jnp.sum(segment_sum(x, POISON, 4) ** 2)
+
+        for jaxpr in (
+            jax.make_jaxpr(partial(segment_sum, num_segments=4))(data, POISON),
+            jax.make_jaxpr(partial(segment_sum, num_segments=4, mode="clip"))(
+                data, POISON
+            ),
+            jax.make_jaxpr(jax.grad(loss))(data),
+            jax.make_jaxpr(jax.hessian(loss))(data),
+        ):
+            dtypes = [
+                np.dtype(dtype)
+                for eqn in jaxpr.jaxpr.eqns
+                for var in (*eqn.invars, *eqn.outvars)
+                if (dtype := getattr(var.aval, "dtype", None)) is not None
+            ]
+            assert all(dtype.itemsize <= 4 for dtype in dtypes)
+
+    def test_clip_bounds_stay_in_the_id_dtype(self) -> None:
+        """The clamp bounds never widen the ids, which x64 makes observable."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        jax.config.update("jax_enable_x64", True)
+        try:
+            clipped = partial(segment_sum, num_segments=4, mode="clip")
+            jaxpr = str(jax.make_jaxpr(clipped)(data, jnp.asarray(POISON, jnp.int32)))
+        finally:
+            jax.config.update("jax_enable_x64", False)
+        assert "i64" not in jaxpr
+
+    def test_lowering_scatters_in_the_wide_accumulator(self) -> None:
+        """The emitted scatter runs in f64 even though x64 is off."""
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        traced = jax.jit(partial(segment_sum, num_segments=4)).trace(data, POISON)
+        text = traced.lower(lowering_platforms=("cpu",)).as_text()
+        assert "scatter" in text
+        assert re.search(r"\bf64\b", text)
+
+    def test_rejects_bad_arguments(self) -> None:
+        """Bad shapes or id dtypes, unsupported modes, and a fill value raise."""
+        with pytest.raises(ValueError, match="1-D"):
+            segment_sum(jnp.zeros((), jnp.float32), jnp.zeros((), jnp.int32), 4)
+        with pytest.raises(ValueError, match="1-D"):
+            segment_sum(jnp.zeros((4,), jnp.float32), jnp.asarray(0, jnp.int32), 4)
+        with pytest.raises(ValueError, match="prefix"):
+            segment_sum(jnp.zeros((4,), jnp.float32), jnp.zeros((3,), jnp.int32), 4)
+        with pytest.raises(ValueError, match="prefix"):
+            segment_sum(jnp.zeros((4, 3), jnp.float32), jnp.zeros((3,), jnp.int32), 4)
+        data = jnp.arange(1.0, 8.0, dtype=jnp.float32)
+        with pytest.raises(ValueError, match="segment_ids must be integral"):
+            segment_sum(data, POISON.astype(jnp.float32), 4)
+        for mode, message in BAD_MODES.items():
+            with pytest.raises(ValueError, match=message):
+                segment_sum(data, POISON, 4, mode=mode)
+        # A dropped update writes nothing, so there is no slot to fill and the sum
+        # takes no `fill_value`, no more than `jax.ops.segment_sum` does.
+        with pytest.raises(TypeError, match="fill_value"):
+            # pyrefly: ignore [unexpected-keyword]
+            segment_sum(data, POISON, 4, fill_value=1.0)
+
+    @pytest.mark.parametrize("mode", MODES)
+    @pytest.mark.parametrize("features", [(), (3,)])
+    def test_ids_covering_several_leading_axes(
+        self, features: tuple[int, ...], mode: str
+    ) -> None:
+        """Ids of any prefix shape bin every axis they cover, under either `mode`."""
+        data, ids, num_segments = _lognormal(features)
+        data, ids = data[:256], ids[:256]
+        shaped = ids.reshape(32, 8)
+        out = segment_sum(
+            data.reshape(32, 8, *features), shaped, num_segments, mode=mode
+        )
+        npt.assert_array_equal(out, segment_sum(data, ids, num_segments, mode=mode))
+        assert _max_ulp_error(out, _reference(data, ids, num_segments, mode)) < 1.5
+
+
+class TestSegmentTake:
+    @pytest.mark.parametrize("mode", MODES)
+    @pytest.mark.parametrize("features", [(), (2, 3)])
+    def test_adjoint_identity(self, features: tuple[int, ...], mode: str) -> None:
+        """Contracting the gather against a cotangent equals contracting the sum."""
+        rng = np.random.default_rng(0)
+        data = jnp.asarray(rng.integers(-8, 8, (7, *features)), jnp.float32)
+        cotangent = jnp.asarray(rng.integers(-8, 8, (4, *features)), jnp.float32)
+        npt.assert_array_equal(
+            jnp.sum(segment_sum(data, POISON, 4, mode=mode) * cotangent),
+            jnp.sum(data * segment_take(cotangent, POISON, mode=mode)),
+        )
+
+    def test_gathers_and_drops(self) -> None:
+        """Rows come through unchanged; ids outside the table gather zero."""
+        table = jnp.arange(1.0, 5.0, dtype=jnp.float32)
+        for mode in DROP_SPELLINGS:
+            out = segment_take(table, POISON, mode=mode)
+            assert out.dtype == jnp.float32
+            npt.assert_array_equal(out, [1.0, 0.0, 3.0, 2.0, 0.0, 0.0, 0.0])
+            npt.assert_array_equal(out, _masked_take(table, POISON))
+        # `jnp.take` agrees on every id it does not read from the end of the table.
+        ids = jnp.array([0, 4, 2, 1, 9, 3], jnp.int32)
+        npt.assert_array_equal(
+            segment_take(table, ids), jnp.take(table, ids, mode="fill", fill_value=0.0)
+        )
+        npt.assert_array_equal(
+            segment_take(jnp.zeros((0, 2), jnp.float32), POISON), jnp.zeros((7, 2))
+        )
+
+    def test_clip_gathers_the_clamped_row(self) -> None:
+        """Clip clamps each id to the first or last row rather than filling."""
+        table = jnp.arange(1.0, 5.0, dtype=jnp.float32)
+        clamped = jnp.take(table, POISON, mode="clip")
+        npt.assert_array_equal(clamped, [1.0, 1.0, 3.0, 2.0, 1.0, 4.0, 4.0])
+        for mode in CLIP_SPELLINGS:
+            npt.assert_array_equal(segment_take(table, POISON, mode=mode), clamped)
+        # An empty table has no row to clamp to, so every output is zero.
+        npt.assert_array_equal(
+            segment_take(jnp.zeros((0, 2), jnp.float32), POISON, mode="clip"),
+            jnp.zeros((7, 2)),
+        )
+        # A zero fill changes nothing, whether trace time knows its value or not.
+        npt.assert_array_equal(
+            segment_take(table, POISON, mode="clip", fill_value=0), clamped
+        )
+        clipped = jax.jit(partial(segment_take, segment_ids=POISON, mode="clip"))
+        npt.assert_array_equal(clipped(table, fill_value=jnp.float32(0.0)), clamped)
+
+    def test_grad_is_the_wide_sum(self) -> None:
+        """Reverse mode is `segment_sum` bit for bit, keeping its accuracy."""
+        data = jnp.asarray([1e8, *[1.0] * 8, -1e8], jnp.float32)
+        ids = jnp.zeros(10, jnp.int32)
+
+        def loss(table: Array) -> Array:
+            return jnp.sum(segment_take(table, ids) * data)
+
+        grad = jax.grad(loss)(jnp.zeros(1, jnp.float32))
+        npt.assert_array_equal(grad, segment_sum(data, ids, 1))
+        npt.assert_array_equal(grad, [8.0])
+
+    @pytest.mark.parametrize("mode", MODES)
+    def test_forward_mode_and_second_order(self, mode: str) -> None:
+        """jvp, grad, and reverse-over-reverse match the masked `jnp.take`."""
+        table = jnp.arange(1.0, 5.0, dtype=jnp.float32)
+        tangent = jnp.arange(4.0, 8.0, dtype=jnp.float32)
+
+        def gathered(t: Array) -> Array:
+            return segment_take(t, POISON, mode=mode)
+
+        npt.assert_array_equal(
+            jax.jvp(gathered, (table,), (tangent,))[1],
+            segment_take(tangent, POISON, mode=mode),
+        )
+
+        def ours(t: Array) -> Array:
+            return jnp.sum(segment_take(t, POISON, mode=mode) ** 3)
+
+        def ref(t: Array) -> Array:
+            return jnp.sum(_masked_take(t, POISON, mode) ** 3)
+
+        npt.assert_allclose(jax.grad(ours)(table), jax.grad(ref)(table), rtol=1e-6)
+        npt.assert_allclose(
+            _hvp(ours, tangent)(table), _hvp(ref, tangent)(table), rtol=1e-6
+        )
+
+    @pytest.mark.parametrize("mode", MODES)
+    @pytest.mark.parametrize("in_axes", [(0, None), (None, 0), (0, 0), (1, 1)])
+    def test_jit_and_vmap(
+        self, in_axes: tuple[int | None, int | None], mode: str
+    ) -> None:
+        """Maps over the table, the ids, or both, each row resolving its own ids."""
+        tables = jnp.arange(1.0, 9.0, dtype=jnp.float32).reshape(2, 4)
+        rows = jnp.stack([POISON, jnp.roll(POISON, 2)])
+        args = (_mapped(tables, in_axes[0]), _mapped(rows, in_axes[1]))
+        npt.assert_array_equal(
+            jax.jit(jax.vmap(partial(segment_take, mode=mode), in_axes=in_axes))(*args),
+            jax.vmap(partial(_masked_take, mode=mode), in_axes=in_axes)(*args),
+        )
+
+    @pytest.mark.parametrize("mode", MODES)
+    def test_nested_vmap(self, mode: str) -> None:
+        """Two mapped axes gather each innermost row from its own table."""
+        tables = jnp.arange(1.0, 25.0, dtype=jnp.float32).reshape(2, 3, 4)
+        ids = jnp.stack([jnp.stack([POISON, jnp.roll(POISON, 2), -POISON])] * 2)
+        gathered = jax.vmap(jax.vmap(partial(segment_take, mode=mode)))(tables, ids)
+        npt.assert_array_equal(
+            gathered,
+            jax.vmap(jax.vmap(partial(_masked_take, mode=mode)))(tables, ids),
+        )
+
+    def test_take_accepts_ids_of_higher_rank(self) -> None:
+        """The gather shapes its output to the ids and stays the sum's adjoint."""
+        table = jnp.exp(jax.random.normal(jax.random.key(1), (8, 3), jnp.float32))
+        ids = jnp.stack([POISON, POISON[::-1]])
+        rows = segment_take(table, ids)
+        assert rows.shape == (*ids.shape, 3)
+        npt.assert_array_equal(
+            rows, _masked_take(table, ids.reshape(-1)).reshape(rows.shape)
+        )
+        cotangent = jax.random.normal(jax.random.key(2), rows.shape, jnp.float32)
+        (gradient,) = jax.vjp(partial(segment_take, segment_ids=ids), table)[1](
+            cotangent
+        )
+        npt.assert_allclose(
+            gradient, segment_sum(cotangent, ids, table.shape[0]), rtol=1e-6
+        )
+
+    def test_fill_value_replaces_dropped_rows(self) -> None:
+        """Dropped ids take `fill_value`, `None` meaning zero, and grad ignores it."""
+        table = jnp.arange(1.0, 5.0, dtype=jnp.float32)
+        out = segment_take(table, POISON, fill_value=99.0)
+        npt.assert_array_equal(out, [1.0, 99.0, 3.0, 2.0, 99.0, 99.0, 99.0])
+        npt.assert_array_equal(out, _masked_take(table, POISON, fill_value=99.0))
+        npt.assert_array_equal(
+            segment_take(table, POISON, fill_value=None), segment_take(table, POISON)
+        )
+        npt.assert_array_equal(
+            segment_take(jnp.zeros((0, 2), jnp.float32), POISON, fill_value=7.0),
+            jnp.full((7, 2), 7.0),
+        )
+
+        def loss(t: Array, fill: float) -> Array:
+            return jnp.sum(segment_take(t, POISON, fill_value=fill) ** 2)
+
+        npt.assert_array_equal(jax.grad(loss)(table, 99.0), jax.grad(loss)(table, 0.0))
+
+    def test_jvp_fills_the_tangent_with_zero(self) -> None:
+        """A nonzero fill is a constant, so the tangent still fills with zero."""
+        table = jnp.arange(1.0, 5.0, dtype=jnp.float32)
+        tangent = jnp.arange(4.0, 8.0, dtype=jnp.float32)
+        gathered = partial(segment_take, segment_ids=POISON, fill_value=99.0)
+        primal, out_tangent = jax.jvp(gathered, (table,), (tangent,))
+        npt.assert_array_equal(primal, segment_take(table, POISON, fill_value=99.0))
+        npt.assert_array_equal(out_tangent, [4.0, 0.0, 6.0, 5.0, 0.0, 0.0, 0.0])
+        npt.assert_array_equal(out_tangent, segment_take(tangent, POISON))
+
+    def test_fall_throughs_honour_mode(self) -> None:
+        """The integer gather clamps and fills exactly as the primitive path does."""
+        table = jnp.arange(1, 5, dtype=jnp.int32)
+        npt.assert_array_equal(
+            segment_take(table, POISON, mode="clip"),
+            jnp.take(table, POISON, mode="clip"),
+        )
+        npt.assert_array_equal(
+            segment_take(table, POISON, fill_value=7), [1, 7, 3, 2, 7, 7, 7]
+        )
+
+    def test_rejects_bad_arguments(self) -> None:
+        """Scalar tables, scalar ids, unsupported modes, and a nonzero clipped fill."""
+        table = jnp.arange(4, dtype=jnp.float32)
+        with pytest.raises(ValueError, match="1-D"):
+            segment_take(jnp.zeros((), jnp.float32), POISON)
+        with pytest.raises(ValueError, match="segment_ids"):
+            segment_take(jnp.zeros((4,), jnp.float32), jnp.asarray(0, jnp.int32))
+        for mode, message in BAD_MODES.items():
+            with pytest.raises(ValueError, match=message):
+                segment_take(table, POISON, mode=mode)
+        with pytest.raises(ValueError, match="fill_value.*clip"):
+            segment_take(table, POISON, mode="clip", fill_value=9.0)


### PR DESCRIPTION
Adds `segment_sum` and `segment_take` as a matched pair of JAX primitives that are exact adjoints of each other.

`segment_sum` is a drop-in replacement for `jax.ops.segment_sum` that accumulates scatter contributions in a wider float (f16/bf16 → f32, f32 → f64) and converts back once on exit, so a bin receiving `k` contributions rounds once rather than `k` times. The wide accumulator lives entirely in the StableHLO lowering and never appears in a jaxpr. A separate TPU lowering caps the accumulator at f32. Integer data and empty inputs fall through to the plain scatter, which is already exact.

`segment_take` gathers rows by segment id and is the forward pass of the pair. Its reverse pass calls `segment_sum`, so differentiating either primitive repeatedly keeps using the wide accumulator instead of falling back to a plain scatter.

Both primitives support `jit`, forward and reverse mode differentiation, repeated differentiation, and `vmap` over either or both arguments. Out-of-range ids are dropped by default or clamped under `mode="clip"`. `segment_take` additionally accepts a `fill_value` for dropped ids, which is treated as an additive constant so gradients ignore it. `segment_ids` may cover several leading axes of `data` rather than only the first.