### PR TITLE
feat: add particles_from_arrays constructor

### DIFF
--- a/src/kups/application/utils/particles.py
+++ b/src/kups/application/utils/particles.py
@@ -90,28 +90,23 @@ def _particles_from_path(
     return _particles_from_atoms(next(ase.io.iread(path, index=-1, store_tags=True)))
 
 
-def _particles_from_atoms(
-    atoms: ase.Atoms,
+def _build_particles_and_cell(
+    *,
+    positions: Array,
+    cell_vectors: Array,
+    periodicity: AnyPeriodicity,
+    masses: Array,
+    atomic_numbers: Array,
+    charges: Array,
+    labels: list[Label],
 ) -> tuple[
     Table[ParticleId, Particles], Cell[AnyPeriodicity], Callable[[Array], Array]
 ]:
-    """Build particle data and cell from an ASE Atoms object."""
-    L, uc_transform = to_lower_triangular(jnp.asarray(atoms.cell.array))
-    pbc = (bool(atoms.pbc[0]), bool(atoms.pbc[1]), bool(atoms.pbc[2]))
-    cell = Cell.from_pbc(TriclinicFrame.from_matrix(L), pbc)
-    positions = uc_transform(jnp.asarray(atoms.positions))
-    masses = jnp.asarray(atoms.get_masses())
-    atomic_numbers = jnp.asarray(atoms.get_atomic_numbers())
+    """Build particle data and cell from extracted source data."""
+    L, uc_transform = to_lower_triangular(cell_vectors)
+    cell = Cell.from_pbc(TriclinicFrame.from_matrix(L), periodicity)
+    positions = uc_transform(positions)
     n_atoms = len(masses)
-    charges = jnp.asarray(
-        atoms.info.get(
-            "_atom_type_partial_charge",
-            atoms.info.get("_atom_site_charge", jnp.zeros((len(positions),))),
-        )
-    )
-    labels = list(
-        map(Label, atoms.info.get("_atom_site_label", atoms.get_chemical_symbols()))
-    )
     particles = Table.arange(
         Particles(
             positions=positions,
@@ -124,3 +119,34 @@ def _particles_from_atoms(
         label=ParticleId,
     )
     return particles, cell, uc_transform
+
+
+def _particles_from_atoms(
+    atoms: ase.Atoms,
+) -> tuple[
+    Table[ParticleId, Particles], Cell[AnyPeriodicity], Callable[[Array], Array]
+]:
+    """Build particle data and cell from an ASE Atoms object."""
+    cell_vectors = jnp.asarray(atoms.cell.array)
+    pbc = (bool(atoms.pbc[0]), bool(atoms.pbc[1]), bool(atoms.pbc[2]))
+    positions = jnp.asarray(atoms.positions)
+    masses = jnp.asarray(atoms.get_masses())
+    atomic_numbers = jnp.asarray(atoms.get_atomic_numbers())
+    charges = jnp.asarray(
+        atoms.info.get(
+            "_atom_type_partial_charge",
+            atoms.info.get("_atom_site_charge", jnp.zeros((len(positions),))),
+        )
+    )
+    labels = list(
+        map(Label, atoms.info.get("_atom_site_label", atoms.get_chemical_symbols()))
+    )
+    return _build_particles_and_cell(
+        positions=positions,
+        cell_vectors=cell_vectors,
+        periodicity=pbc,
+        masses=masses,
+        atomic_numbers=atomic_numbers,
+        charges=charges,
+        labels=labels,
+    )

--- a/src/kups/application/utils/particles.py
+++ b/src/kups/application/utils/particles.py
@@ -5,14 +5,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import cache
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 import ase
 import ase.io
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
+from jax.typing import ArrayLike
 
 from kups.core.cell import AnyPeriodicity, Cell, TriclinicFrame, to_lower_triangular
 from kups.core.data import Index, Table
@@ -58,6 +61,106 @@ def default_exclusion(n: int) -> Index[ExclusionId]:
     return Index.integer(jnp.arange(n), n=n, label=ExclusionId)
 
 
+def particles_from_arrays(
+    *,
+    positions: ArrayLike,
+    cell_vectors: ArrayLike,
+    periodicity: (
+        Sequence[bool | np.bool_ | Array] | np.ndarray[Any, np.dtype[np.bool_]] | Array
+    ),
+    masses: ArrayLike,
+    atomic_numbers: ArrayLike,
+    labels: Sequence[str],
+    charges: ArrayLike | None = None,
+) -> tuple[
+    Table[ParticleId, Particles], Cell[AnyPeriodicity], Callable[[Array], Array]
+]:
+    """Build particle data and cell from source-neutral arrays.
+
+    Numeric inputs follow the active JAX dtype configuration; exact dtype
+    preservation is not guaranteed.
+
+    Args:
+        positions: Cartesian positions in Å, shape ``(n, 3)``, expressed in the
+            same Cartesian coordinate frame as ``cell_vectors``.
+        cell_vectors: Three cell vectors in Å stored row-wise, shape ``(3, 3)``.
+            The caller must provide a valid cell or bounding frame.
+        periodicity: Three boolean values selecting periodic axes.
+        masses: Particle masses in amu, shape ``(n,)``.
+        atomic_numbers: Integer atomic numbers, shape ``(n,)``.
+        labels: Non-string sequence of string labels, one per particle.
+        charges: Partial charges in elementary-charge units, shape ``(n,)``.
+            Omitted charges default to floating zeros.
+
+    Returns:
+        Tuple of ``(particles, cell, uc_transform)`` where ``uc_transform``
+        rotates Cartesian coordinates into the lower-triangular cell frame.
+
+    Raises:
+        ValueError: If an input shape or particle/label count is invalid.
+        TypeError: If conversion fails or an input has an invalid type or dtype.
+    """
+    positions_array = _as_jax_array("positions", positions)
+    cell_vectors_array = _as_jax_array("cell_vectors", cell_vectors)
+    masses_array = _as_jax_array("masses", masses)
+    atomic_numbers_array = _as_jax_array("atomic_numbers", atomic_numbers)
+    charges_array = None if charges is None else _as_jax_array("charges", charges)
+
+    _require_real_dtype("positions", positions_array)
+    _require_real_dtype("cell_vectors", cell_vectors_array)
+    _require_real_dtype("masses", masses_array)
+    _require_integer_dtype("atomic_numbers", atomic_numbers_array)
+    if charges_array is not None:
+        _require_real_dtype("charges", charges_array)
+
+    if positions_array.ndim != 2 or positions_array.shape[1] != 3:
+        raise ValueError(
+            f"positions must have shape (n, 3); got {positions_array.shape}."
+        )
+    if cell_vectors_array.shape != (3, 3):
+        raise ValueError(
+            f"cell_vectors must have shape (3, 3); got {cell_vectors_array.shape}."
+        )
+
+    n_particles = positions_array.shape[0]
+    _require_particle_shape("masses", masses_array, n_particles)
+    _require_particle_shape("atomic_numbers", atomic_numbers_array, n_particles)
+    if charges_array is not None:
+        _require_particle_shape("charges", charges_array, n_particles)
+
+    if isinstance(labels, (str, bytes)):
+        raise TypeError("labels must be a non-string sequence of strings.")
+    try:
+        label_values = list(labels)
+    except TypeError as error:
+        raise TypeError("labels must be a sequence of strings.") from error
+    if len(label_values) != n_particles:
+        raise ValueError(
+            f"labels must contain {n_particles} values; got {len(label_values)}."
+        )
+    if not all(isinstance(label, str) for label in label_values):
+        raise TypeError("labels must contain only strings.")
+
+    periodicity_tuple = _normalize_periodicity(periodicity)
+    positions_array = _promote_integer_to_float(positions_array)
+    cell_vectors_array = _promote_integer_to_float(cell_vectors_array)
+    masses_array = _promote_integer_to_float(masses_array)
+    if charges_array is None:
+        charges_array = jnp.zeros(n_particles, dtype=jnp.result_type(float))
+    else:
+        charges_array = _promote_integer_to_float(charges_array)
+
+    return _build_particles_and_cell(
+        positions=positions_array,
+        cell_vectors=cell_vectors_array,
+        periodicity=periodicity_tuple,
+        masses=masses_array,
+        atomic_numbers=atomic_numbers_array,
+        charges=charges_array,
+        labels=list(map(Label, label_values)),
+    )
+
+
 def particles_from_ase(
     atoms: ase.Atoms | str | Path,
 ) -> tuple[
@@ -88,6 +191,71 @@ def _particles_from_path(
 ]:
     """Read an ASE-readable file and build cached particle data and cell."""
     return _particles_from_atoms(next(ase.io.iread(path, index=-1, store_tags=True)))
+
+
+def _as_jax_array(name: str, value: ArrayLike) -> Array:
+    """Convert one public numeric argument to a JAX array."""
+    try:
+        return jnp.asarray(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise TypeError(f"{name} could not be converted to a JAX array.") from error
+
+
+def _require_real_dtype(name: str, value: Array) -> None:
+    """Require a real integer or floating dtype."""
+    if not (
+        jnp.issubdtype(value.dtype, jnp.integer)
+        or jnp.issubdtype(value.dtype, jnp.floating)
+    ):
+        raise TypeError(
+            f"{name} must have a real integer or floating dtype; got {value.dtype}."
+        )
+
+
+def _require_integer_dtype(name: str, value: Array) -> None:
+    """Require an integer dtype."""
+    if not jnp.issubdtype(value.dtype, jnp.integer):
+        raise TypeError(f"{name} must have an integer dtype; got {value.dtype}.")
+
+
+def _require_particle_shape(name: str, value: Array, n_particles: int) -> None:
+    """Require a one-dimensional per-particle field."""
+    if value.shape != (n_particles,):
+        raise ValueError(f"{name} must have shape ({n_particles},); got {value.shape}.")
+
+
+def _normalize_periodicity(
+    periodicity: (
+        Sequence[bool | np.bool_ | Array] | np.ndarray[Any, np.dtype[np.bool_]] | Array
+    ),
+) -> AnyPeriodicity:
+    """Validate and normalize periodicity to an exact Python boolean tuple."""
+    try:
+        periodicity_array = jnp.asarray(periodicity)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise TypeError("periodicity could not be converted to a JAX array.") from error
+    if periodicity_array.shape != (3,):
+        raise ValueError(
+            f"periodicity must contain exactly three values; "
+            f"got shape {periodicity_array.shape}."
+        )
+    if not jnp.issubdtype(periodicity_array.dtype, jnp.bool_):
+        raise TypeError(
+            f"periodicity must contain only boolean values; "
+            f"got {periodicity_array.dtype}."
+        )
+    return (
+        bool(periodicity_array[0]),
+        bool(periodicity_array[1]),
+        bool(periodicity_array[2]),
+    )
+
+
+def _promote_integer_to_float(value: Array) -> Array:
+    """Promote integer inputs to JAX's active default floating dtype."""
+    if jnp.issubdtype(value.dtype, jnp.integer):
+        return value.astype(jnp.result_type(float))
+    return value
 
 
 def _build_particles_and_cell(

--- a/test/application/utils/test_particles.py
+++ b/test/application/utils/test_particles.py
@@ -10,7 +10,8 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from kups.application.utils.particles import Particles
+from kups.application.utils.particles import Particles, particles_from_arrays
+from kups.core.cell import Cell, PeriodicCell, TriclinicFrame, VacuumCell
 from kups.core.data.index import Index
 from kups.core.data.table import Table
 from kups.core.typing import InclusionId, Label, ParticleId, SystemId
@@ -257,3 +258,265 @@ class TestParticlesFromAsePbcDispatch:
         assert isinstance(cell, Cell)
         assert not isinstance(cell, (PeriodicCell, VacuumCell))
         assert cell.periodic == pbc
+
+
+class TestParticlesFromArrays:
+    """Test the public source-neutral particle constructor."""
+
+    @staticmethod
+    def _valid_inputs():
+        return {
+            "positions": np.array([[0.2, 0.4, 0.6], [1.1, 1.3, 1.5]]),
+            "cell_vectors": np.diag([4.0, 5.0, 6.0]),
+            "periodicity": (True, True, True),
+            "masses": np.array([22.99, 35.45]),
+            "atomic_numbers": np.array([11, 17]),
+            "labels": ["Na", "Cl"],
+        }
+
+    @staticmethod
+    def _assert_particle_parity(actual, expected):
+        assert actual.keys == expected.keys
+        assert all(isinstance(key, ParticleId) for key in actual.keys)
+        npt.assert_allclose(actual.data.positions, expected.data.positions)
+        npt.assert_allclose(actual.data.masses, expected.data.masses)
+        npt.assert_array_equal(actual.data.atomic_numbers, expected.data.atomic_numbers)
+        npt.assert_allclose(actual.data.charges, expected.data.charges)
+        assert actual.data.labels.keys == expected.data.labels.keys
+        npt.assert_array_equal(actual.data.labels.indices, expected.data.labels.indices)
+        assert actual.data.system.keys == expected.data.system.keys
+        npt.assert_array_equal(actual.data.system.indices, expected.data.system.indices)
+
+    def test_numpy_orthogonal_periodic_matches_ase(self):
+        from ase import Atoms
+
+        from kups.application.utils.particles import particles_from_ase
+
+        inputs = self._valid_inputs()
+        charges = np.array([0.75, -0.75])
+        atoms = Atoms(
+            "NaCl",
+            positions=inputs["positions"],
+            cell=inputs["cell_vectors"],
+            pbc=True,
+        )
+        atoms.set_masses(inputs["masses"])
+        atoms.info["_atom_type_partial_charge"] = charges
+        atoms.info["_atom_site_label"] = inputs["labels"]
+
+        expected_particles, expected_cell, expected_transform = particles_from_ase(
+            atoms
+        )
+        inputs["periodicity"] = np.array([True, True, True], dtype=bool)
+        actual_particles, actual_cell, actual_transform = particles_from_arrays(
+            **inputs,
+            charges=charges,
+        )
+
+        self._assert_particle_parity(actual_particles, expected_particles)
+        assert isinstance(actual_cell, PeriodicCell)
+        assert type(actual_cell) is type(expected_cell)
+        assert type(actual_cell.frame) is type(expected_cell.frame)
+        assert isinstance(actual_cell.frame, TriclinicFrame)
+        assert actual_cell.periodic == expected_cell.periodic
+        npt.assert_allclose(actual_cell.vectors, expected_cell.vectors)
+        npt.assert_allclose(actual_cell.frame.tril, expected_cell.frame.tril)
+        probe = jnp.array([[0.25, 0.5, 0.75], [-0.4, 1.2, 0.3]])
+        npt.assert_allclose(
+            actual_transform(probe), expected_transform(probe), atol=1e-12
+        )
+
+    def test_jax_non_lower_triangular_joint_transformation(self):
+        from ase import Atoms
+
+        from kups.application.utils.particles import particles_from_ase
+
+        positions = jnp.array([[0.4, 0.8, 1.2], [1.5, 0.3, 2.1]])
+        cell_vectors = jnp.array([[0.0, 2.0, 0.0], [1.5, 0.2, 0.0], [0.3, 0.4, 3.0]])
+        masses = jnp.array([12.0, 16.0])
+        atomic_numbers = jnp.array([6, 8])
+        labels = ["C", "O"]
+        atoms = Atoms(
+            "CO",
+            positions=np.asarray(positions),
+            cell=np.asarray(cell_vectors),
+            pbc=(True, False, True),
+        )
+        atoms.set_masses(np.asarray(masses))
+
+        expected_particles, expected_cell, expected_transform = particles_from_ase(
+            atoms
+        )
+        actual_particles, actual_cell, actual_transform = particles_from_arrays(
+            positions=positions,
+            cell_vectors=cell_vectors,
+            periodicity=jnp.array([True, False, True]),
+            masses=masses,
+            atomic_numbers=atomic_numbers,
+            labels=labels,
+        )
+
+        self._assert_particle_parity(actual_particles, expected_particles)
+        assert type(actual_cell) is Cell
+        assert actual_cell.periodic == (True, False, True)
+        assert all(type(value) is bool for value in actual_cell.periodic)
+        npt.assert_allclose(actual_cell.vectors, expected_cell.vectors, atol=1e-12)
+        npt.assert_allclose(
+            actual_particles.data.positions,
+            actual_transform(positions),
+            atol=1e-12,
+        )
+        npt.assert_allclose(
+            jnp.triu(actual_cell.vectors, k=1), jnp.zeros((3, 3)), atol=1e-12
+        )
+        probe = jnp.array([[0.6, -0.2, 0.9], [1.1, 0.7, -0.5]])
+        npt.assert_allclose(
+            actual_transform(probe), expected_transform(probe), atol=1e-12
+        )
+
+    def test_omitted_charges_default_to_floating_zeros(self):
+        particles, _, _ = particles_from_arrays(**self._valid_inputs())
+
+        npt.assert_array_equal(particles.data.charges, jnp.zeros(2))
+        assert jnp.issubdtype(particles.data.charges.dtype, jnp.floating)
+
+    def test_integer_masses_and_charges_are_promoted(self):
+        inputs = self._valid_inputs()
+        inputs["positions"] = np.array([[0, 1, 2], [1, 2, 3]], dtype=int)
+        inputs["cell_vectors"] = np.diag(np.array([4, 5, 6], dtype=int))
+        inputs["masses"] = np.array([23, 35], dtype=int)
+        charges = np.array([1, -1], dtype=int)
+
+        particles, cell, _ = particles_from_arrays(**inputs, charges=charges)
+
+        assert jnp.issubdtype(particles.data.masses.dtype, jnp.floating)
+        assert jnp.issubdtype(particles.data.charges.dtype, jnp.floating)
+        assert jnp.issubdtype(particles.data.positions.dtype, jnp.floating)
+        assert jnp.issubdtype(cell.vectors.dtype, jnp.floating)
+        npt.assert_array_equal(particles.data.masses, jnp.array([23.0, 35.0]))
+        npt.assert_array_equal(particles.data.charges, jnp.array([1.0, -1.0]))
+
+    def test_numpy_boolean_mask_constructs_periodic_cell(self):
+        inputs = self._valid_inputs()
+        inputs["periodicity"] = np.array([True, True, True], dtype=bool)
+
+        _, cell, _ = particles_from_arrays(**inputs)
+
+        assert isinstance(cell, PeriodicCell)
+        assert cell.periodic == (True, True, True)
+
+    def test_numpy_boolean_tuple_constructs_vacuum_cell(self):
+        inputs = self._valid_inputs()
+        inputs["periodicity"] = (np.bool_(False),) * 3
+
+        _, cell, _ = particles_from_arrays(**inputs)
+
+        assert isinstance(cell, VacuumCell)
+        assert cell.periodic == (False, False, False)
+
+    def test_mixed_mask_constructs_generic_cell_with_python_booleans(self):
+        inputs = self._valid_inputs()
+        inputs["periodicity"] = jnp.array([True, False, True])
+
+        _, cell, _ = particles_from_arrays(**inputs)
+
+        assert type(cell) is Cell
+        assert type(cell.periodic) is tuple
+        assert cell.periodic == (True, False, True)
+        assert all(type(value) is bool for value in cell.periodic)
+
+    @pytest.mark.parametrize(
+        ("argument", "value"),
+        [
+            ("positions", np.zeros((2, 2))),
+            ("cell_vectors", np.eye(2)),
+        ],
+        ids=["positions", "cell-vectors"],
+    )
+    def test_invalid_geometry_shape(self, argument, value):
+        inputs = self._valid_inputs()
+        inputs[argument] = value
+
+        with pytest.raises(ValueError, match=argument):
+            particles_from_arrays(**inputs)
+
+    @pytest.mark.parametrize(
+        ("argument", "value"),
+        [
+            ("masses", np.ones(1)),
+            ("atomic_numbers", np.array([11, 17, 19])),
+            ("charges", np.zeros(1)),
+        ],
+    )
+    def test_mismatched_particle_field_length(self, argument, value):
+        inputs = self._valid_inputs()
+        inputs[argument] = value
+
+        with pytest.raises(ValueError, match=argument):
+            particles_from_arrays(**inputs)
+
+    def test_incorrect_label_count(self):
+        inputs = self._valid_inputs()
+        inputs["labels"] = ["Na"]
+
+        with pytest.raises(ValueError, match="labels"):
+            particles_from_arrays(**inputs)
+
+    @pytest.mark.parametrize("labels", ["Na", b"Na"], ids=["str", "bytes"])
+    def test_string_like_scalar_labels_are_rejected(self, labels):
+        inputs = self._valid_inputs()
+        inputs["labels"] = labels
+
+        with pytest.raises(TypeError, match="labels"):
+            particles_from_arrays(**inputs)
+
+    def test_non_string_label(self):
+        inputs = self._valid_inputs()
+        inputs["labels"] = ["Na", 17]
+
+        with pytest.raises(TypeError, match="labels"):
+            particles_from_arrays(**inputs)
+
+    def test_floating_atomic_numbers_are_rejected(self):
+        inputs = self._valid_inputs()
+        inputs["atomic_numbers"] = np.array([11.0, 17.0])
+
+        with pytest.raises(TypeError, match="atomic_numbers"):
+            particles_from_arrays(**inputs)
+
+    @pytest.mark.parametrize(
+        ("argument", "value"),
+        [
+            ("positions", np.zeros((2, 3), dtype=bool)),
+            ("cell_vectors", np.eye(3, dtype=complex)),
+            ("masses", np.array(["23", "35"])),
+            ("charges", np.array([1.0, object()], dtype=object)),
+            ("atomic_numbers", np.array([True, False])),
+        ],
+        ids=["boolean", "complex", "string", "object", "atomic-boolean"],
+    )
+    def test_incompatible_physical_dtype(self, argument, value):
+        inputs = self._valid_inputs()
+        inputs[argument] = value
+
+        with pytest.raises(TypeError, match=argument):
+            particles_from_arrays(**inputs)
+
+    @pytest.mark.parametrize(
+        "periodicity",
+        [(1, 1, 0), ("yes", "yes", "no")],
+        ids=["integer", "string"],
+    )
+    def test_non_boolean_periodicity_is_rejected(self, periodicity):
+        inputs = self._valid_inputs()
+        inputs["periodicity"] = periodicity
+
+        with pytest.raises(TypeError, match="periodicity"):
+            particles_from_arrays(**inputs)
+
+    def test_periodicity_requires_exactly_three_values(self):
+        inputs = self._valid_inputs()
+        inputs["periodicity"] = [True, False]
+
+        with pytest.raises(ValueError, match="periodicity"):
+            particles_from_arrays(**inputs)


### PR DESCRIPTION
Closes #273.

## Summary

This PR adds a public, source-neutral `particles_from_arrays()` constructor for building kUPS particle and cell data directly from NumPy-compatible inputs or existing JAX arrays. Array-native callers no longer need to create an intermediate `ase.Atoms` object while receiving an equivalent particle table, transformed cell, and coordinate transformation.

## Implementation

* Extracts the shared cell and position transformation and kUPS object construction into `_build_particles_and_cell()`.
* Keeps ASE-specific extraction, charge and label precedence, caching, path loading, and public behavior unchanged.
* Converts numeric inputs independently with `jnp.asarray()` and validates their shapes and dtype categories.
* Uses the active JAX dtype configuration without guaranteeing exact dtype preservation. Integer-typed positions, cell vectors, masses, and charges are promoted with `jnp.result_type(float)`, while atomic numbers retain an integer dtype.
* Defaults omitted charges to floating zeros and normalizes periodicity to an exact Python boolean tuple before cell construction.

## Verification

The added tests cover parity with `particles_from_ase()`, joint position and cell transformation for non-orthogonal cells, returned-transform parity, charge defaults, integer promotion, periodicity dispatch, and invalid shapes, dtypes, labels, and particle-field lengths.

Local pre-commit checks on the changed files, Ruff lint and formatting checks, `pyrefly check src/`, and `git diff --check` all pass. The local full test suite passes with `1908 passed, 7 skipped, 5 warnings`.

## Scope

This change adds no new dependencies and leaves the existing application builders unchanged.