### PR TITLE
perf: Replace `jax.ops.segment_sum` with wider-accumulating `segment_sum` and use `segment_take` for float gather adjoints

### DIFF
--- a/src/kups/core/data/index.py
+++ b/src/kups/core/data/index.py
@@ -34,6 +34,7 @@ from kups.core.utils.jax import (
     no_jax_tracing,
     skip_post_init_if_disabled,
 )
+from kups.core.utils.segment import segment_sum
 from kups.core.utils.subselect import subselect
 
 type PyTree = Any
@@ -528,8 +529,12 @@ class Index[Key: SupportsSorting]:
     def sum_over(self, array: Array) -> Table[Key, Array]:
         """Sums ``array`` values grouped by this index via segment sum.
 
+        Accumulates in a float wider than ``array``, so a key taking ``k``
+        contributions rounds once rather than ``k`` times. Entries whose index
+        is the OOB sentinel contribute nothing.
+
         Args:
-            array: Array with leading dimension matching ``self.indices``.
+            array: Array whose leading dimensions match ``self.indices``.
 
         Returns:
             A ``Table`` mapping each key to its summed values.
@@ -538,7 +543,7 @@ class Index[Key: SupportsSorting]:
 
         return Table(
             self.keys,
-            jax.ops.segment_sum(array, self.indices, self.num_labels, mode="drop"),
+            segment_sum(array, self.indices, self.num_labels),
             _cls=self._cls,
         )
 

--- a/src/kups/core/lens.py
+++ b/src/kups/core/lens.py
@@ -46,6 +46,7 @@ from typing import (
 )
 
 import jax
+import jax.numpy as jnp
 from jax import Array
 from jax.tree_util import DictKey, GetAttrKey, SequenceKey
 
@@ -61,6 +62,7 @@ from kups.core.utils.jax import (
     tree_map,
     tree_scatter_set,
 )
+from kups.core.utils.segment import segment_take
 
 
 class View[S, R](Protocol):
@@ -646,6 +648,70 @@ class LambdaLens(BaseLens[S, R]):
         return self._set(state, value)
 
 
+def _leading_axis_rows(idxs: Any) -> Array | None:
+    """The row index of a leading-axis gather, or ``None`` for any other index.
+
+    Args:
+        idxs: Index expression handed to ``Array.at[]``, which may equally be a
+            slice, an integer, ``None``, or a tuple selecting several axes.
+
+    Returns:
+        The integer array selecting rows, of any rank, or ``None`` when `idxs`
+        does not select whole rows of the leading axis by index.
+    """
+    if isinstance(idxs, tuple):
+        if len(idxs) != 1:
+            return None
+        idxs = idxs[0]
+    if not isinstance(idxs, Array) or idxs.ndim == 0:
+        return None
+    return idxs if jnp.issubdtype(idxs.dtype, jnp.integer) else None
+
+
+def _wide_gather_args(args: ScatterArgs) -> dict[str, Any] | None:
+    """The `segment_take` keywords reproducing `args`, or ``None`` if it cannot.
+
+    Reproducible are the bare gather and an explicit fill, the two policies that
+    keep the gather an exact adjoint of the sum. A caller asking to clamp keeps
+    plain indexing, whose cotangents are dropped rather than piled into the
+    clamped row, as does one leaning on ``at[].get()``'s own defaults, which
+    ignore a `fill_value` given without a `mode` and fill with NaN without one.
+
+    Args:
+        args: Scatter keywords the leaf would otherwise be gathered with.
+
+    Returns:
+        Keywords for [segment_take][kups.core.utils.segment.segment_take], or
+        ``None`` when `args` asks for something it cannot express.
+    """
+    if not args:
+        return {"mode": None, "fill_value": 0}
+    if set(args) != {"mode", "fill_value"} or args["mode"] not in ("fill", "drop"):
+        return None
+    return {"mode": args["mode"], "fill_value": args["fill_value"]}
+
+
+def _gathers_wide(arr: Array) -> bool:
+    """Whether gathering `arr` is worth the wide adjoint.
+
+    Integer and boolean leaves have no cotangent to accumulate; a weakly typed
+    leaf would come back strongly typed and promote differently downstream; and
+    a single-row table gathers by broadcast, which the out-of-range mask would
+    only make more expensive than the adjoint saves.
+
+    Args:
+        arr: Leaf about to be gathered.
+
+    Returns:
+        ``True`` when the wide adjoint both helps and changes nothing else.
+    """
+    return (
+        arr.shape[0] > 1
+        and jnp.issubdtype(arr.dtype, jnp.inexact)
+        and not arr.weak_type
+    )
+
+
 @dataclass
 class IndexLens(BaseLens[S, R]):
     """A lens that performs array indexing operations on the focused data.
@@ -667,9 +733,22 @@ class IndexLens(BaseLens[S, R]):
 
     @override
     def get[S2](self: IndexLens[S2, R], state: S2) -> R:
-        """Get values by applying array indexing to the focused data."""
+        """Get values by applying array indexing to the focused data.
+
+        Multi-row float leaves selected by a plain integer index array are
+        gathered with [segment_take][kups.core.utils.segment.segment_take],
+        whose reverse pass sums the cotangents landing in each row in a wider
+        float. Such a leaf takes its fill value where the index is out of range,
+        zero by default, rather than the clamped last row a bare ``at[].get()``
+        would give; every other leaf, and every other form of index, keeps the
+        plain indexing semantics.
+        """
+        rows = _leading_axis_rows(self.idxs)
 
         def _array_getter(scatter_args: ScatterArgs, arr: Array) -> Array:
+            take = _wide_gather_args(scatter_args)
+            if rows is not None and take is not None and _gathers_wide(arr):
+                return segment_take(arr, rows, **take)
             return arr.at[self.idxs].get(**scatter_args)
 
         def _getter(arr: Array | HasScatterArgs) -> Array | HasScatterArgs:

--- a/src/kups/core/utils/position.py
+++ b/src/kups/core/utils/position.py
@@ -9,7 +9,6 @@ axes pass through unchanged. The same code path covers fully-periodic
 crystals, vacuum clusters, and slab / wire geometries.
 """
 
-import jax
 import jax.numpy as jnp
 from jax import Array
 
@@ -17,6 +16,7 @@ from kups.core.cell import AnyPeriodicity, Cell
 from kups.core.data import Table
 from kups.core.typing import HasPositionsAndGroupIndex, HasWeights, ParticleId
 from kups.core.utils.jax import jit
+from kups.core.utils.segment import segment_sum
 
 
 @jit
@@ -70,12 +70,12 @@ def center_of_mass[P: HasPositionsAndGroupIndex](
     offsets = positions[ref_idx]
     rel_positions = positions - offsets[group_ids]
     rel_positions = batched_cells.wrap(rel_positions)
-    center_of_masses = jax.ops.segment_sum(
+    center_of_masses = segment_sum(
         rel_positions * weight,
         group_ids,
         num_groups,
     )
-    total_mass = jax.ops.segment_sum(
+    total_mass = segment_sum(
         weight,
         group_ids,
         num_groups,

--- a/src/kups/md/integrators.py
+++ b/src/kups/md/integrators.py
@@ -45,6 +45,7 @@ from kups.core.utils.functools import pipe
 from kups.core.utils.jax import dataclass, field, tree_map, vectorize
 from kups.core.utils.math import solve_affine_ode
 from kups.core.utils.random import sample_like
+from kups.core.utils.segment import segment_sum
 from kups.md.observables import (
     instantaneous_pressure,
     instantaneous_pressure_tensor,
@@ -815,7 +816,7 @@ class StochasticCellRescalingStep[State](Propagator[State]):
             particles.data.momenta, particles.data.masses
         )
         # K: total kinetic energy per system [energy]
-        kinetic_energy = jax.ops.segment_sum(
+        kinetic_energy = segment_sum(
             per_particle_ke,
             particles.data.system.indices,
             particles.data.system.num_labels,

--- a/src/kups/observables/stress.py
+++ b/src/kups/observables/stress.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
-import jax
 import jax.numpy as jnp
 from jax import Array
 
@@ -39,6 +38,7 @@ from kups.core.typing import (
     SystemId,
 )
 from kups.core.utils.jax import tree_map
+from kups.core.utils.segment import segment_sum
 
 
 @runtime_checkable
@@ -135,7 +135,7 @@ def _molecular_stress_via_virial_theorem(
     )
     offsets = positions[ref_idx]
     rel = batched_cells.wrap(positions - offsets[group.indices])
-    com = jax.ops.segment_sum(rel, group.indices, num_groups)
+    com = segment_sum(rel, group.indices, num_groups)
     counts = jnp.bincount(group.indices, length=num_groups)[:, None]
     com = com / jnp.maximum(counts, 1) + offsets
     com = group_cells.wrap(com)

--- a/src/kups/potential/classical/ewald.py
+++ b/src/kups/potential/classical/ewald.py
@@ -66,6 +66,7 @@ from kups.core.utils.jax import (
 from kups.core.utils.kahan import KahanSummand
 from kups.core.utils.math import triangular_3x3_matmul
 from kups.core.utils.ops import where_broadcast_last
+from kups.core.utils.segment import segment_sum
 from kups.potential.classical.coulomb import _pairwise_coulomb_energy
 from kups.potential.common.energy import (
     EnergyFunction,
@@ -307,7 +308,7 @@ def ewald_self_interaction_energy(
     """
     sys_idx = inp.graph.systems.index
     energies = (
-        -jax.ops.segment_sum(
+        -segment_sum(
             inp.graph.particles.data.charges**2,
             inp.graph.particles.data.system.indices,
             inp.graph.batch_size,
@@ -427,7 +428,7 @@ def _structure_factor_full(
         Structure factor, shape ``(n_systems, n_kvecs, 2)``.
     """
     response = _frequency_response(positions, charges, kvecs, batch_mask)
-    structure_factor = jax.ops.segment_sum(
+    structure_factor = segment_sum(
         response,
         batch_mask.indices,
         batch_mask.num_labels,
@@ -471,12 +472,12 @@ def _structure_factor_update(
         kvecs,
         updates.system,
     )
-    sk_delta = jax.ops.segment_sum(
+    sk_delta = segment_sum(
         new_response,
         batch_mask.indices[idx_data],
         batch_mask.num_labels,
         mode="drop",
-    ) - jax.ops.segment_sum(
+    ) - segment_sum(
         old_response,
         updates.system.indices,
         updates.system.num_labels,
@@ -536,7 +537,7 @@ def _structure_factor_update_jvp(
             full_response,
             "particles, particles, particles shifts two -> particles shifts two",
         )
-    sk_dot = jax.ops.segment_sum(
+    sk_dot = segment_sum(
         full_response_dot,
         batch_mask.indices,
         batch_mask.num_labels,
@@ -597,7 +598,7 @@ def ewald_net_charge_energy(inp: EwaldLongRangeInput[Any]) -> Table[SystemId, En
     """
     particles = inp.point_cloud.particles.data
     sys_idx = inp.point_cloud.systems.index
-    net_charge = jax.ops.segment_sum(
+    net_charge = segment_sum(
         particles.charges,
         particles.system.indices,
         inp.point_cloud.batch_size,

--- a/src/kups/potential/mliap/local.py
+++ b/src/kups/potential/mliap/local.py
@@ -67,6 +67,7 @@ from kups.core.typing import (
 from kups.core.utils.jax import dataclass, field, sequential_vmap_with_vjp, tree_map
 from kups.core.utils.kahan import KahanSummand
 from kups.core.utils.ops import where_broadcast_last
+from kups.core.utils.segment import segment_sum
 from kups.potential.common.energy import (
     PotentialFromEnergy,
     Sum,
@@ -344,7 +345,7 @@ def local_mliap_energy_full[
         edges.difference_vectors(point_cloud.particles, point_cloud.systems)[:, 0],
     )
     # Aggregate messages
-    msg_sum = jax.ops.segment_sum(edge_emb, edges.indices.indices[:, 0], n)
+    msg_sum = segment_sum(edge_emb, edges.indices.indices[:, 0], n)
     # Node-wise energies
     energies = inp.config.readout_function(node_emb, msg_sum)
     # Total energies per system
@@ -417,8 +418,8 @@ def local_mliap_energy_update[
     # Update message sums
     msg_sum = (
         inp.config.cache.msg_sum
-        - jax.ops.segment_sum(old_edge_emb, inp.edges_deleted.indices.indices[:, 0], n)
-        + jax.ops.segment_sum(new_edge_emb, inp.edges.indices.indices[:, 0], n)
+        - segment_sum(old_edge_emb, inp.edges_deleted.indices.indices[:, 0], n)
+        + segment_sum(new_edge_emb, inp.edges.indices.indices[:, 0], n)
     )
     # Node-wise readout
     energies = inp.config.readout_function(node_emb, msg_sum)

--- a/test/core/test_index.py
+++ b/test/core/test_index.py
@@ -367,6 +367,41 @@ class TestSumOver:
             [[6.0, 8.0], [3.0, 4.0]],
         )
 
+    def test_accumulates_in_a_wider_float(self):
+        """A cancelling spike leaves the float32 addends the plain scatter rounds away."""
+        data = jnp.asarray([1e8, *[1.0] * 8, -1e8], jnp.float32)
+        idx = Index.integer(jnp.zeros(10, int), n=1, label=SystemId)
+        summed = idx.sum_over(data)
+        assert summed.data.dtype == jnp.float32
+        npt.assert_array_equal(summed.data, [8.0])
+        assert jax.ops.segment_sum(data, idx.indices, 1)[0] != 8.0
+
+    def test_out_of_bounds_entries_are_dropped(self):
+        """The OOB sentinel contributes to no key."""
+        idx = Index.integer(jnp.asarray([0, 2, 1, 2]), n=2, label=SystemId)
+        npt.assert_array_equal(
+            idx.sum_over(jnp.asarray([1.0, 9.0, 3.0, 9.0], jnp.float32)).data,
+            [1.0, 3.0],
+        )
+
+    def test_multi_dimensional_index(self):
+        """A 2-D index groups elementwise, one contribution per entry."""
+        idx = Index.integer(jnp.asarray([[0, 1], [1, 2]]), n=2, label=SystemId)
+        npt.assert_array_equal(
+            idx.sum_over(jnp.ones((2, 2), jnp.float32)).data, [1.0, 2.0]
+        )
+
+    def test_grad_is_a_gather(self):
+        """Reverse mode hands each contribution its key's cotangent."""
+        idx = Index.integer(jnp.asarray([0, 2, 1, 0]), n=2, label=SystemId)
+        cotangent = jnp.asarray([10.0, 100.0], jnp.float32)
+
+        def loss(x: jax.Array) -> jax.Array:
+            return jnp.sum(idx.sum_over(x).data * cotangent)
+
+        grad = jax.grad(loss)(jnp.ones(4, jnp.float32))
+        npt.assert_array_equal(grad, [10.0, 0.0, 100.0, 10.0])
+
 
 class TestMaxOver:
     def test_max_over(self):

--- a/test/core/test_table.py
+++ b/test/core/test_table.py
@@ -262,6 +262,57 @@ class TestGetitem:
         indexed = Table.arange(jnp.array([100.0, 200.0, 300.0]))
         npt.assert_array_equal(indexed[Index.new([2, 0])], [300.0, 100.0])
 
+    def test_multi_dimensional_index(self):
+        """A 2-D index, as edges carry, keeps its shape ahead of the feature dims."""
+        table = Table.arange(jnp.arange(6.0, dtype=jnp.float32).reshape(3, 2))
+        pairs = Index.integer(jnp.asarray([[0, 2], [1, 1]]), n=3)
+        gathered = table[pairs]
+        assert gathered.shape == (2, 2, 2)
+        npt.assert_array_equal(gathered, [[[0.0, 1.0], [4.0, 5.0]], [[2.0, 3.0]] * 2])
+
+    def test_grad_accumulates_in_a_wider_float(self):
+        """Rows gathered many times sum their float32 cotangents once, not per edge."""
+        table = Table.arange(jnp.zeros((2, 3), jnp.float32), label=ParticleId)
+        edges = Index.integer(jnp.zeros(10, int), n=2, label=ParticleId)
+        cotangent = jnp.asarray([1e8, *[1.0] * 8, -1e8], jnp.float32)[:, None]
+
+        def loss(positions: jax.Array) -> jax.Array:
+            return jnp.sum(
+                Table(table.keys, positions, _cls=ParticleId)[edges] * cotangent
+            )
+
+        npt.assert_array_equal(jax.grad(loss)(table.data)[0], jnp.full(3, 8.0))
+
+    def test_single_row_tables_keep_plain_indexing(self):
+        """One row gathers by broadcast, which an out-of-range mask only slows down."""
+        single = Table.arange(jnp.asarray([[1.0, 2.0]], jnp.float32), label=ParticleId)
+        oob = Index.integer([0, 1], n=1, label=ParticleId)
+        npt.assert_array_equal(single[oob], [[1.0, 2.0], [1.0, 2.0]])
+
+    def test_out_of_bounds_reads_zero_but_keeps_index_sentinels(self):
+        """A float leaf reads zero out of bounds; an ``Index`` leaf keeps the sentinel."""
+        data = ParticleData(
+            jnp.asarray([[1.0, 1.0], [2.0, 2.0]], jnp.float32),
+            Index.integer(jnp.asarray([0, 1]), n=2, label=SystemId),
+        )
+        oob = Index.integer([0, 2], n=2, label=ParticleId)
+        gathered = Table.arange(data, label=ParticleId)[oob]
+        npt.assert_array_equal(gathered.positions, [[1.0, 1.0], [0.0, 0.0]])
+        npt.assert_array_equal(gathered.system.indices, [0, 2])
+        assert not gathered.system.valid_mask[1]
+
+    def test_non_float_leaves_keep_plain_indexing(self):
+        """Integer and boolean leaves clamp out of bounds, as ``at[].get()`` does."""
+        oob = Index.integer([0, 2], n=2)
+        ints = Table.arange(jnp.asarray([10, 20], jnp.int32))
+        npt.assert_array_equal(ints[oob], [10, 20])
+        flags = Table.arange(jnp.asarray([False, True]))
+        npt.assert_array_equal(flags[oob], [False, True])
+        npt.assert_array_equal(
+            flags.at(oob, args={"mode": "fill", "fill_value": False}).get(),
+            [False, False],
+        )
+
 
 class TestSlice:
     def test_slice(self):


### PR DESCRIPTION
This PR introduces a dedicated `segment_sum` utility and a new `segment_take` function, replacing direct calls to `jax.ops.segment_sum` throughout the codebase to improve numerical accuracy and gradient quality.

## Motivation

`jax.ops.segment_sum` accumulates contributions in the same float precision as the input, meaning a key receiving `k` contributions rounds `k` times. For float32 inputs with many contributions or large dynamic range, this causes meaningful numerical error. Similarly, the reverse pass of a plain `arr.at[idxs].get()` gather clamps out-of-bounds indices to the last row and piles cotangents there rather than distributing them correctly.

## Changes

**`segment_sum`**: The new utility accumulates in a wider float before casting back to the input dtype, so each key rounds once regardless of how many contributions it receives. Out-of-bounds sentinel indices contribute nothing.

**`segment_take`**: Replaces `arr.at[idxs].get()` for multi-row float leaves selected by a plain integer index array. Its reverse pass sums cotangents using the wider `segment_sum`, making the gather an exact adjoint of the sum. Out-of-range indices return a fill value (zero by default) rather than clamping to the last row.

The wide gather is applied selectively — only to multi-row, non-weakly-typed inexact leaves selected by a plain integer index array. Single-row tables, integer/boolean leaves, clamped-mode gathers, and non-row-selecting index expressions all retain plain `at[].get()` semantics.

## Tests

- `Index.sum_over` correctly resolves a cancelling spike that float32 sequential accumulation rounds away
- Out-of-bounds sentinel entries contribute nothing to any key
- Multi-dimensional indices group element-wise
- Reverse mode distributes each key's cotangent to its contributing rows
- `Table.__getitem__` gradient accumulates float32 cotangents in wider precision for rows gathered many times
- Single-row tables, non-float leaves, and non-row-selecting indices preserve existing plain indexing behavior
- Out-of-bounds reads return zero for float leaves while `Index` leaves retain their sentinel values

## Results

Lennard-Jones energy in float32 against a float64 reference, fcc Ar rattled by 0.05 Å:

| system | cutoff | before | after |
|---|---|---|---|
| 32 atoms | 10 Å | 7.03e-07 | 2.15e-09 (327x) |
| 108 atoms | 14 Å | 2.08e-05 | 4.64e-08 (449x) |

Per-row cotangent accumulation in float32 against a float64 reference, 64 rows of 3 features, maximum relative error:

| contributions per row | magnitude spread | plain gather | `segment_take` |
|---|---|---|---|
| 32 | none | 1.39e-07 | 4.12e-08 (3.4x) |
| 32 | none, 75% zeros | 9.02e-08 | 3.07e-08 (2.9x) |
| 256 | none | 7.46e-07 | 3.30e-08 (22.6x) |
| 256 | 4 decades | 3.81e-07 | 2.56e-08 (14.9x) |
| 2048 | 4 decades, 50% zeros | 1.03e-06 | 2.44e-08 (42.4x) |

Jitted Lennard-Jones energy and forces, arms compiled up front from one settled neighbour-list state and timed round-robin; median of 61 rounds on an L4, 41 on 8 pinned CPU cores:

| | 108 atoms | 500 atoms | 864 atoms |
|---|---|---|---|
| GPU before | 0.556 ms | 0.415 ms | 0.706 ms |
| GPU after | 0.556 ms (+0.1%) | 0.420 ms (+1.3%) | 0.704 ms (-0.2%) |
| CPU before | 15.47 ms | 15.56 ms | 61.44 ms |
| CPU after | 14.96 ms (-3.3%) | 13.50 ms (-13.3%) | 57.01 ms (-7.2%) |
| flops after | +0.8% | +5.3% | +8.7% |
| flops without the single-row guard | +34.2% | +44.2% | +57.2% |

Forces are bitwise unchanged; the energy gain is entirely `Index.sum_over`.
