### PR TITLE
fix: Skip `Batched` shape validation when leaf list is empty (flax.nnx `None` placeholder unflatten)

### DIFF
--- a/src/kups/core/data/batched.py
+++ b/src/kups/core/data/batched.py
@@ -25,25 +25,26 @@ class Batched:
             shapes = tuple(x.shape for x in leaves)
         except AttributeError:
             return
-        if not isinstance(leaves[0], jax.Array | np.ndarray):
+        # An empty leaf list means there is nothing to validate; this happens when a
+        # pytree is rebuilt with ``None`` placeholders instead of arrays.
+        if not leaves or not isinstance(leaves[0], jax.Array | np.ndarray):
             return
-        if len(shapes) > 0:
-            reference = shapes[0]
-            if len(reference) == 0:
-                raise ValueError(
-                    f"Batched cannot be initialized with no leading dimension. Got shapes: {shapes}."
-                )
-            errors: list[tuple[int, tuple[int, ...]]] = []
-            for i, shape in enumerate(shapes[1:]):
-                if len(shape) == 0 or shape[0] != reference[0]:
-                    errors.append((i + 1, shape))
-            if len(errors) > 0:
-                msg = "Inconsistent shapes in batched data: "
-                msg += f"Expected all leaves to have the same first dimension size {reference[0]}.\n"
-                msg += "The following leaves have different shapes: "
-                for idx, shape in errors:
-                    msg += f"Leaf {idx} has shape {shape}, expected {reference}. "
-                raise ValueError(msg)
+        reference = shapes[0]
+        if len(reference) == 0:
+            raise ValueError(
+                f"Batched cannot be initialized with no leading dimension. Got shapes: {shapes}."
+            )
+        errors: list[tuple[int, tuple[int, ...]]] = []
+        for i, shape in enumerate(shapes[1:]):
+            if len(shape) == 0 or shape[0] != reference[0]:
+                errors.append((i + 1, shape))
+        if len(errors) > 0:
+            msg = "Inconsistent shapes in batched data: "
+            msg += f"Expected all leaves to have the same first dimension size {reference[0]}.\n"
+            msg += "The following leaves have different shapes: "
+            for idx, shape in errors:
+                msg += f"Leaf {idx} has shape {shape}, expected {reference}. "
+            raise ValueError(msg)
 
     def __len__(self) -> int:
         """Return the batch size (leading dimension size).

--- a/test/core/test_batched.py
+++ b/test/core/test_batched.py
@@ -1,0 +1,50 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Batched mixin."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from kups.core.cell import PeriodicCell, TriclinicFrame
+from kups.core.data import Batched
+from kups.core.utils.jax import dataclass
+
+
+@dataclass
+class _Pair(Batched):
+    a: jax.Array
+    b: jax.Array
+
+
+class TestBatched:
+    def test_consistent_leading_dim(self):
+        pair = _Pair(jnp.zeros((4, 3)), jnp.ones((4,)))
+        assert len(pair) == 4 and pair.size == 4
+
+    def test_inconsistent_leading_dim(self):
+        with pytest.raises(ValueError, match="Inconsistent shapes"):
+            _Pair(jnp.zeros((4, 3)), jnp.ones((2,)))
+
+    def test_missing_leading_dim(self):
+        with pytest.raises(ValueError, match="no leading dimension"):
+            _Pair(jnp.zeros(()), jnp.zeros(()))
+
+    @pytest.mark.parametrize(
+        "obj",
+        [
+            _Pair(jnp.zeros((4, 3)), jnp.ones((4,))),
+            PeriodicCell(frame=TriclinicFrame.from_matrix(jnp.eye(3)[None])),
+        ],
+        ids=["pair", "cell"],
+    )
+    def test_unflatten_with_none_leaves(self, obj: Batched):
+        """Rebuilding with ``None`` leaves must not fail.
+
+        ``flax.nnx`` replaces every non-graph-node leaf with ``None`` and
+        unflattens, so ``__post_init__`` runs on a leafless placeholder.
+        """
+        leaves, treedef = jax.tree.flatten(obj)
+        rebuilt = jax.tree.unflatten(treedef, [None] * len(leaves))
+        assert type(rebuilt) is type(obj)


### PR DESCRIPTION
Fixes #270