### PR TITLE
refactor: Replace `IsBlockingSpheresProbe.neighborlist` with `particles` and pass probe through blocking-sphere propagators

### DIFF
--- a/src/kups/application/potential/classical/blocking.py
+++ b/src/kups/application/potential/classical/blocking.py
@@ -114,8 +114,8 @@ def make_blocking_spheres_from_state(
         state: Lens into the sub-state providing particles, groups, systems, and
             neighbor list (plus ``blocking_spheres_parameters`` when
             ``parameters`` is not given).
-        probe: Probe returning a IsBlockingSpheresProbe; ``None`` for full
-            recomputation.
+        probe: Probe returning a IsBlockingSpheresProbe; ``None`` evaluates a
+            patched state over every particle.
         parameters: Constant blocking sphere parameters. When given they are
             bound with a constant lens and the state need not carry
             ``blocking_spheres_parameters``.

--- a/src/kups/application/simulations/mcmc_rigid.py
+++ b/src/kups/application/simulations/mcmc_rigid.py
@@ -363,7 +363,7 @@ def make_propagator(
         logging.info("Charged particles detected: including Ewald potential.")
     # If we have any blocking spheres, we include the blocking spheres potential
     if state.has_blocking_spheres:
-        potentials.append(make_blocking_spheres_from_state(state_lens))
+        potentials.append(make_blocking_spheres_from_state(state_lens, _probe))
         logging.info("Blocking spheres detected: including blocking spheres potential.")
     potential = sum_potentials(*potentials)
     potential, probability_ratio = make_muvt_probability_ratio(state_lens, potential)

--- a/src/kups/application/simulations/mcmc_widom.py
+++ b/src/kups/application/simulations/mcmc_widom.py
@@ -308,7 +308,7 @@ def make_propagator(
             make_ewald_from_state(state_lens, _probe, include_exclusion_mask=True)
         )
     if state.has_blocking_spheres:
-        potentials.append(make_blocking_spheres_from_state(state_lens))
+        potentials.append(make_blocking_spheres_from_state(state_lens, _probe))
     potential = sum_potentials(*potentials)
     cached_potential, muvt_ratio = make_muvt_probability_ratio(state_lens, potential)
     boltzmann_ratio = muvt_ratio.boltzmann_log_likelihood_ratio

--- a/src/kups/potential/classical/blocking.py
+++ b/src/kups/potential/classical/blocking.py
@@ -27,7 +27,7 @@ import jax.numpy as jnp
 from jax import Array
 
 from kups.core.cell import AnyPeriodicity, Cell
-from kups.core.data import Index, Table
+from kups.core.data import Index, Table, WithIndices
 from kups.core.lens import Lens, View
 from kups.core.neighborlist import (
     Edges,
@@ -148,14 +148,12 @@ type BlockingSpheresNeighborListFactory = Callable[
 class IsBlockingSpheresProbe(Protocol):
     """Probe result for blocking spheres incremental updates.
 
-    Bundles changed particle indices with the updated neighbor list,
-    enabling efficient re-evaluation when only a subset of particles move.
+    Exposes the particles a patch touches, so the sphere query can be
+    restricted to them instead of sweeping the whole configuration.
     """
 
     @property
-    def changed_particle_idx(self) -> Array: ...
-    @property
-    def neighborlist(self) -> NeighborList[Literal[2]]: ...
+    def particles(self) -> WithIndices[ParticleId, _BlockingParticles]: ...
 
 
 @dataclass
@@ -224,7 +222,8 @@ class BlockingSpheresSumComposer[State, Ptch: Patch[Any]](
         systems_view: Extracts indexed systems from state
         parameters_view: Extracts blocking sphere parameters from state
         neighborlist_view: Extracts a factory that binds cutoffs to a neighbor list
-        probe: Probe providing a IsBlockingSpheresProbe
+        probe: Probe providing a IsBlockingSpheresProbe; without it a patched
+            state is evaluated over every particle
     """
 
     particles_view: View[State, Table[ParticleId, _BlockingParticles]] = field(
@@ -243,31 +242,36 @@ class BlockingSpheresSumComposer[State, Ptch: Patch[Any]](
     def __call__(
         self, state: State, patch: Ptch | None
     ) -> Sum[BlockingSpheresPotentialInput]:  # type: ignore[reportReturnType]
+        changed: Index[ParticleId] | None = None
+        if patch is not None:
+            # The patch is always applied; a probe only narrows the sphere query
+            # to the particles it touches, otherwise everything is re-evaluated.
+            if self.probe is not None:
+                changed = self.probe(state, patch).particles.indices
+            systems = self.systems_view(state)
+            state = patch(
+                state, systems.set_data(jnp.ones(len(systems), dtype=jnp.bool_))
+            )
+
         particles = self.particles_view(state)
+        if changed is not None:
+            particles = Table.arange(particles[changed], label=ParticleId)
+            queried = particles.data.group.valid_mask & changed.valid_mask
+        else:
+            queried = particles.data.group.valid_mask
         systems = self.systems_view(state)
         parameters = self.parameters_view(state)
         neighborlist_factory = self.neighborlist_view(state)
-        probe_neighborlist = None
-
-        if patch is not None and self.probe is not None:
-            n_sys = particles.data.system.num_labels
-            patched_state = patch(
-                state, systems.set_data(jnp.ones((n_sys,), dtype=jnp.bool_))
-            )
-            probe_result = self.probe(state, patch)
-            probe_neighborlist = probe_result.neighborlist
-            particles = self.particles_view(patched_state)
 
         # Build cutoffs: remap sphere system indices into systems index space
         seg_ids = parameters.system.indices_in(tuple(systems.keys))
         max_radii = jax.ops.segment_max(parameters.radii, seg_ids, len(systems.keys))
         cutoffs = Table(systems.keys, max_radii)
 
-        # NNList particles
         nnlist_particles = particles.map_data(
             lambda p: _BlockingSpherePoints(
                 positions=p.positions,
-                system=(sys := p.system.apply_mask(p.group.valid_mask)),
+                system=(sys := p.system.apply_mask(queried)),
                 inclusion=sys.to_cls(InclusionId),
                 exclusion=Index.arange(len(sys), label=ExclusionId),
             )
@@ -289,7 +293,7 @@ class BlockingSpheresSumComposer[State, Ptch: Patch[Any]](
             label=ParticleId,
         )
 
-        neighborlist = probe_neighborlist or neighborlist_factory(cutoffs)
+        neighborlist = neighborlist_factory(cutoffs)
         edges = neighborlist(nnlist_particles, systems, queries=spheres)
         cell = systems.map_data(lambda s: s.cell)
         groups = self.groups_view(state)
@@ -324,7 +328,8 @@ def make_blocking_spheres_potential[State, Gradients, Hessians, Ptch: Patch[Any]
         systems_view: Extracts indexed systems from state
         parameters_view: Extracts blocking sphere parameters (positions, radii)
         neighborlist_view: Extracts a factory that binds cutoffs to a neighbor list
-        probe: Probe returning a IsBlockingSpheresProbe; ``None`` for full recomputation
+        probe: Probe returning a IsBlockingSpheresProbe; ``None`` evaluates a
+            patched state over every particle
         gradient_lens: Specifies gradients to compute
         hessian_lens: Specifies Hessians to compute
         hessian_idx_view: Hessian index structure

--- a/test/application/test_mcmc_rigid.py
+++ b/test/application/test_mcmc_rigid.py
@@ -21,6 +21,9 @@ from kups.application.mcmc.data import (
     MotifParticles,
     RunConfig,
 )
+from kups.application.potential.classical.blocking import (
+    make_blocking_spheres_from_state,
+)
 from kups.application.potential.classical.ewald import make_ewald_from_state
 from kups.application.potential.classical.lennard_jones import (
     make_lennard_jones_from_state,
@@ -687,6 +690,64 @@ def test_reinsertion_onto_colliding_particle_matches_full(state: MCMCState):
     e_full = pot(new_state).data.total_energies.data
     assert float(e_full[0]) > 1.0, "reinserted molecule must contact particle 0"
     npt.assert_allclose(out.data.total_energies.data, e_full, rtol=1e-6, atol=1e-6)
+
+
+class TestBlockingSpheresPatch:
+    """A proposed move must be evaluated against the blocking spheres.
+
+    ``movement_update_pid0`` moves particle 0 from ``[2, 2, 2]`` onto the sphere
+    centre, so the patched configuration is blocked while the current one is not.
+    """
+
+    @staticmethod
+    def _with_sphere(state: MCMCState) -> MCMCState:
+        return bind(state, lambda x: x.blocking_spheres_parameters).set(
+            BlockingSpheresParameters(
+                radii=jnp.array([1.0]),
+                positions=jnp.array([[3.0, 3.0, 3.0]]),
+                system=Index.new([SystemId(0)]).populate_max_count(),
+                motif=Index.new([MotifId(0)]).populate_max_count(),
+            )
+        )
+
+    def test_probed_move_into_sphere_is_blocked(
+        self, state: MCMCState, movement_update_pid0: MCMCStateUpdate
+    ):
+        pot = make_blocking_spheres_from_state(identity_lens(MCMCState), _probe)
+        blocked = self._with_sphere(state)
+        assert pot(blocked).data.total_energies.data[0] == 0.0
+        assert jnp.isinf(pot(blocked, movement_update_pid0).data.total_energies.data[0])
+
+    def test_probed_move_outside_sphere_is_free(
+        self,
+        state: MCMCState,
+        movement_update_newpos: tuple[MCMCStateUpdate, jax.Array],
+    ):
+        pot = make_blocking_spheres_from_state(identity_lens(MCMCState), _probe)
+        update, _ = movement_update_newpos
+        assert pot(self._with_sphere(state), update).data.total_energies.data[0] == 0.0
+
+    def test_probe_narrows_the_query(
+        self, state: MCMCState, movement_update_pid0: MCMCStateUpdate
+    ):
+        """The probed plan carries only the moved particle, not the whole table."""
+        blocked = self._with_sphere(state)
+        sl = identity_lens(MCMCState)
+        ((probed, _),) = make_blocking_spheres_from_state(sl, _probe).composer(
+            blocked, movement_update_pid0
+        )
+        ((full, _),) = make_blocking_spheres_from_state(sl).composer(
+            blocked, movement_update_pid0
+        )
+        assert len(probed.particles) == 1
+        assert len(full.particles) == len(state.particles)
+
+    def test_unprobed_move_into_sphere_is_blocked(
+        self, state: MCMCState, movement_update_pid0: MCMCStateUpdate
+    ):
+        pot = make_blocking_spheres_from_state(identity_lens(MCMCState))
+        blocked = self._with_sphere(state)
+        assert jnp.isinf(pot(blocked, movement_update_pid0).data.total_energies.data[0])
 
 
 class TestRunNVT:


### PR DESCRIPTION
The blocking spheres potential previously relied on a probe-supplied neighbor list for incremental updates. This approach is replaced so that the probe is now used solely to identify which particles a patch touches, narrowing the sphere query to only those particles rather than sweeping the full configuration. When no probe is provided, the patched state is evaluated over every particle as before.

The `IsBlockingSpheresProbe` protocol is updated to expose a `particles` property (a `WithIndices`-wrapped table) instead of separate `changed_particle_idx` and `neighborlist` properties. The neighbor list is now always constructed from the cutoff factory rather than being sourced from the probe result.

`BlockingSpheresSumComposer.__call__` is restructured so the patch is applied unconditionally when present, and the probe is consulted only to restrict the set of queried particles. The `queried` mask is derived from the probe-narrowed particle set when a probe is available, or from the full valid mask otherwise.

Both `mcmc_rigid` and `mcmc_widom` propagator factories are updated to pass the probe through to `make_blocking_spheres_from_state`, enabling the narrowed evaluation path in those simulations.

Tests are added covering probed and unprobed moves into and outside a blocking sphere, and asserting that the probed path carries only the moved particle while the unprobed path carries the full particle table.