### PR TITLE
fix: Drop non-finite Kahan compensation to preserve infinite sums instead of producing NaN

### DIFF
--- a/src/kups/core/utils/jax.py
+++ b/src/kups/core/utils/jax.py
@@ -909,6 +909,27 @@ def isin(a: Array, b: Array, max_item: int) -> Array:
     )
 
 
+def drop_nonfinite_compensation[T](compensate: T) -> T:
+    """Zero the compensation terms that are not finite.
+
+    Once a running sum reaches an infinity the compensation update yields NaN or
+    an infinity, which would poison later additions. Exact dtypes pass through.
+
+    Args:
+        compensate: Compensation PyTree from a compensated-summation step.
+
+    Returns:
+        The compensation with every non-finite entry replaced by zero.
+    """
+
+    def drop(c: Any) -> Any:
+        if not jnp.issubdtype(jnp.result_type(c), jnp.inexact):
+            return c
+        return jnp.where(jnp.isfinite(c), c, jnp.zeros_like(c))
+
+    return tree_map(drop, compensate)
+
+
 def kahan_summation[T](*summands: T, compensate: T | None = None) -> tuple[T, T]:
     """Numerically stable summation using Kahan's compensated algorithm.
 
@@ -918,6 +939,9 @@ def kahan_summation[T](*summands: T, compensate: T | None = None) -> tuple[T, T]
 
     The algorithm maintains an error compensation term that captures lost
     precision, significantly reducing numerical drift in iterative computations.
+
+    A step whose compensation is not finite drops it, so an infinite sum stays
+    infinite instead of becoming NaN.
 
     Args:
         *summands: One or more PyTrees to sum together.
@@ -954,7 +978,7 @@ def kahan_summation[T](*summands: T, compensate: T | None = None) -> tuple[T, T]
     for summand in summands[1:]:
         y = sub(summand, compensate)
         t = add(result, y)
-        compensate = sub(sub(t, result), y)
+        compensate = drop_nonfinite_compensation(sub(sub(t, result), y))
         result = t
     return result, compensate
 

--- a/src/kups/core/utils/kahan.py
+++ b/src/kups/core/utils/kahan.py
@@ -15,7 +15,11 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.utils.jax import dataclass, kahan_summation
+from kups.core.utils.jax import (
+    dataclass,
+    drop_nonfinite_compensation,
+    kahan_summation,
+)
 
 
 @dataclass
@@ -30,10 +34,13 @@ class KahanSummand[T]:
     Values may be arbitrary PyTrees, mirroring
     [kahan_summation][kups.core.utils.jax.kahan_summation].
 
+    An infinite value carries a zero compensation, so an infinite total stays
+    infinite rather than becoming NaN.
+
     Attributes:
         value: Current running sum as a PyTree.
         compensate: Accumulated rounding error; the best estimate of the true
-            sum is ``value - compensate``.
+            sum is ``value - compensate``; zero where `value` is not finite.
 
     Example:
         ```python
@@ -125,7 +132,7 @@ class KahanSummand[T]:
             other.compensate,
             jax.tree.map(excess, value, self.value, other.value),
         )
-        return KahanSummand(value, compensate)
+        return KahanSummand(value, drop_nonfinite_compensation(compensate))
 
     def __radd__(self, other: KahanSummand[T] | T) -> KahanSummand[T]:
         """Accumulate from the left so `sum` and `other + summand` work.

--- a/test/core/test_kahan.py
+++ b/test/core/test_kahan.py
@@ -87,6 +87,18 @@ class TestKahanSummand:
         npt.assert_array_equal(s.total - big, 1.0)
         npt.assert_array_equal(naive - big, 0.0)
 
+    def test_infinite_value_keeps_infinite_total(self):
+        """An infinite addend leaves the total infinite instead of NaN."""
+        finite = KahanSummand.init(jnp.array(1.0)) + jnp.array(0.5)
+        blocked = finite + jnp.array(jnp.inf)
+        npt.assert_array_equal(blocked.compensate, 0.0)
+        npt.assert_array_equal(blocked.total, jnp.inf)
+        npt.assert_array_equal((blocked + jnp.array(-5.0)).total, jnp.inf)
+        npt.assert_array_equal(blocked.difference(finite), jnp.inf)
+        npt.assert_array_equal(finite.difference(blocked), -jnp.inf)
+        infinite = KahanSummand.init(jnp.array(jnp.inf))
+        npt.assert_array_equal((finite + infinite).total, jnp.inf)
+
     def test_total(self):
         """`total` reports the compensated sum for scalars and PyTrees."""
         s = KahanSummand(jnp.array(4.0), jnp.array(0.25))

--- a/test/mcmc/test_probability.py
+++ b/test/mcmc/test_probability.py
@@ -225,6 +225,32 @@ class TestNVTProbabilityRatio:
         )
         npt.assert_allclose(result.data.data, expected, rtol=1e-10)
 
+    def test_infinite_energy_is_certain_accept_or_reject(self):
+        """A blocked state (inf energy) escapes with certainty; entering rejects."""
+        blocked = MockState(
+            temperature=self.temperature,
+            last_potential_out=KahanSummand.init(
+                PotentialOut(
+                    total_energies=Table.arange(
+                        jnp.full(self.n_systems, jnp.inf), label=SystemId
+                    ),
+                    gradients=(),
+                    hessians=(),
+                )
+            ),
+        )
+        escape = BoltzmannLogProbabilityRatio(
+            temperature=self.temperature_view,
+            potential=self.create_mock_potential(self.old_energies),
+        )(blocked, self.test_patch)
+        npt.assert_array_equal(escape.data.data, jnp.inf)
+
+        enter = BoltzmannLogProbabilityRatio(
+            temperature=self.temperature_view,
+            potential=self.create_mock_potential(jnp.full(self.n_systems, jnp.inf)),
+        )(self.state, self.test_patch)
+        npt.assert_array_equal(enter.data.data, -jnp.inf)
+
     def test_temperature_dependence_exact(self):
         """Test exact temperature dependence of probability ratio."""
         energy_increase = 5.0


### PR DESCRIPTION
Fix Kahan compensated summation to preserve infinities instead of producing NaN

When a running sum reaches infinity, the compensation update `(sum + y) - sum - y` evaluates to NaN or infinity, which would poison all subsequent additions. This introduces `drop_nonfinite_compensation`, which zeroes out any non-finite compensation terms after each Kahan step, keeping the infinity in the running sum intact while preventing NaN propagation.

The fix is applied in both the low-level `kahan_summation` function and the `KahanSummand.__add__` path. As a result, an infinite energy contribution (e.g. from a blocking hard-sphere potential) correctly produces an infinite total energy and an infinite log-probability ratio, ensuring that moves into blocked states are always rejected and escapes from blocked states are always accepted.