### PR TITLE
fix(observables): take the molecular virial about the centre of mass

### DIFF
--- a/src/kups/core/utils/position.py
+++ b/src/kups/core/utils/position.py
@@ -14,7 +14,12 @@ from jax import Array
 
 from kups.core.cell import AnyPeriodicity, Cell
 from kups.core.data import Table
-from kups.core.typing import HasPositionsAndGroupIndex, HasWeights, ParticleId
+from kups.core.typing import (
+    HasMasses,
+    HasPositionsAndGroupIndex,
+    HasWeights,
+    ParticleId,
+)
 from kups.core.utils.jax import jit
 from kups.core.utils.segment import segment_sum
 
@@ -36,7 +41,8 @@ def center_of_mass[P: HasPositionsAndGroupIndex](
         yield incorrect results.
 
     Args:
-        particles: Indexed particles, optionally supporting `HasWeights` for mass weighting.
+        particles: Indexed particles, optionally supporting `HasWeights` (or
+            `HasMasses`) for mass weighting; unweighted otherwise.
         cells: Cell(s) carrying lattice geometry and per-axis periodicity.
             Must have one cell per group.
 
@@ -65,6 +71,8 @@ def center_of_mass[P: HasPositionsAndGroupIndex](
     positions = particles.data.positions
     if isinstance(particles.data, HasWeights):
         weight = particles.data.weights[:, None]
+    elif isinstance(particles.data, HasMasses):
+        weight = particles.data.masses[:, None]
     else:
         weight = jnp.ones_like(positions[:, 0])[:, None]
     offsets = positions[ref_idx]
@@ -100,7 +108,7 @@ def to_relative_positions[P: HasPositionsAndGroupIndex](
 
     Args:
         particles: Indexed particles with position and group index data. Supports
-            `HasWeights` if center of mass needs to be computed.
+            `HasWeights` or `HasMasses` if center of mass needs to be computed.
         cells: Cell(s) carrying lattice geometry and per-axis periodicity.
         center_of_masses: Optional precomputed centers of mass. If `None`,
             will be computed automatically.

--- a/src/kups/observables/stress.py
+++ b/src/kups/observables/stress.py
@@ -32,13 +32,14 @@ from kups.core.typing import (
     GroupId,
     HasCell,
     HasGroupIndex,
+    HasMasses,
     HasPositions,
     HasSystemIndex,
     ParticleId,
     SystemId,
 )
 from kups.core.utils.jax import tree_map
-from kups.core.utils.segment import segment_sum
+from kups.core.utils.position import center_of_mass
 
 
 @runtime_checkable
@@ -59,8 +60,15 @@ class IsVirialSystems(HasCell[AnyPeriodicity], Protocol):
 
 
 @runtime_checkable
-class IsMolecularVirialParticles(HasPositions, HasGroupIndex, HasSystemIndex, Protocol):
-    """Particles with position gradients, group and system assignment."""
+class IsMolecularVirialParticles(
+    HasPositions, HasGroupIndex, HasSystemIndex, HasMasses, Protocol
+):
+    """Particles with position gradients, masses, group and system assignment.
+
+    Masses are required because the molecular virial is taken about each
+    group's centre of mass, not its geometric centroid; the two differ for
+    heteronuclear or asymmetric groups.
+    """
 
     @property
     def position_gradients(self) -> Array: ...
@@ -120,25 +128,18 @@ def _molecular_stress_via_virial_theorem(
     position_gradients: Array,
     vector_gradients: Array,
     positions: Array,
+    com: Array,
     group: Index[GroupId],
     group_cells: Cell[AnyPeriodicity],
     system: Index[SystemId],
     system_cell: Cell[AnyPeriodicity],
 ) -> Array:
-    """Molecular virial stress using center-of-mass positions (RASPA convention)."""
-    num_groups = group.num_labels
+    """Molecular virial stress about per-group centres of mass (RASPA convention).
+
+    ``com`` comes from [center_of_mass][kups.core.utils.position.center_of_mass],
+    which is mass-weighted and minimum-image aware.
+    """
     batched_cells = group_cells[group.indices]
-    ref_idx = (
-        jnp.zeros(num_groups, dtype=int)
-        .at[group.indices]
-        .set(jnp.arange(group.indices.shape[0]), mode="drop")
-    )
-    offsets = positions[ref_idx]
-    rel = batched_cells.wrap(positions - offsets[group.indices])
-    com = segment_sum(rel, group.indices, num_groups)
-    counts = jnp.bincount(group.indices, length=num_groups)[:, None]
-    com = com / jnp.maximum(counts, 1) + offsets
-    com = group_cells.wrap(com)
     rel_pos = batched_cells.wrap(
         positions - com.at[group.indices].get(mode="fill", fill_value=0)
     )
@@ -229,8 +230,13 @@ def molecular_stress_via_virial_theorem(
 ) -> Table[SystemId, Array]:
     """Compute molecular virial stress tensor (RASPA convention).
 
+    The position virial is taken about each group's mass-weighted centre of
+    mass rather than about the individual atoms, so intramolecular forces
+    cancel. For heteronuclear or asymmetric groups this differs from the
+    unweighted geometric centroid.
+
     Args:
-        particles: Per-particle positions, group/system index, and gradients.
+        particles: Per-particle positions, masses, group/system index, and gradients.
         groups: Per-group system assignment.
         systems: Per-system cell and cell gradients (lower-triangular).
 
@@ -243,6 +249,7 @@ def molecular_stress_via_virial_theorem(
         particles.data.position_gradients,
         cell.frame.vectors_gradient(systems.data.cell_gradients.frame),
         particles.data.positions,
+        center_of_mass(particles, group_cells),
         particles.data.group,
         group_cells,
         particles.data.system,

--- a/test/core/test_position.py
+++ b/test/core/test_position.py
@@ -27,6 +27,19 @@ class ParticlesWithMass:
     group: Index[GroupId]
 
 
+@dataclass
+class ParticlesUsingMasses:
+    positions: jax.Array
+    masses: jax.Array
+    group: Index[GroupId]
+
+
+@dataclass
+class ParticlesWithoutWeights:
+    positions: jax.Array
+    group: Index[GroupId]
+
+
 def _make_group_index(ids: list[int], num_groups: int) -> Index[GroupId]:
     """Create an Index[GroupId] from integer group assignments."""
     labels = tuple(GroupId(i) for i in range(num_groups))
@@ -113,6 +126,37 @@ class TestCenterOfMass:
         com4 = center_of_mass(particles4, cells_2sys[:2])
         expected_wrapped = cells_2sys[:2].wrap(positions4)
         npt.assert_allclose(com4, expected_wrapped, atol=1e-10)
+
+    def test_masses_weight_the_average_when_weights_are_absent(self, cells_2sys):
+        """Test that a masses field weights the CoM, and that its absence does not.
+
+        Every particle type in the package names this field masses rather than
+        weights, so checking only for weights would silently fall back to an
+        unweighted centroid throughout the library.
+        """
+        positions = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+        group = _make_group_index([0, 0], 1)
+
+        weighted = center_of_mass(
+            Table.arange(
+                ParticlesUsingMasses(
+                    positions=positions, masses=jnp.array([3.0, 1.0]), group=group
+                ),
+                label=ParticleId,
+            ),
+            cells_2sys[:1],
+        )
+        npt.assert_allclose(weighted, jnp.array([[0.25, 0.0, 0.0]]), atol=1e-10)
+
+        # Same geometry with no weight field at all falls back to the centroid.
+        unweighted = center_of_mass(
+            Table.arange(
+                ParticlesWithoutWeights(positions=positions, group=group),
+                label=ParticleId,
+            ),
+            cells_2sys[:1],
+        )
+        npt.assert_allclose(unweighted, jnp.array([[0.5, 0.0, 0.0]]), atol=1e-10)
 
     def test_center_of_mass_assertion_error(self, cells_2sys):
         """Test that assertion error is raised when cells don't match groups."""

--- a/test/observables/test_stress.py
+++ b/test/observables/test_stress.py
@@ -19,9 +19,10 @@ from kups.core.cell import (
     VacuumCell,
 )
 from kups.core.data import Index, Table
-from kups.core.typing import ParticleId, SystemId
+from kups.core.typing import GroupId, ParticleId, SystemId
 from kups.core.utils.jax import dataclass
 from kups.observables.stress import (
+    molecular_stress_via_virial_theorem,
     stress_via_virial_theorem,
     total_lattice_gradient,
 )
@@ -76,6 +77,64 @@ def _make_particles(
             positions=positions,
             position_gradients=position_gradients,
             system=Index(sys_keys, system_ids),
+        ),
+    )
+
+
+@dataclass
+class _MolecularVirialParticles:
+    positions: Array
+    position_gradients: Array
+    masses: Array
+    group: Index[GroupId]
+    system: Index[SystemId]
+
+
+@dataclass
+class _MolecularGroups:
+    system: Index[SystemId]
+
+
+def _make_molecular_particles(
+    positions: Array,
+    position_gradients: Array,
+    group_ids: Array,
+    n_groups: int,
+    system_ids: Array | None = None,
+    n_systems: int = 1,
+    masses: Array | None = None,
+) -> Table[ParticleId, _MolecularVirialParticles]:
+    """Helper: particle Table carrying a group index as well as a system index.
+
+    ``masses`` default to equal weights, which makes the centre of mass
+    coincide with the geometric centroid.
+    """
+    n = positions.shape[0]
+    if system_ids is None:
+        system_ids = jnp.zeros(n, dtype=int)
+    if masses is None:
+        masses = jnp.ones(n)
+    return Table(
+        tuple(ParticleId(i) for i in range(n)),
+        _MolecularVirialParticles(
+            positions=positions,
+            position_gradients=position_gradients,
+            masses=masses,
+            group=Index(tuple(GroupId(i) for i in range(n_groups)), group_ids),
+            system=Index(tuple(SystemId(i) for i in range(n_systems)), system_ids),
+        ),
+    )
+
+
+def _make_groups(
+    group_system_ids: Array, n_systems: int = 1
+) -> Table[GroupId, _MolecularGroups]:
+    """Helper: group Table assigning each group to a system."""
+    n = group_system_ids.shape[0]
+    return Table(
+        tuple(GroupId(i) for i in range(n)),
+        _MolecularGroups(
+            system=Index(tuple(SystemId(i) for i in range(n_systems)), group_system_ids)
         ),
     )
 
@@ -297,3 +356,79 @@ class TestTotalLatticeGradient:
             positions, g, _periodic(frame), _periodic(partial_frame), system
         )
         assert not jnp.allclose(periodic.data.frame.vectors, partial_frame.vectors)
+
+
+class TestMolecularStressViaVirialTheorem:
+    """σ referenced to group centres of mass rather than atom positions.
+
+    One test per property that delegating the reference point to
+    ``center_of_mass`` could have broken: equivalence with the atomic formula,
+    minimum-image handling, and mass weighting itself. Tests that pass no
+    explicit masses use equal weights, where the centre of mass coincides with
+    the geometric centroid.
+    """
+
+    def test_singleton_groups_reduce_to_atomic_virial(self):
+        """One particle per group makes the centroid the particle itself."""
+        positions = jnp.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
+        lv = jnp.eye(3)[None] * 20.0
+        systems = _make_systems(lv)
+        atomic = stress_via_virial_theorem(_make_particles(positions), systems)
+        molecular = molecular_stress_via_virial_theorem(
+            _make_molecular_particles(
+                positions, positions, jnp.arange(2, dtype=int), n_groups=2
+            ),
+            _make_groups(jnp.zeros(2, dtype=int)),
+            systems,
+        )
+        npt.assert_allclose(molecular.data, atomic.data, atol=1e-12)
+
+    def test_centroid_uses_the_image_nearest_each_particle(self):
+        """A group straddling the boundary must not be centred in mid-box.
+
+        Particles at ``x = 9`` and ``x = 2`` in a 10 A box form one molecule
+        across the boundary; its centroid is ``x = 0.5 (mod L)``, not the naive
+        in-box mean ``5.5``. Each particle then pairs with the centroid image
+        closest to itself -- ``x = 10.5`` for the particle at ``9`` -- so the
+        virial stays continuous as a molecule drifts across the boundary.
+        """
+        L = 10.0
+        positions = jnp.array([[9.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+        gradients = jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        result = molecular_stress_via_virial_theorem(
+            _make_molecular_particles(
+                positions, gradients, jnp.zeros(2, dtype=int), n_groups=1
+            ),
+            _make_groups(jnp.zeros(1, dtype=int)),
+            _make_systems(jnp.eye(3)[None] * L),
+        )
+        expected = jnp.zeros((3, 3)).at[0, 0].set(-10.5 / L**3)
+        npt.assert_allclose(result.data[0], expected, atol=1e-12)
+        # The naive in-box centroid (5.5) would give a different answer.
+        assert not jnp.allclose(result.data[0, 0, 0], -5.5 / L**3)
+
+    def test_reference_point_is_mass_weighted(self):
+        """A heteronuclear pair is referenced to its COM, not its centroid.
+
+        Two particles at ``x = 0`` and ``x = 6`` with masses ``1`` and ``3``
+        have COM ``x = 4.5`` but centroid ``x = 3``. Only the light particle
+        carries a force, so the position virial reads off the reference point
+        directly and the two conventions are cleanly separated.
+        """
+        L = 40.0  # large enough that no minimum-image wrapping intervenes
+        positions = jnp.array([[0.0, 0.0, 0.0], [6.0, 0.0, 0.0]])
+        gradients = jnp.array([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        result = molecular_stress_via_virial_theorem(
+            _make_molecular_particles(
+                positions,
+                gradients,
+                jnp.zeros(2, dtype=int),
+                n_groups=1,
+                masses=jnp.array([1.0, 3.0]),
+            ),
+            _make_groups(jnp.zeros(1, dtype=int)),
+            _make_systems(jnp.eye(3)[None] * L),
+        )
+        com_x, centroid_x = 4.5, 3.0
+        npt.assert_allclose(result.data[0, 0, 0], -com_x / L**3, atol=1e-12)
+        assert not jnp.allclose(result.data[0, 0, 0], -centroid_x / L**3)


### PR DESCRIPTION
One of the follow-ups I mentioned on #276. Independent of it — no shared files, no conflict, and
it needs no reference-value changes of its own.

`center_of_mass` gates its mass weighting on `isinstance(particles.data, HasWeights)`, i.e. on a
`weights` attribute — and **no particle type in the package defines one**; they all expose
`masses`. The branch is only ever taken by `test/core/test_position.py`, so in production
"centre of mass" has always meant "unweighted centroid".

**This is not only a reporting issue.** `center_of_mass` also sets the pivot for the rigid-body
rotation move (`mcmc/moves.py`), so it affects sampled trajectories, not just diagnostics.
Rotating about a body-fixed point other than the COM is still valid MC — detailed balance
holds — but it is not the documented convention and it changes the move's behaviour for
asymmetric adsorbates.

Separately, `molecular_stress_via_virial_theorem` documents the RASPA centre-of-mass convention
but carried its own inlined, unweighted copy of the group-centroid computation. It now reuses
`center_of_mass`, which deletes the duplicate.

## Changes

- `center_of_mass` falls back to `HasMasses` when `HasWeights` is absent, leaving the existing
  `HasWeights` contract intact.
- `molecular_stress_via_virial_theorem` takes the reference point from `center_of_mass` instead
  of recomputing it; `IsMolecularVirialParticles` gains `HasMasses`.

## Nothing in the shipped references moves

CO2 is symmetric — C at the origin, two equal O sites at ±1.16 Å — so its centroid and centre of
mass coincide exactly for any masses. Verified bit-identical for a randomly rotated and
translated CO2 pair evaluated with real versus equal masses. The same symmetry means the
rotation pivot is unchanged, so `nvt_50co2_30box` needs no update. Asymmetric or heteronuclear
adsorbates do change, which is the point.

## Tests

`molecular_stress_via_virial_theorem` had no coverage. Three tests, one per property that
delegating the reference point could have broken: equivalence with the atomic formula for
singleton groups, minimum-image handling for a group straddling the boundary, and mass weighting
itself (a heteronuclear pair whose COM at `x = 4.5` and centroid at `x = 3` differ, which fails
on the old code). Plus one test covering the new `HasMasses` branch directly in
`test/core/test_position.py`.

## Question

I took the least invasive option, but the `HasWeights` / `HasMasses` split is your call and I am
happy to redo it: `HasWeights` currently has no implementers anywhere in the package, so it could
equally be removed, or the particle types could grow a `weights` property instead of the fallback
here. Tell me which you prefer.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
