### PR TITLE
ci: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,12 +3,12 @@ description: "Setup kUPS environment"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: /tmp/jax_cache
         key: ${{ runner.os }}-${{ github.job }}-jax-${{ hashFiles('**/uv.lock') }}
     - name: Install uv
-      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       with:
         enable-cache: true
         prune-cache: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+
+# Actions are pinned to commit SHAs, which do not update themselves. Dependabot
+# reads the `# vX.Y.Z` comment beside each SHA to know the current version, and
+# rewrites both the SHA and the comment when it opens a bump PR.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  # Composite actions are scanned per-directory, separately from the workflows.
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,10 +8,10 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
       - name: Cache pre-commit
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-3${{ hashFiles('.pre-commit-config.yaml') }}
@@ -29,13 +29,13 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
         resolution: ["highest", "lowest-direct"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
       - name: Get main commit hash
         id: get-main-hash
         run: echo "main_hash=$(git rev-parse origin/main)" >> $GITHUB_OUTPUT
       - id: testmon-cache-restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .testmondata
           key: testmon-${{ steps.get-main-hash.outputs.main_hash }}-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.resolution }}
@@ -54,7 +54,7 @@ jobs:
         env:
           JAX_PLATFORMS: cpu
       - id: testmon-cache-save
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         if: always() && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         with:
           path: .testmondata

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,13 +14,13 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
       - name: Install dependencies
         run: uv sync --no-default-groups --group docs --group notebook
       - name: Build documentation
         run: JAX_COMPILATION_CACHE_DIR="/tmp/jax_cache" ./docs/scripts/build.sh
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: site
 
@@ -42,8 +42,8 @@ jobs:
     # Specify runner + deployment step
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 

--- a/.github/workflows/gpu.yaml
+++ b/.github/workflows/gpu.yaml
@@ -8,7 +8,7 @@ jobs:
   validate:
     runs-on: t4-gpu-github
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
       - name: Nvidia smi
         run: nvidia-smi

--- a/.github/workflows/issue-labeling.yml
+++ b/.github/workflows/issue-labeling.yml
@@ -22,12 +22,12 @@ jobs:
       issues: write    # Apply labels and assign milestones
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Label issue
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const script = require('./.github/scripts/label-issue.js');

--- a/.github/workflows/pr-labeling.yml
+++ b/.github/workflows/pr-labeling.yml
@@ -15,10 +15,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Label PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -36,10 +36,10 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Generate PR Description
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const title = context.payload.pull_request.title;

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Build distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - uses: ./.github/actions/setup
       - name: Verify tag matches pyproject.toml version
         run: |
@@ -27,7 +27,7 @@ jobs:
       - name: Build sdist and wheel
         run: uv build
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/
@@ -44,12 +44,12 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
   github-release:
     name: Sign artifacts and create GitHub release
@@ -60,12 +60,12 @@ jobs:
       id-token: write
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist/
       - name: Sign artifacts with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 # v3.0.0
         with:
           inputs: ./dist/*.tar.gz ./dist/*.whl
       - name: Create GitHub release

--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -20,13 +20,13 @@ jobs:
       pull-requests: read  # Gather PR activity
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Generate summary
         id: summary
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const script = require('./.github/scripts/weekly-summary.js');


### PR DESCRIPTION
Pins every third-party `uses:` reference to the full commit SHA it currently resolves to, annotated with its version tag.

A tag is a mutable pointer — anyone able to push to an action's repository can move `v4` onto arbitrary code, and every workflow referencing it executes that code on the next run. A SHA cannot be repointed.

This is the precondition for dropping the `sha_pinning_required: false` override that `cusp-ai-oss` carries in the Kapitan inventory (`grid/inventory/targets/github/cusp-ai-oss/org.yml`), deferred under CUSP-11504. kUPS is the first of ten repos in the org.

## What changed

27 refs across 9 files. The 5 local `./.github/actions/setup` refs are untouched — path references resolve within this repo and are not pinnable.

| Action | Was | Pinned at |
|---|---|---|
| `actions/checkout` | `v4` | `11d5960` — v4.4.0 |
| `actions/cache` (+ `/restore`, `/save`) | `v4` | `0057852` — v4.3.0 |
| `actions/github-script` | `v7` | `f28e40c` — v7.1.0 |
| `actions/download-artifact` | `v4` | `d3f86a1` — v4.3.0 |
| `actions/upload-artifact` | `v4` | `ea165f8` — v4.6.2 |
| `actions/upload-pages-artifact` | `v4` | `7b1f4a7` — v4.0.0 |
| `actions/configure-pages` | `v5` | `983d773` — v5.0.0 |
| `actions/deploy-pages` | `v4` | `d6db901` — v4.0.5 |
| `pypa/gh-action-pypi-publish` | `release/v1` | `dc37677` — v1.14.2 |
| `sigstore/gh-action-sigstore-python` | `v3.0.0` | `f514d46` — v3.0.0 |
| `astral-sh/setup-uv` | already a SHA | unchanged, now labelled v8.0.0 |

**No behaviour changes today.** Each SHA is the commit the tag already resolved to — e.g. `v4` and `v4.4.0` are two tags on the same `actions/checkout` commit, so the same code runs before and after.

One entry is more than a freeze: **`pypa/gh-action-pypi-publish@release/v1` was tracking a branch**, not a tag. Every release run executed whatever that branch pointed at, on the job holding this project's PyPI trusted-publishing identity. It is now fixed at v1.14.2.

## Why the second commit

SHA pins don't update themselves, so pinning alone trades a supply-chain risk for staleness. The `dependabot.yml` closes that: the `github-actions` ecosystem reads the `# vX.Y.Z` comment to determine the current version and rewrites both SHA and comment in a bump PR. Updates are grouped into a single weekly PR.

Happy to split that into its own PR if you'd rather review it separately.

## Verification

- All 9 files parse as YAML; the diff is exactly 27 insertions / 27 deletions, one line each.
- Every remaining `uses:` is either a 40-character SHA or a local `./` path.
- Each SHA was resolved from the live GitHub API, dereferencing annotated tag objects to their target commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
