### PR TITLE
refactor: route custom-primitive vma handling through one shim module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ conflicts = [[{ extra = "uma" }, { extra = "mace" }]]
 JAX_ENABLE_X64 = "True"
 JAX_PLATFORMS = { value = "cpu", "skip_if_set" = true }
 JAX_DISABLE_MOST_OPTIMIZATIONS = { value = "True", "skip_if_set" = true }
+XLA_FLAGS = { value = "--xla_force_host_platform_device_count=4", "skip_if_set" = true }
 
 [tool.pytest.ini_options]
 addopts = "-n auto --durations=10 --dist loadfile -v --color=yes --cov=kups"

--- a/src/kups/core/assertion.py
+++ b/src/kups/core/assertion.py
@@ -22,7 +22,7 @@ import traceback
 import typing
 from collections.abc import Callable
 from functools import partial
-from typing import Any, Final, Self, no_type_check, override
+from typing import Any, Final, Self, override
 
 import jax
 import jax.interpreters.partial_eval as pe
@@ -217,14 +217,10 @@ def _make_noop_primitive(name: str) -> Primitive:
     return primitive
 
 
-@no_type_check
 def _scalar_bool(x: ShapedArray) -> ShapedArray:
-    # JAX 0.10 renamed the ShapeDtypeStruct kwarg ``vma`` → ``manual_axis_type``.
-    mat = getattr(x, "manual_axis_type", getattr(x, "vma", None))
-    try:
-        return ShapedArray((), jnp.bool, sharding=x.sharding, manual_axis_type=mat)
-    except TypeError:
-        return ShapedArray((), jnp.bool, sharding=x.sharding, vma=mat)
+    # No vma copy needed: operand vma flows through the paired noop
+    # primitive's pass-through avals.
+    return ShapedArray((), jnp.bool, sharding=x.sharding)
 
 
 def _make_constant_primitive(name: str) -> Primitive:

--- a/src/kups/core/utils/segment.py
+++ b/src/kups/core/utils/segment.py
@@ -24,6 +24,8 @@ from jax.extend.mlir.dialects import stablehlo
 from jax.interpreters import ad, batching, mlir, xla
 from jax.typing import ArrayLike, DTypeLike
 
+from kups.core.utils.vma import insert_pvary, out_aval
+
 type Zero = ad.Zero
 type Undefined = ad.UndefinedPrimal
 type Mode = jax.lax.GatherScatterMode
@@ -225,8 +227,9 @@ def _segment_sum_abstract_eval(
     data: ShapedArray, segment_ids: ShapedArray, *, num_segments: int
 ) -> ShapedArray:
     """Bins of `data`'s dtype; the wide accumulator never reaches an aval."""
-    del segment_ids
-    return ShapedArray((num_segments, *data.shape[1:]), data.dtype)
+    return out_aval(
+        "kups_segment_sum", (num_segments, *data.shape[1:]), data, segment_ids
+    )
 
 
 @segment_take_p.def_abstract_eval
@@ -234,7 +237,27 @@ def _segment_take_abstract_eval(
     data: ShapedArray, segment_ids: ShapedArray
 ) -> ShapedArray:
     """One gathered row per id."""
-    return ShapedArray((*segment_ids.shape, *data.shape[1:]), data.dtype)
+    return out_aval(
+        "kups_segment_take", (*segment_ids.shape, *data.shape[1:]), data, segment_ids
+    )
+
+
+def _bind_segment_sum(data: Array, segment_ids: Array, num_segments: int) -> Array:
+    """Bind the sum with the operands' varying manual axes unified.
+
+    ``insert_pvary`` broadcasts each operand to the union of the varying axes,
+    so the abstract eval sees consistent inputs; its transpose is the matching
+    mesh reduction, which keeps cotangent types aligned with the original
+    operands. A no-op outside ``shard_map`` or with ``check_vma=False``.
+    """
+    data, segment_ids = insert_pvary(data, segment_ids)
+    return segment_sum_p.bind(data, segment_ids, num_segments=num_segments)
+
+
+def _bind_segment_take(data: Array, segment_ids: Array) -> Array:
+    """Bind the gather with the operands' varying manual axes unified (see ``_bind_segment_sum``)."""
+    data, segment_ids = insert_pvary(data, segment_ids)
+    return segment_take_p.bind(data, segment_ids)
 
 
 segment_sum_p.def_impl(partial(xla.apply_primitive, segment_sum_p))
@@ -318,7 +341,7 @@ def _segment_sum_jvp(
         Tangent of the bin sums.
     """
     del data
-    return segment_sum_p.bind(tangent, segment_ids, num_segments=num_segments)
+    return _bind_segment_sum(tangent, segment_ids, num_segments=num_segments)
 
 
 def _segment_sum_transpose(
@@ -344,7 +367,7 @@ def _segment_sum_transpose(
         return [None, None]
     if isinstance(cotangent, ad.Zero):
         return [ad.Zero(data.aval), None]
-    return [segment_take_p.bind(cotangent, segment_ids), None]
+    return [_bind_segment_take(cotangent, segment_ids), None]
 
 
 def _segment_take_jvp(tangent: Array, data: Array, segment_ids: Array) -> Array:
@@ -359,7 +382,7 @@ def _segment_take_jvp(tangent: Array, data: Array, segment_ids: Array) -> Array:
         Tangent of the gathered rows.
     """
     del data
-    return segment_take_p.bind(tangent, segment_ids)
+    return _bind_segment_take(tangent, segment_ids)
 
 
 def _segment_take_transpose(
@@ -380,7 +403,7 @@ def _segment_take_transpose(
     if isinstance(cotangent, ad.Zero):
         return [ad.Zero(data.aval), None]
     return [
-        segment_sum_p.bind(cotangent, segment_ids, num_segments=data.aval.shape[0]),
+        _bind_segment_sum(cotangent, segment_ids, num_segments=data.aval.shape[0]),
         None,
     ]
 
@@ -406,12 +429,12 @@ def _segment_sum_batcher(
     if ids_dim is None:
         assert data_dim is not None
         data = jnp.moveaxis(data, data_dim, data.ndim - 1)
-        out = segment_sum_p.bind(data, segment_ids, num_segments=num_segments)
+        out = _bind_segment_sum(data, segment_ids, num_segments=num_segments)
         return out, out.ndim - 1
     flat_data, flat_ids, size, features = _flatten_batch(
         data, segment_ids, data_dim, ids_dim, num_segments
     )
-    out = segment_sum_p.bind(flat_data, flat_ids, num_segments=size * num_segments)
+    out = _bind_segment_sum(flat_data, flat_ids, num_segments=size * num_segments)
     return out.reshape(size, num_segments, *features), 0
 
 
@@ -432,18 +455,18 @@ def _segment_take_batcher(
     if ids_dim is None:
         assert data_dim is not None
         data = jnp.moveaxis(data, data_dim, data.ndim - 1)
-        out = segment_take_p.bind(data, segment_ids)
+        out = _bind_segment_take(data, segment_ids)
         return out, out.ndim - 1
     if data_dim is None:
         size = segment_ids.shape[ids_dim]
         ids = batching.bdim_at_front(segment_ids, ids_dim, size)
-        out = segment_take_p.bind(data, ids.reshape(-1))
+        out = _bind_segment_take(data, ids.reshape(-1))
         return out.reshape(size, ids.shape[1], *data.shape[1:]), 0
     rows = data.shape[1] if data_dim == 0 else data.shape[0]
     flat_data, flat_ids, size, features = _flatten_batch(
         data, segment_ids, data_dim, ids_dim, rows
     )
-    out = segment_take_p.bind(flat_data, flat_ids)
+    out = _bind_segment_take(flat_data, flat_ids)
     return out.reshape(size, flat_ids.shape[0] // size, *features), 0
 
 
@@ -531,7 +554,7 @@ def segment_sum(
         segment_ids = segment_ids.reshape(-1)
     if data.shape[0] == 0 or not jnp.issubdtype(data.dtype, jnp.inexact):
         return jax.ops.segment_sum(data, segment_ids, num_segments, mode="drop")
-    return segment_sum_p.bind(data, segment_ids, num_segments=num_segments)
+    return _bind_segment_sum(data, segment_ids, num_segments=num_segments)
 
 
 def segment_take(
@@ -608,7 +631,7 @@ def segment_take(
     if data.shape[0] == 0 or not jnp.issubdtype(data.dtype, jnp.inexact):
         rows = _gather(data, segment_ids)
     else:
-        flat = segment_take_p.bind(data, segment_ids.reshape(-1))
+        flat = _bind_segment_take(data, segment_ids.reshape(-1))
         rows = flat.reshape(*segment_ids.shape, *data.shape[1:])
     # Clamped ids leave nothing out of range, so only the default mode fills.
     if clipped or (known_fill is not None and not known_fill.any()):

--- a/src/kups/core/utils/vma.py
+++ b/src/kups/core/utils/vma.py
@@ -1,0 +1,63 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Varying-manual-axes (vma) plumbing for kUPS' custom primitives.
+
+Under ``shard_map(..., check_vma=True)`` every abstract value tracks which
+manual mesh axes it varies over; an output aval that dropped them would type
+the value as replicated, and the transpose's cotangent would then mismatch a
+varying primal. jax has no public registry for custom primitives' vma rules
+(jax-ml/jax#24726 tracks a public primitive API), so the segment sum/take
+primitives route their vma handling through this module, the single place
+that touches the jax-internal helpers.
+
+Version knowledge lives here and nowhere else: ``aval.vma`` (jax 0.7) became
+``aval.manual_axis_type.varying`` (jax 0.8+), and ``standard_insert_pvary``
+became ``auto_insert_reshard`` (jax 0.11). A future rename fails loudly on
+the attribute lookup below.
+"""
+
+from typing import Any
+
+from jax._src import core as jax_core
+from jax.core import ShapedArray
+
+insert_pvary: Any = getattr(
+    jax_core,
+    "standard_insert_pvary",  # jax <= 0.10
+    getattr(jax_core, "auto_insert_reshard", None),  # jax >= 0.11
+)
+"""Broadcast operands to the union of their varying manual axes.
+
+Bind wrappers call this on their operands so the standard vma rule sees
+consistent inputs; its transpose is the matching mesh reduction, which keeps
+cotangent types aligned with the original operands. A no-op outside
+``shard_map`` or with ``check_vma=False``.
+"""
+assert insert_pvary is not None, "jax exposes no vma operand-unifying helper"
+
+
+def out_aval(
+    name: str, shape: tuple[Any, ...], data: ShapedArray, *operands: Any
+) -> ShapedArray:
+    """Output aval of ``shape`` and ``data``'s dtype carrying the operands' vma.
+
+    The vma set is the standard unification of ``data`` and ``operands``
+    (empty outside a manual region, where a plain aval is returned). The
+    varying case derives the aval from ``data`` via ``update`` so its (manual)
+    sharding carries over — valid only rank-preservingly, which the callers
+    guarantee and the assert pins.
+    """
+    vma = jax_core.standard_vma_rule(name, data, *operands)
+    if not vma:
+        return ShapedArray(shape, data.dtype)
+    assert len(shape) == data.ndim, (shape, data.shape)
+    mat = getattr(data, "manual_axis_type", None)
+    if mat is None:  # jax 0.7
+        return data.update(shape=shape, weak_type=False, vma=vma)
+    return data.update(
+        shape=shape, weak_type=False, manual_axis_type=mat.update(varying=vma)
+    )
+
+
+__all__ = ["insert_pvary", "out_aval"]

--- a/test/core/test_vma.py
+++ b/test/core/test_vma.py
@@ -1,0 +1,94 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gates for the vma shim: custom-primitive avals keep their varying manual axes.
+
+Without the shim an output aval would drop its axes, be typed as replicated,
+and ``shard_map(check_vma=True)`` would reject the program (or the transpose's
+cotangent would mismatch a varying primal). Runs on the simulated 4-device CPU
+mesh from the pytest ``XLA_FLAGS`` env.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from kups.core.assertion import runtime_assert
+from kups.core.result import as_result_function
+from kups.core.utils.segment import segment_sum
+from kups.core.utils.vma import out_aval
+
+_VARYING = jax.sharding.PartitionSpec("X")
+_REPL = jax.sharding.PartitionSpec()
+
+
+def _mesh() -> jax.sharding.Mesh:
+    return jax.sharding.Mesh(np.array(jax.devices()), axis_names=("X",))
+
+
+def test_out_aval_is_plain_outside_manual_region() -> None:
+    data = jax.core.ShapedArray((6, 3), jnp.float64)
+    ids = jax.core.ShapedArray((6,), jnp.int32)
+    out = out_aval("test_prim", (4, 3), data, ids)
+    assert out.shape == (4, 3) and out.dtype == data.dtype
+
+
+def test_segment_sum_grad_under_shard_map() -> None:
+    """Without the vma rules the segment output avals are typed replicated and
+    differentiating through ``shard_map`` raises a cotangent-type mismatch —
+    the failure the domain-decomposed potentials hit."""
+    if len(jax.devices()) < 2:
+        pytest.skip("needs a multi-device mesh")
+    ids = jnp.array([0, 1, 0, 1])
+
+    def per_device(x: jax.Array) -> jax.Array:
+        return jax.lax.psum(segment_sum(x * x, ids, num_segments=2).sum(), "X")
+
+    f = jax.shard_map(per_device, mesh=_mesh(), in_specs=(_VARYING,), out_specs=_REPL)
+    x = jnp.arange(float(4 * len(jax.devices())))
+    total, grad = jax.value_and_grad(f)(x)
+    npt.assert_allclose(total, (x * x).sum())
+    npt.assert_allclose(grad, 2 * x)
+
+
+def test_assertion_primitive_keeps_vma_under_shard_map() -> None:
+    if len(jax.devices()) < 2:
+        pytest.skip("needs a multi-device mesh")
+
+    def per_device(x: jax.Array) -> jax.Array:
+        # Assertion values must be device-invariant to leave the manual
+        # region through the replicated assertion context, so mesh-reduce.
+        bound = jax.lax.pmax(x.max(), "X")
+        runtime_assert(
+            bound < 100.0, "x must stay below 100, got {bound}", {"bound": bound}
+        )
+        return jax.lax.psum(x.sum(), "X")
+
+    f = jax.shard_map(per_device, mesh=_mesh(), in_specs=(_VARYING,), out_specs=_REPL)
+    result = as_result_function(f)(jnp.arange(8.0))
+    result.raise_assertion()
+    assert len(result.assertions) == 1
+    assert jnp.allclose(result.value, jnp.arange(8.0).sum())
+
+
+def test_varying_assertion_is_rejected_by_replicated_context() -> None:
+    """A device-varying assertion value must not silently leave the manual region.
+
+    Pins the contract the domain-decomposition capacities rely on: a
+    per-device predicate is typed varying and rejected at trace time, instead
+    of one device's verdict standing in for the mesh — enforced by the noop
+    primitive's pass-through avals, which is why ``_scalar_bool`` needs no
+    vma copy of its own.
+    """
+    if len(jax.devices()) < 2:
+        pytest.skip("needs a multi-device mesh")
+
+    def per_device(x: jax.Array) -> jax.Array:
+        runtime_assert(x.max() < 100.0, "per-device bound {m}", {"m": x.max()})
+        return jax.lax.psum(x.sum(), "X")
+
+    f = jax.shard_map(per_device, mesh=_mesh(), in_specs=(_VARYING,), out_specs=_REPL)
+    with pytest.raises(Exception, match="vary|replicat"):
+        as_result_function(f)(jnp.arange(8.0))


### PR DESCRIPTION
shard_map(check_vma=True) tracks varying manual axes on every aval, and
jax has no public registry for custom primitives' vma rules
(jax-ml/jax#24726). core/utils/vma.py (insert_pvary, out_aval) is now the
single place touching the jax internals: the segment primitives get their
vma rules here, so differentiating them under shard_map produces
correctly-typed cotangents. Version knowledge lives only in the shim —
aval.vma (0.7) vs manual_axis_type.varying (0.8+), standard_insert_pvary
(<=0.10) vs auto_insert_reshard (>=0.11) — each branch tested on its jax.

The assertion primitives need no vma handling: the noop's abstract eval
passes input avals through unchanged. _scalar_bool's manual vma copy is
deleted (sabotage-verified unobserved on jax 0.7.2 and 0.10), leaving a
plain sharding-preserving scalar aval.

Gates on the 4-device CPU mesh: grad through a shard-mapped segment_sum
matches the closed form, and a device-varying assertion value is rejected
at trace time; out_aval and insert_pvary are sabotage-verified.
