### PR TITLE
test: pin tuple-key Table construction and combined per-species counts

### DIFF
--- a/test/core/test_index.py
+++ b/test/core/test_index.py
@@ -14,7 +14,7 @@ from kups.core.data.index import (
     Index,
     unify_keys_by_cls,
 )
-from kups.core.typing import ExclusionId, ParticleId, SystemId
+from kups.core.typing import ExclusionId, MotifId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
 
 
@@ -347,6 +347,19 @@ class TestCombineIndices:
             (SystemId(1), ParticleId(0)),
         )
         npt.assert_array_equal(result4.indices, [0, 0, 1])
+
+    def test_combined_counts_with_colliding_flattened_keys(self):
+        # Regression: the per-(system, motif) counts expression used by GCMC logging.
+        # 1.0.4's Table key check flattened the tuple keys via np.asarray(dtype=object),
+        # so SystemId(0) collided with MotifId(0) and any multi-system x multi-motif
+        # batch raised "Primary keys must be unique".
+        system = Index.new([SystemId(0), SystemId(0), SystemId(1), SystemId(1)])
+        motif = Index.new([MotifId(0), MotifId(1), MotifId(0), MotifId(1)])
+        counts = Index.combine(system, motif).counts
+        assert counts.keys == tuple(
+            (SystemId(s), MotifId(m)) for s in range(2) for m in range(2)
+        )
+        npt.assert_array_equal(counts.data, [1, 1, 1, 1])
 
 
 class TestSumOver:

--- a/test/core/test_table.py
+++ b/test/core/test_table.py
@@ -10,7 +10,7 @@ import pytest
 
 from kups.core.data.index import Index
 from kups.core.data.table import Table
-from kups.core.typing import GroupId, Label, ParticleId, SystemId
+from kups.core.typing import GroupId, Label, MotifId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
 
 
@@ -99,6 +99,14 @@ class TestKeyOrdering:
     def test_constructor_rejects_duplicate_keys(self):
         with pytest.raises(ValueError, match="must be unique"):
             Table(("a", "a"), jnp.array([1.0, 2.0]))
+
+    def test_accepts_tuple_keys_with_colliding_elements(self):
+        # Regression: 1.0.4 checked uniqueness via np.unique(np.asarray(keys, dtype=object)),
+        # which turns equal-length tuple keys into a 2-D array and compares the flattened
+        # scalars, so any multi-system x multi-motif key set was rejected as "duplicate".
+        keys = tuple((SystemId(s), MotifId(m)) for s in range(2) for m in range(2))
+        table = Table(keys, jnp.arange(4))
+        assert table.keys == keys
 
     def test_new_sorts_keys_and_data(self):
         t = Table.new(("c", "a", "b"), jnp.array([30.0, 10.0, 20.0]))


### PR DESCRIPTION
## The bug (present in released `kups==1.0.4`)

`Table.__post_init__` validated key uniqueness with `np.unique(np.asarray(self.keys, dtype=object))`. For equal-length **tuple keys**, `np.asarray(..., dtype=object)` silently builds a 2-D `(n, k)` array, so the uniqueness check runs over the flattened scalars instead of the tuples. Typed ids compare by integer value, so `SystemId(0)` collides with `MotifId(0)` and any multi-system × multi-motif key set is rejected even though every pair is unique:

```python
import jax.numpy as jnp
from kups.core.data import Index
from kups.core.typing import MotifId, SystemId

system = Index(keys=(SystemId(0), SystemId(1)), indices=jnp.array([0, 0, 1, 1]))
motif = Index(keys=(MotifId(0), MotifId(1)), indices=jnp.array([0, 1, 0, 1]))
Index.combine(system, motif).counts
# kups 1.0.4: AssertionError: Primary keys must be unique
# main (after #250): Table(tuple, keys=((0, 0), (0, 1), (1, 0), (1, 1)), data=[1 1 1 1])
```

This is exactly the per-`(system, motif)` counts expression downstream GCMC logging evaluates every cycle (`kups_sim` `mcmc/gcmc/adsorption/logging.py`), so on 1.0.4 any **batched multi-system, multi-species** loading run dies at the first logged step. It goes unnoticed today only because current workloads are single-species batches or single-system mixtures.

## Why there is no code change here

#250 replaced the numpy check with a pairwise `_check_keys` walk (motivated by *sortedness*, not tuples) and fixed this **incidentally** — verified: the repro above passes on `main` and fails on the `v1.0.4` code. Nothing in the suite pinned tuple keys, so a future numpy-based refactor of `_check_keys` could silently reintroduce the flattening. This PR adds the two regression tests:

- `TestKeyOrdering::test_accepts_tuple_keys_with_colliding_elements` — `Table` construction with `(SystemId, MotifId)` keys whose flattened elements collide.
- `TestCombineIndices::test_combined_counts_with_colliding_flattened_keys` — the end-to-end `Index.combine(...).counts` expression used by GCMC logging.

Both files: 62/62 tests pass locally.

Note for downstream: `kups_sim` pins `kups[cuda]==1.0.4`, so the fix only reaches the platform with the next release — worth including in the `1.0.5` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)