### PR TITLE
refactor: detect placeholder unflattens in the dataclass pytree layer

### DIFF
--- a/src/kups/core/data/table.py
+++ b/src/kups/core/data/table.py
@@ -392,7 +392,10 @@ class Table(Batched, Generic[TKey, TData]):
 
     def __iter__(self):
         def data_slice(i: int) -> TData:
-            return tree_map(lambda x: x[i], self.data)
+            # Row slices of nested containers (Batched, Index) lose the
+            # shared leading dimension their validation asserts over.
+            with no_post_init():
+                return tree_map(lambda x: x[i], self.data)
 
         yield from ((key, data_slice(i)) for i, key in enumerate(self.keys))
 

--- a/src/kups/core/neighborlist/parameters.py
+++ b/src/kups/core/neighborlist/parameters.py
@@ -20,7 +20,7 @@ from kups.core.data import Table
 from kups.core.neighborlist.common import candidate_image_counts, num_cells
 from kups.core.neighborlist.types import NeighborListSystems
 from kups.core.typing import SystemId
-from kups.core.utils.jax import dataclass, field, no_jax_tracing, no_post_init
+from kups.core.utils.jax import dataclass, field, no_jax_tracing
 from kups.core.utils.math import next_higher_power
 
 
@@ -110,21 +110,20 @@ class UniversalNeighborlistParameters:
 
         sys = Table.join(systems, particles_per_system, cutoffs)
         total_candidates = total_image_candidates = total_edges = max_cells = 0
-        with no_post_init():
-            for _, (s, n_p, c) in sys:
-                n_bins = num_cells(s, c).prod()
-                candidates = min(n_p / n_bins * (3**3), n_p)
-                # A cutoff reaching past perp/2 replicates each candidate once per
-                # periodic image (product of per-axis image counts). Summing per
-                # system keeps the estimate tight for heterogeneous cutoffs instead
-                # of assuming every system replicates at the maximum rate.
-                images = candidate_image_counts(s.cell, c).prod()
-                total_candidates += candidates
-                total_image_candidates += _next_power(candidates) * images
-                total_edges += _estimate_avg_num_edges(
-                    n_p, s.cell.volume, c, base, multiplier
-                )
-                max_cells = max(n_bins, max_cells)
+        for _, (s, n_p, c) in sys:
+            n_bins = num_cells(s, c).prod()
+            candidates = min(n_p / n_bins * (3**3), n_p)
+            # A cutoff reaching past perp/2 replicates each candidate once per
+            # periodic image (product of per-axis image counts). Summing per
+            # system keeps the estimate tight for heterogeneous cutoffs instead
+            # of assuming every system replicates at the maximum rate.
+            images = candidate_image_counts(s.cell, c).prod()
+            total_candidates += candidates
+            total_image_candidates += _next_power(candidates) * images
+            total_edges += _estimate_avg_num_edges(
+                n_p, s.cell.volume, c, base, multiplier
+            )
+            max_cells = max(n_bins, max_cells)
 
         return UniversalNeighborlistParameters(
             avg_edges=int(total_edges // sys.size),

--- a/src/kups/core/storage.py
+++ b/src/kups/core/storage.py
@@ -615,8 +615,7 @@ class GroupReader[Storage]:
         structure — and yields the dataset name(s) for the focused field, so a
         field read touches only those datasets.
         """
-        with no_post_init():
-            return self.tree_def.unflatten(self.paths)  # type: ignore - string leaves stand in for arrays
+        return self.tree_def.unflatten(self.paths)  # type: ignore - string leaves stand in for arrays
 
     def _read_leaves(
         self, leaves: list[str], treedef: PyTreeDef[Any], index: Index

--- a/src/kups/core/utils/jax.py
+++ b/src/kups/core/utils/jax.py
@@ -764,8 +764,24 @@ def dataclass[T](
             _meta: tuple[str, ...] = meta_fields,
             _init_meta: frozenset[str] = frozenset(init_meta_fields),
         ) -> T:
+            data = tuple(data)
             kwargs = dict(zip(_data, data))
             kwargs.update((n, v) for n, v in zip(_meta, meta) if n in _init_meta)
+            # jax's pytree contract lets callers unflatten with placeholder
+            # leaves (device_put/shard_map sentinels, flax.nnx ``None``
+            # erasure, string name trees); validating those is meaningless.
+            # Placeholders are detected from the payload itself — leaves that
+            # are not data — so every such boundary is covered here, at the
+            # one point all unflattens pass through, instead of by per-caller
+            # suppression. Real-leaf unflattens validate exactly as before.
+            # The ambient check comes first: inside a ``no_post_init`` region
+            # validation is skipped anyway, and lens traversal proxies must
+            # not see the ``hasattr`` probes (they record attribute access).
+            if _data and not getattr(_no_post_init, "active", False):
+                leaves = jax.tree_util.tree_leaves(data)
+                if not leaves or any(not _is_data_leaf(x) for x in leaves):
+                    with no_post_init():
+                        return _cls(**kwargs)
             return _cls(**kwargs)
 
         jax.tree_util.register_pytree_with_keys(dcls, _flatten_with_keys, _unflatten)
@@ -774,6 +790,17 @@ def dataclass[T](
     if cls is None:
         return make_dataclass
     return make_dataclass(cls)
+
+
+def _is_data_leaf(leaf: object) -> bool:
+    """Whether jax could trace this leaf: array-like or a scalar.
+
+    Dynamic fields hold traceable data by construction, so anything else in
+    leaf position is an unflatten placeholder.
+    """
+    return isinstance(leaf, (bool, int, float, complex)) or (
+        hasattr(leaf, "shape") and hasattr(leaf, "dtype")
+    )
 
 
 _no_post_init = threading.local()
@@ -801,11 +828,13 @@ def skip_post_init_if_disabled(post_init: Callable[..., None]):
     """Skip ``__post_init__`` validation when inside a :func:`no_post_init` context.
 
     JAX dataclass containers like ``Table`` and ``Buffered`` validate
-    invariants (unique keys, matching dimensions, …) in ``__post_init__``.
-    During deserialization or lens-based structural updates the intermediate
-    objects may temporarily violate those invariants, so validation is
-    suppressed via the :func:`no_post_init` context manager.  Decorate a
-    ``__post_init__`` with this function to opt into that suppression.
+    invariants (unique keys, matching dimensions, …) in ``__post_init__``;
+    this decorator opts a ``__post_init__`` into suppression. Validation is
+    skipped in three situations: placeholder unflattens (detected
+    automatically in ``_unflatten``), host-side re-validation of jitted
+    outputs (the :func:`jit` wrapper), and construction sites that build
+    temporarily inconsistent objects and wrap themselves in
+    :func:`no_post_init`.
     """
 
     def wrapper(self: object, *args: Any, **kwargs: Any):

--- a/test/core/test_jax_utils.py
+++ b/test/core/test_jax_utils.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
 
+from kups.core.data.table import Table
 from kups.core.utils.jax import (
     NotJaxCompatibleError,
     dataclass,
@@ -678,3 +679,66 @@ class TestSkipIfDisabled:
         # Restored after context
         with pytest.raises(ValueError, match="non-negative"):
             Validated(x=-1)
+
+
+@dataclass
+class _Strict:
+    values: jax.Array
+
+    @skip_post_init_if_disabled
+    def __post_init__(self) -> None:
+        assert isinstance(self.values, jax.Array) or hasattr(self.values, "dtype")
+        assert self.values.ndim == 1, "values must be 1-D"
+
+
+@dataclass
+class _StrictOuter:
+    inner: _Strict
+
+    @skip_post_init_if_disabled
+    def __post_init__(self) -> None:
+        assert self.inner.values.ndim == 1, "inner values must be 1-D"
+
+
+class TestPlaceholderUnflatten:
+    """Unflatten skips validation for placeholder payloads, never for real data.
+
+    jax's pytree contract allows unflattening with placeholder leaves
+    (``device_put``/``shard_map`` sentinel round-trips, flax.nnx ``None``
+    erasure); the detection lives in the dataclass ``_unflatten`` itself so no
+    caller has to know which library round-trips with dummies.
+    """
+
+    def test_object_sentinels_skip_validation(self):
+        _, treedef = jax.tree.flatten(_Strict(jnp.arange(3.0)))
+        rebuilt = jax.tree.unflatten(treedef, [object()])
+        assert not isinstance(rebuilt.values, jax.Array)
+
+    def test_none_erasure_skips_validation(self):
+        _, treedef = jax.tree.flatten(_Strict(jnp.arange(3.0)))
+        rebuilt = jax.tree.unflatten(treedef, [None])
+        assert rebuilt.values is None
+
+    def test_real_leaves_still_validate(self):
+        _, treedef = jax.tree.flatten(_Strict(jnp.arange(3.0)))
+        with pytest.raises(AssertionError, match="1-D"):
+            jax.tree.unflatten(treedef, [jnp.zeros((2, 2))])
+        ok = jax.tree.unflatten(treedef, [jnp.arange(5.0)])
+        assert ok.values.shape == (5,)
+
+    def test_nested_placeholders_skip_outer_validation(self):
+        # Placeholder-ness must be seen through sub-nodes: the outer node's
+        # direct child is a real ``_Strict`` instance whose leaves are dummies.
+        _, treedef = jax.tree.flatten(_StrictOuter(_Strict(jnp.arange(3.0))))
+        rebuilt = jax.tree.unflatten(treedef, [object()])
+        assert not isinstance(rebuilt.inner.values, jax.Array)
+
+    def test_table_sentinel_roundtrip(self):
+        # The real-world case: jax<=0.7 device_put round-trips pytrees through
+        # a sentinel unflatten before moving the actual arrays.
+        table = Table((0, 1, 2), jnp.arange(3.0))
+        leaves, treedef = jax.tree.flatten(table)
+        rebuilt = jax.tree.unflatten(treedef, [object()] * len(leaves))
+        assert rebuilt.keys == table.keys
+        restored = jax.tree.unflatten(treedef, leaves)
+        npt.assert_array_equal(restored.data, table.data)


### PR DESCRIPTION
jax's pytree contract allows unflattening with placeholder leaves
(device_put/shard_map sentinel round-trips, flax.nnx None erasure, string
name trees); until now every such boundary needed its own no_post_init
wrapper. The dataclass _unflatten now skips validation exactly when the
payload is not traceable data (a leaf without shape/dtype, or erasure of
every dynamic leaf); real-leaf unflattens validate as before.

no_post_init keeps its two deliberate uses (documented on
skip_post_init_if_disabled): the jit wrapper's validate-in-trace policy,
and construction of temporarily inconsistent objects. storage._names_tree
is subsumed; the estimate() wrapper moves into Table.__iter__'s row
slicing, which it was compensating for; Table.subset and
BaseFrame.vectors_gradient stay. Each verified in both directions.
