### PR TITLE
feat: Add a source-neutral relaxation builder from particles and cell

### DIFF
--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -102,6 +102,94 @@ class RelaxRunConfig(BaseModel):
     """Whether to also relax lattice vectors."""
 
 
+def relax_state_from_particles_and_cell(
+    particles: Table[ParticleId, Particles],
+    cell: Cell[AnyPeriodicity],
+) -> tuple[Table[ParticleId, RelaxParticles], Table[SystemId, RelaxSystems]]:
+    """Build one-system relaxation data from source-neutral particles and a cell.
+
+    The supplied particles and cell must already describe the same system in the
+    same kUPS coordinate frame. This builder does not transform geometry; it adds
+    the system axis and an identity ``MatrixLogFrame`` deformation around the
+    input frame, preserving the input's initial physical cell vectors.
+
+    Args:
+        particles: Non-empty particle table for exactly one complete system.
+        cell: Unbatched cell with vectors of shape ``(3, 3)`` and an undeformed
+            outer frame (not a :class:`DeformedFrame`).
+
+    Returns:
+        Relaxation particle and system tables preserving the input particle keys
+        and referenced ``SystemId``.
+
+    Raises:
+        ValueError: If ``particles`` is empty, does not reference exactly one
+            system with one reference per particle selecting that system, if
+            ``cell.vectors`` is not shape ``(3, 3)``, or if ``cell.frame`` is a
+            :class:`DeformedFrame`.
+    """
+    p = particles.data
+    n_particles = len(particles)
+    if n_particles == 0:
+        raise ValueError("particles must contain at least one particle.")
+    if len(p.system.keys) != 1:
+        raise ValueError(
+            "particles must reference exactly one system; "
+            f"got {len(p.system.keys)} system keys."
+        )
+    if p.system.indices.shape != (n_particles,):
+        raise ValueError(
+            "particles must contain one system reference per particle; "
+            f"got shape {p.system.indices.shape} for {n_particles} particles."
+        )
+    if bool(jnp.any(p.system.indices != 0)):
+        raise ValueError(
+            "particles system references must all select the sole SystemId."
+        )
+    if cell.vectors.shape != (3, 3):
+        raise ValueError(
+            f"cell.vectors must have shape (3, 3); got {cell.vectors.shape}."
+        )
+    if isinstance(cell.frame, DeformedFrame):
+        raise ValueError(
+            "cell.frame must be an undeformed frame, not a DeformedFrame; "
+            "restart and rebasing semantics are out of scope."
+        )
+
+    relax_particles = particles.set_data(
+        RelaxParticles(
+            positions=p.positions,
+            masses=p.masses,
+            atomic_numbers=p.atomic_numbers,
+            charges=p.charges,
+            labels=p.labels,
+            system=p.system,
+            position_gradients=jnp.zeros_like(p.positions),
+        ),
+    )
+    # cell_factor = per-system atom count (ASE's exp_cell_factor) balances the
+    # extensive cell-virial gradient against the per-atom forces in the joint
+    # optimiser. bincount over the system index gives one count per system.
+    n_systems = p.system.num_labels
+    cell_factor = jnp.bincount(p.system.indices, length=n_systems).astype(
+        p.positions.dtype
+    )
+    deformed_cell = bind(cell[None], lambda x: x.frame).apply(
+        lambda f: DeformedFrame.from_frame(
+            f, cell_factor=cell_factor, deformation=MatrixLogFrame
+        )
+    )
+    systems = Table(
+        (p.system.keys[0],),
+        RelaxSystems(
+            cell=deformed_cell,
+            cell_gradients=tree_zeros_like(deformed_cell),
+            potential_energy=jnp.zeros(n_systems),
+        ),
+    )
+    return relax_particles, systems
+
+
 def relax_state_from_ase(
     atoms: ase.Atoms | str | Path,
 ) -> tuple[Table[ParticleId, RelaxParticles], Table[SystemId, RelaxSystems]]:
@@ -114,36 +202,5 @@ def relax_state_from_ase(
     Returns:
         Tuple of ``(particles, systems)`` ready for relaxation propagators.
     """
-    p, cell, _ = particles_from_ase(atoms)
-    particles = p.set_data(
-        RelaxParticles(
-            positions=p.data.positions,
-            masses=p.data.masses,
-            atomic_numbers=p.data.atomic_numbers,
-            charges=p.data.charges,
-            labels=p.data.labels,
-            system=p.data.system,
-            position_gradients=jnp.zeros_like(p.data.positions),
-        ),
-    )
-    # cell_factor = per-system atom count (ASE's exp_cell_factor) balances the
-    # extensive cell-virial gradient against the per-atom forces in the joint
-    # optimiser. bincount over the system index gives one count per system.
-    n_systems = p.data.system.num_labels
-    cell_factor = jnp.bincount(p.data.system.indices, length=n_systems).astype(
-        p.data.positions.dtype
-    )
-    cell = bind(cell[None], lambda x: x.frame).apply(
-        lambda f: DeformedFrame.from_frame(
-            f, cell_factor=cell_factor, deformation=MatrixLogFrame
-        )
-    )
-    systems = Table.arange(
-        RelaxSystems(
-            cell=cell,
-            cell_gradients=tree_zeros_like(cell),
-            potential_energy=jnp.zeros(n_systems),
-        ),
-        label=SystemId,
-    )
-    return particles, systems
+    particles, cell, _ = particles_from_ase(atoms)
+    return relax_state_from_particles_and_cell(particles, cell)

--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -63,9 +63,10 @@ class RelaxSystems:
     """Cell geometry, batched with shape (1,)."""
     cell_gradients: Cell[AnyPeriodicity]
     """Optimizer cell-DOF gradient ``∂E/∂u_cell`` (the relaxation filter's output),
-    stored on :attr:`cell`'s frame (the lower-triangular log-deformation entries
-    under ``cell_filter``). The ASE-fmax convergence quantity for the cell; the
-    atoms-ride-the-cell coupling is already folded in by the filter pullback."""
+    a matching-structure copy of :attr:`cell` (wrapper, periodicity, and frame
+    leaves, including the ``MatrixLogFrame`` deformation). The ASE-fmax cell
+    quantity; the atoms-ride-the-cell coupling is already folded in by the
+    filter pullback."""
     potential_energy: Array
     """Potential energy per system, shape (1,)."""
 

--- a/test/application/relaxation/__init__.py
+++ b/test/application/relaxation/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0

--- a/test/application/relaxation/test_relaxation_data.py
+++ b/test/application/relaxation/test_relaxation_data.py
@@ -1,0 +1,554 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for kups.application.relaxation.data source-neutral builder."""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import ase
+import ase.io
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import kups.application.relaxation.data as relax_data
+from kups.application.relaxation.data import (
+    RelaxParticles,
+    RelaxSystems,
+    relax_state_from_ase,
+    relax_state_from_particles_and_cell,
+)
+from kups.application.utils.particles import Particles, particles_from_arrays
+from kups.core.cell import (
+    AnyPeriodicity,
+    Cell,
+    DeformedFrame,
+    LogTriclinicFrame,
+    MatrixLogFrame,
+    OrthogonalFrame,
+    TriclinicFrame,
+)
+from kups.core.data import Index, Table
+from kups.core.typing import ExclusionId, Label, ParticleId, SystemId
+
+
+def _cell() -> Cell[AnyPeriodicity]:
+    """Return an unbatched skewed triclinic test cell."""
+    return Cell.from_pbc(
+        TriclinicFrame.from_matrix(
+            jnp.array(
+                [
+                    [4.0, 0.0, 0.0],
+                    [0.5, 5.0, 0.0],
+                    [0.25, 0.75, 6.0],
+                ]
+            )
+        ),
+        (True, True, True),
+    )
+
+
+def _particles(
+    system: Index[SystemId],
+    *,
+    keys: tuple[ParticleId, ...] | None = None,
+) -> Table[ParticleId, Particles]:
+    """Build a one-system particle table for builder tests."""
+    n_particles = len(system)
+    if keys is None:
+        keys = tuple(ParticleId(i) for i in range(n_particles))
+    return Table(
+        keys,
+        Particles(
+            positions=jnp.arange(n_particles * 3, dtype=float).reshape(n_particles, 3),
+            masses=jnp.arange(1, n_particles + 1, dtype=float),
+            atomic_numbers=jnp.full(n_particles, 18, dtype=int),
+            charges=jnp.zeros(n_particles),
+            labels=Index(
+                (Label("Ar"),),
+                jnp.zeros(n_particles, dtype=int),
+                _cls=Label,
+            ),
+            system=system,
+        ),
+        _cls=ParticleId,
+    )
+
+
+def _deformation_factor(systems: Table[SystemId, RelaxSystems]) -> jax.Array:
+    """Return the per-system deformation cell_factor as a flat array."""
+    frame = systems.data.cell.frame
+    assert isinstance(frame, DeformedFrame)
+    deformation = frame.deformation
+    assert isinstance(deformation, MatrixLogFrame)
+    return deformation.cell_factor.reshape(-1)
+
+
+def _assert_tree_allclose(actual: object, expected: object) -> None:
+    """Compare two PyTrees numerically, including structure."""
+    actual_structure = jax.tree_util.tree_structure(actual)
+    expected_structure = jax.tree_util.tree_structure(expected)
+    assert actual_structure == expected_structure
+    for actual_leaf, expected_leaf in zip(
+        jax.tree_util.tree_leaves(actual),
+        jax.tree_util.tree_leaves(expected),
+        strict=True,
+    ):
+        npt.assert_allclose(actual_leaf, expected_leaf, rtol=1e-12, atol=1e-12)
+
+
+def test_public_builder_signature_without_module_all() -> None:
+    """Public signature is (particles, cell); the module adds no __all__."""
+    signature = inspect.signature(relax_state_from_particles_and_cell)
+
+    assert tuple(signature.parameters) == ("particles", "cell")
+    assert not hasattr(relax_data, "__all__")
+
+
+def test_builder_preserves_identity_and_geometry() -> None:
+    """Particle keys, the referenced SystemId, and geometry are preserved."""
+    system_key = SystemId(12)
+    particle_keys = (ParticleId(4), ParticleId(9))
+    particles = _particles(
+        Index((system_key,), jnp.zeros(2, dtype=int)),
+        keys=particle_keys,
+    )
+    cell = _cell()
+
+    relax_particles, systems = relax_state_from_particles_and_cell(particles, cell)
+
+    assert relax_particles.keys == particle_keys
+    assert relax_particles.data.system.keys == (system_key,)
+    npt.assert_array_equal(
+        relax_particles.data.system.indices,
+        jnp.zeros(2, dtype=int),
+    )
+    assert systems.keys == (system_key,)
+    npt.assert_array_equal(relax_particles.data.positions, particles.data.positions)
+    assert systems.data.cell.vectors.shape == (1, 3, 3)
+    npt.assert_allclose(systems.data.cell.vectors[0], cell.vectors, atol=1e-12)
+
+
+def test_empty_particles_are_rejected() -> None:
+    """Empty particle tables raise ValueError."""
+    particles = _particles(
+        Index((SystemId(12),), jnp.empty((0,), dtype=int)),
+        keys=(),
+    )
+
+    with pytest.raises(ValueError, match="particles.*at least one"):
+        relax_state_from_particles_and_cell(particles, _cell())
+
+
+def test_multiple_system_keys_are_rejected() -> None:
+    """Multiple SystemId keys raise ValueError."""
+    particles = _particles(
+        Index((SystemId(12), SystemId(13)), jnp.array([0, 1])),
+    )
+
+    with pytest.raises(ValueError, match="particles.*exactly one system"):
+        relax_state_from_particles_and_cell(particles, _cell())
+
+
+def test_invalid_reference_into_single_system_key_is_rejected() -> None:
+    """Indices that do not select the sole SystemId raise ValueError."""
+    particles = _particles(
+        Index((SystemId(12),), jnp.array([0, 1])),
+    )
+
+    with pytest.raises(ValueError, match="particles.*sole SystemId"):
+        relax_state_from_particles_and_cell(particles, _cell())
+
+
+def test_column_vector_system_indices_are_rejected() -> None:
+    """Column-vector system.indices raise ValueError."""
+    particles = _particles(
+        Index((SystemId(12),), jnp.zeros((2, 1), dtype=int)),
+    )
+
+    with pytest.raises(
+        ValueError, match=r"particles.*one system reference per particle"
+    ):
+        relax_state_from_particles_and_cell(particles, _cell())
+
+
+def test_batched_cell_is_rejected() -> None:
+    """A cell whose vectors are not shape (3, 3) raises ValueError."""
+    particles = _particles(
+        Index((SystemId(12),), jnp.zeros(2, dtype=int)),
+    )
+
+    with pytest.raises(ValueError, match=r"cell\.vectors.*\(3, 3\)"):
+        relax_state_from_particles_and_cell(particles, _cell()[None])
+
+
+def test_deformed_frame_is_rejected() -> None:
+    """An unbatched cell with an outer DeformedFrame raises ValueError.
+
+    Distinct from the already-batched cell rejected by the shape check.
+    """
+    particles = _particles(
+        Index((SystemId(12),), jnp.zeros(2, dtype=int)),
+    )
+    base = _cell()
+    deformed = Cell.from_pbc(
+        DeformedFrame.from_frame(base.frame),
+        (True, True, True),
+    )
+    assert deformed.vectors.shape == (3, 3)
+
+    with pytest.raises(ValueError, match=r"DeformedFrame"):
+        relax_state_from_particles_and_cell(particles, deformed)
+
+
+def test_ase_wrapper_delegates_to_source_neutral_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """relax_state_from_ase forwards adapter output to the builder."""
+    particles = _particles(
+        Index((SystemId(0),), jnp.zeros(2, dtype=int)),
+    )
+    cell = _cell()
+    expected = (object(), object())
+    calls: list[tuple[object, ...]] = []
+
+    def fake_particles_from_ase(
+        atoms: ase.Atoms | str | Path,
+    ) -> tuple[Table[ParticleId, Particles], Cell[AnyPeriodicity], object]:
+        calls.append(("adapter", atoms))
+        return particles, cell, object()
+
+    def fake_builder(
+        actual_particles: Table[ParticleId, Particles],
+        actual_cell: Cell[AnyPeriodicity],
+    ) -> tuple[object, object]:
+        calls.append(("builder", actual_particles, actual_cell))
+        return expected
+
+    monkeypatch.setattr(relax_data, "particles_from_ase", fake_particles_from_ase)
+    monkeypatch.setattr(relax_data, "relax_state_from_particles_and_cell", fake_builder)
+
+    actual = relax_state_from_ase("input.cif")
+
+    assert actual is expected
+    assert calls == [
+        ("adapter", "input.cif"),
+        ("builder", particles, cell),
+    ]
+
+
+@pytest.mark.parametrize("use_path", [False, True], ids=["atoms", "file-path"])
+def test_ase_wrapper_retains_input_forms(tmp_path: Path, use_path: bool) -> None:
+    """ASE Atoms and file-path inputs remain supported and canonical."""
+    atoms = ase.Atoms(
+        "Ar2",
+        positions=[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+        cell=[4.0, 4.0, 4.0],
+        pbc=True,
+    )
+    source: ase.Atoms | str = atoms
+    if use_path:
+        path = tmp_path / "atoms.cif"
+        ase.io.write(path, atoms)
+        source = str(path)
+
+    particles, systems = relax_state_from_ase(source)
+
+    assert particles.keys == (ParticleId(0), ParticleId(1))
+    assert systems.keys == (SystemId(0),)
+    npt.assert_array_equal(_deformation_factor(systems), [2.0])
+
+
+def test_array_builder_matches_ase_for_skewed_cell() -> None:
+    """Array and ASE paths agree for the same skewed-cell input."""
+    positions = jnp.array(
+        [
+            [0.4, 0.8, 1.2],
+            [1.5, 0.3, 2.1],
+            [0.7, 1.1, 0.5],
+        ]
+    )
+    cell_vectors = jnp.array(
+        [
+            [0.0, 2.0, 0.0],
+            [1.5, 0.2, 0.0],
+            [0.3, 0.4, 3.0],
+        ]
+    )
+    masses = jnp.array([12.5, 16.25, 14.0])
+    atomic_numbers = jnp.array([6, 8, 7])
+    charges = jnp.array([0.2, -0.3, 0.1])
+    labels = ["carbon-site", "oxygen-site", "nitrogen-site"]
+    atoms = ase.Atoms(
+        "CON",
+        positions=np.asarray(positions),
+        cell=np.asarray(cell_vectors),
+        masses=np.asarray(masses),
+        pbc=(True, False, True),
+    )
+    atoms.info["_atom_type_partial_charge"] = np.asarray(charges)
+    atoms.info["_atom_site_label"] = labels
+
+    array_particles, array_cell, _ = particles_from_arrays(
+        positions=positions,
+        cell_vectors=cell_vectors,
+        periodicity=(True, False, True),
+        masses=masses,
+        atomic_numbers=atomic_numbers,
+        charges=charges,
+        labels=labels,
+    )
+    actual_particles, actual_systems = relax_state_from_particles_and_cell(
+        array_particles,
+        array_cell,
+    )
+    expected_particles, expected_systems = relax_state_from_ase(atoms)
+
+    assert not jnp.allclose(cell_vectors, jnp.tril(cell_vectors))
+    assert actual_particles.keys == expected_particles.keys
+    assert actual_systems.keys == expected_systems.keys
+    _assert_tree_allclose(actual_particles.data, expected_particles.data)
+    _assert_tree_allclose(actual_systems.data, expected_systems.data)
+
+
+def test_canonical_array_outputs_support_table_union() -> None:
+    """Union of canonical outputs preserves each differently-sized system.
+
+    Two systems of unequal size (2 and 3 particles) with distinct diagonal
+    cells are merged; particle-to-system associations, per-system cell vectors,
+    and per-system deformation factors are checked against independently
+    specified expectations.
+    """
+    system_lengths = (
+        jnp.array([4.0, 5.0, 6.0]),
+        jnp.array([7.0, 8.0, 9.0]),
+    )
+    specs = [
+        {
+            "positions": jnp.array([[0.2, 0.4, 0.6], [1.1, 1.3, 1.5]]),
+            "cell_vectors": jnp.diag(system_lengths[0]),
+            "masses": jnp.array([22.99, 35.45]),
+            "atomic_numbers": jnp.array([11, 17]),
+            "charges": jnp.array([0.75, -0.75]),
+            "labels": ["Na", "Cl"],
+        },
+        {
+            "positions": jnp.array([[0.3, 0.5, 0.7], [1.2, 1.4, 1.6], [2.1, 2.3, 2.5]]),
+            "cell_vectors": jnp.diag(system_lengths[1]),
+            "masses": jnp.array([15.999, 1.008, 1.008]),
+            "atomic_numbers": jnp.array([8, 1, 1]),
+            "charges": jnp.array([-0.8, 0.4, 0.4]),
+            "labels": ["O", "H", "H"],
+        },
+    ]
+    outputs = []
+    for spec in specs:
+        particles, cell, _ = particles_from_arrays(
+            periodicity=(True, True, True), **spec
+        )
+        outputs.append(relax_state_from_particles_and_cell(particles, cell))
+
+    merged_particles, merged_systems = Table.union(
+        [outputs[0][0], outputs[1][0]],
+        [outputs[0][1], outputs[1][1]],
+    )
+
+    # Particle-to-system associations: globally-unique keys, two systems, and
+    # a per-particle reference of [system0 x2, system1 x3].
+    assert merged_particles.keys == tuple(ParticleId(i) for i in range(5))
+    assert merged_systems.keys == (SystemId(0), SystemId(1))
+    assert merged_particles.data.system.keys == (SystemId(0), SystemId(1))
+    npt.assert_array_equal(merged_particles.data.system.indices, [0, 0, 1, 1, 1])
+    # The non-key exclusion leaf merges by dedup: keys (0, 1, 2), each system
+    # keeping its own per-atom groups.
+    assert merged_particles.data.exclusion.keys == (
+        ExclusionId(0),
+        ExclusionId(1),
+        ExclusionId(2),
+    )
+    npt.assert_array_equal(merged_particles.data.exclusion.indices, [0, 1, 0, 1, 2])
+
+    # Each system keeps its own cell vectors (diagonal cells stay diagonal) and
+    # its own deformation factor (its particle count).
+    assert merged_systems.data.cell.vectors.shape == (2, 3, 3)
+    npt.assert_allclose(
+        merged_systems.data.cell.vectors[0], jnp.diag(system_lengths[0]), atol=1e-12
+    )
+    npt.assert_allclose(
+        merged_systems.data.cell.vectors[1], jnp.diag(system_lengths[1]), atol=1e-12
+    )
+    npt.assert_array_equal(_deformation_factor(merged_systems), [2.0, 3.0])
+
+
+def test_builder_initial_zero_state_and_pytree_contract() -> None:
+    """Zero gradients, zero energy, default exclusions, matching cell trees."""
+    particles = _particles(
+        Index((SystemId(4),), jnp.zeros(3, dtype=int)),
+    )
+    cell = _cell()
+
+    relax_particles, systems = relax_state_from_particles_and_cell(particles, cell)
+
+    for field_name in ("positions", "masses", "atomic_numbers", "charges"):
+        actual = getattr(relax_particles.data, field_name)
+        expected = getattr(particles.data, field_name)
+        assert actual.shape == expected.shape
+        assert actual.dtype == expected.dtype
+        npt.assert_array_equal(actual, expected)
+
+    assert relax_particles.data.position_gradients.shape == (3, 3)
+    assert (
+        relax_particles.data.position_gradients.dtype == particles.data.positions.dtype
+    )
+    npt.assert_array_equal(
+        relax_particles.data.position_gradients,
+        jnp.zeros_like(particles.data.positions),
+    )
+    npt.assert_array_equal(relax_particles.data.forces, jnp.zeros((3, 3)))
+    assert relax_particles.data.exclusion.keys == tuple(
+        ExclusionId(i) for i in range(3)
+    )
+    npt.assert_array_equal(relax_particles.data.exclusion.indices, jnp.arange(3))
+
+    assert systems.data.cell.vectors.shape == (1, 3, 3)
+    assert systems.data.potential_energy.shape == (1,)
+    npt.assert_array_equal(systems.data.potential_energy, jnp.zeros(1))
+
+    assert jax.tree_util.tree_structure(
+        systems.data.cell_gradients
+    ) == jax.tree_util.tree_structure(systems.data.cell)
+    for gradient_leaf, cell_leaf in zip(
+        jax.tree_util.tree_leaves(systems.data.cell_gradients),
+        jax.tree_util.tree_leaves(systems.data.cell),
+        strict=True,
+    ):
+        assert gradient_leaf.shape == cell_leaf.shape
+        assert gradient_leaf.dtype == cell_leaf.dtype
+        npt.assert_array_equal(gradient_leaf, jnp.zeros_like(cell_leaf))
+
+    system_structure = jax.tree_util.tree_structure(systems.data)
+    assert (
+        type(
+            jax.tree_util.tree_unflatten(
+                system_structure, jax.tree_util.tree_leaves(systems.data)
+            )
+        )
+        is RelaxSystems
+    )
+    particle_structure = jax.tree_util.tree_structure(relax_particles.data)
+    assert (
+        type(
+            jax.tree_util.tree_unflatten(
+                particle_structure, jax.tree_util.tree_leaves(relax_particles.data)
+            )
+        )
+        is RelaxParticles
+    )
+
+
+@pytest.mark.parametrize("n_particles", [1, 5])
+def test_cell_factor_equals_particle_count_and_ase_parity(n_particles: int) -> None:
+    """Deformation cell_factor is the per-system particle count for both paths."""
+    particles = _particles(
+        Index((SystemId(0),), jnp.zeros(n_particles, dtype=int)),
+    )
+    cell = _cell()
+
+    _, systems = relax_state_from_particles_and_cell(particles, cell)
+    factor = _deformation_factor(systems)
+
+    assert factor.shape == (1,)
+    npt.assert_array_equal(factor, [float(n_particles)])
+    assert factor.dtype == particles.data.positions.dtype
+
+    atoms = ase.Atoms(
+        f"Ar{n_particles}",
+        positions=np.asarray(particles.data.positions),
+        cell=np.asarray(cell.vectors),
+        pbc=True,
+    )
+    _, ase_systems = relax_state_from_ase(atoms)
+    npt.assert_array_equal(_deformation_factor(ase_systems), factor)
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        TriclinicFrame.from_matrix(
+            jnp.array([[4.0, 0.0, 0.0], [0.5, 5.0, 0.0], [0.25, 0.75, 6.0]])
+        ),
+        OrthogonalFrame(lengths=jnp.array([4.0, 5.0, 6.0])),
+    ],
+    ids=["triclinic", "orthogonal"],
+)
+def test_undeformed_frames_are_accepted_without_transform(frame: object) -> None:
+    """Representative undeformed frames build with unchanged physical vectors."""
+    particles = _particles(
+        Index((SystemId(0),), jnp.zeros(2, dtype=int)),
+    )
+    cell = Cell.from_pbc(frame, (True, True, True))
+
+    _, systems = relax_state_from_particles_and_cell(particles, cell)
+
+    assert isinstance(systems.data.cell.frame, DeformedFrame)
+    npt.assert_allclose(systems.data.cell.vectors[0], cell.vectors, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "periodicity",
+    [(True, True, True), (False, False, False), (True, True, False)],
+    ids=["periodic", "vacuum", "slab-xy"],
+)
+def test_periodicity_and_cell_variant_are_preserved(
+    periodicity: AnyPeriodicity,
+) -> None:
+    """The prepared cell keeps the input periodicity and concrete Cell variant.
+
+    Checked directly against the input cell, independent of the ASE wrapper, so
+    fully periodic, non-periodic, and partially periodic inputs are all covered.
+    """
+    frame = TriclinicFrame.from_matrix(
+        jnp.array([[4.0, 0.0, 0.0], [0.5, 5.0, 0.0], [0.25, 0.75, 6.0]])
+    )
+    cell = Cell.from_pbc(frame, periodicity)
+    particles = _particles(Index((SystemId(0),), jnp.zeros(2, dtype=int)))
+
+    _, systems = relax_state_from_particles_and_cell(particles, cell)
+
+    prepared = systems.data.cell
+    assert prepared.periodic == periodicity
+    assert prepared.periodic == cell.periodic
+    assert type(prepared) is type(cell)
+
+
+@pytest.mark.parametrize(
+    "make_frame",
+    [
+        lambda vecs: LogTriclinicFrame.from_matrix(vecs, cell_factor=7.0),
+        lambda vecs: MatrixLogFrame.from_lower_triangular(vecs, cell_factor=7.0),
+    ],
+    ids=["log-triclinic", "matrix-log"],
+)
+def test_source_log_frame_factor_preserved_in_reference_base(
+    make_frame: object,
+) -> None:
+    """A raw log-frame source keeps its cell_factor in the deformation base."""
+    vecs = jnp.array([[4.0, 0.0, 0.0], [0.5, 5.0, 0.0], [0.25, 0.75, 6.0]])
+    cell = Cell.from_pbc(make_frame(vecs), (True, True, True))  # type: ignore[operator]
+
+    particles = _particles(
+        Index((SystemId(0),), jnp.zeros(3, dtype=int)),
+    )
+
+    _, systems = relax_state_from_particles_and_cell(particles, cell)
+
+    frame = systems.data.cell.frame
+    assert isinstance(frame, DeformedFrame)
+    npt.assert_allclose(systems.data.cell.vectors[0], cell.vectors, atol=1e-12)
+    npt.assert_array_equal(np.unique(np.asarray(frame.base.cell_factor)), [7.0])
+    npt.assert_array_equal(_deformation_factor(systems), [3.0])

--- a/test/application/relaxation/test_relaxation_data.py
+++ b/test/application/relaxation/test_relaxation_data.py
@@ -129,6 +129,11 @@ def test_builder_preserves_identity_and_geometry() -> None:
         jnp.zeros(2, dtype=int),
     )
     assert systems.keys == (system_key,)
+    assert relax_particles.data.labels.keys == particles.data.labels.keys
+    npt.assert_array_equal(
+        relax_particles.data.labels.indices,
+        particles.data.labels.indices,
+    )
     npt.assert_array_equal(relax_particles.data.positions, particles.data.positions)
     assert systems.data.cell.vectors.shape == (1, 3, 3)
     npt.assert_allclose(systems.data.cell.vectors[0], cell.vectors, atol=1e-12)
@@ -400,6 +405,16 @@ def test_builder_initial_zero_state_and_pytree_contract() -> None:
         assert actual.shape == expected.shape
         assert actual.dtype == expected.dtype
         npt.assert_array_equal(actual, expected)
+    assert relax_particles.data.labels.keys == particles.data.labels.keys
+    npt.assert_array_equal(
+        relax_particles.data.labels.indices,
+        particles.data.labels.indices,
+    )
+    assert relax_particles.data.system.keys == particles.data.system.keys
+    npt.assert_array_equal(
+        relax_particles.data.system.indices,
+        particles.data.system.indices,
+    )
 
     assert relax_particles.data.position_gradients.shape == (3, 3)
     assert (
@@ -464,7 +479,6 @@ def test_cell_factor_equals_particle_count_and_ase_parity(n_particles: int) -> N
 
     assert factor.shape == (1,)
     npt.assert_array_equal(factor, [float(n_particles)])
-    assert factor.dtype == particles.data.positions.dtype
 
     atoms = ase.Atoms(
         f"Ar{n_particles}",
@@ -474,6 +488,48 @@ def test_cell_factor_equals_particle_count_and_ase_parity(n_particles: int) -> N
     )
     _, ase_systems = relax_state_from_ase(atoms)
     npt.assert_array_equal(_deformation_factor(ase_systems), factor)
+
+
+def test_cell_factor_value_survives_mixed_input_dtypes() -> None:
+    """Deformation factor value is the particle count when dtypes differ.
+
+    Asserts the actual builder-input dtypes. JAX may collapse an explicit
+    float64 request to float32 when x64 is off; that is a skip, not coverage.
+    """
+    n_particles = 2
+    positions = jnp.arange(n_particles * 3, dtype=jnp.float32).reshape(n_particles, 3)
+    cell_vectors = jnp.array(
+        [[4.0, 0.0, 0.0], [0.5, 5.0, 0.0], [0.25, 0.75, 6.0]],
+        dtype=jnp.float64,
+    )
+    particles = Table(
+        tuple(ParticleId(i) for i in range(n_particles)),
+        Particles(
+            positions=positions,
+            masses=jnp.arange(1, n_particles + 1, dtype=jnp.float32),
+            atomic_numbers=jnp.full(n_particles, 18, dtype=int),
+            charges=jnp.zeros(n_particles, dtype=jnp.float32),
+            labels=Index(
+                (Label("Ar"),),
+                jnp.zeros(n_particles, dtype=int),
+                _cls=Label,
+            ),
+            system=Index((SystemId(0),), jnp.zeros(n_particles, dtype=int)),
+        ),
+        _cls=ParticleId,
+    )
+    cell = Cell.from_pbc(TriclinicFrame.from_matrix(cell_vectors), (True, True, True))
+    if particles.data.positions.dtype != jnp.dtype(
+        jnp.float32
+    ) or cell.vectors.dtype != jnp.dtype(jnp.float64):
+        pytest.skip(
+            "JAX did not keep the requested mixed dtypes "
+            f"(positions={particles.data.positions.dtype}, cell={cell.vectors.dtype})"
+        )
+
+    _, systems = relax_state_from_particles_and_cell(particles, cell)
+
+    npt.assert_array_equal(_deformation_factor(systems), [float(n_particles)])
 
 
 @pytest.mark.parametrize(
@@ -496,6 +552,7 @@ def test_undeformed_frames_are_accepted_without_transform(frame: object) -> None
     _, systems = relax_state_from_particles_and_cell(particles, cell)
 
     assert isinstance(systems.data.cell.frame, DeformedFrame)
+    assert type(systems.data.cell.frame.base) is type(frame)
     npt.assert_allclose(systems.data.cell.vectors[0], cell.vectors, atol=1e-12)
 
 
@@ -549,6 +606,33 @@ def test_source_log_frame_factor_preserved_in_reference_base(
 
     frame = systems.data.cell.frame
     assert isinstance(frame, DeformedFrame)
+    npt.assert_allclose(systems.data.cell.vectors[0], cell.vectors, atol=1e-12)
+    npt.assert_array_equal(np.unique(np.asarray(frame.base.cell_factor)), [7.0])
+    npt.assert_array_equal(_deformation_factor(systems), [3.0])
+    assert type(frame.base) is type(cell.frame)
+
+
+def test_non_triangular_matrix_log_frame_vectors_are_preserved() -> None:
+    """A full-matrix MatrixLogFrame source keeps its vectors and frame type."""
+    vecs = jnp.array(
+        [
+            [2.0, 0.3, -0.1],
+            [0.4, 3.0, 0.2],
+            [-0.2, 0.5, 4.0],
+        ]
+    )
+    assert not jnp.allclose(vecs, jnp.tril(vecs))
+    cell = Cell.from_pbc(
+        MatrixLogFrame.from_matrix(vecs, cell_factor=7.0),
+        (True, True, True),
+    )
+    particles = _particles(Index((SystemId(0),), jnp.zeros(3, dtype=int)))
+
+    _, systems = relax_state_from_particles_and_cell(particles, cell)
+
+    frame = systems.data.cell.frame
+    assert isinstance(frame, DeformedFrame)
+    assert type(frame.base) is MatrixLogFrame
     npt.assert_allclose(systems.data.cell.vectors[0], cell.vectors, atol=1e-12)
     npt.assert_array_equal(np.unique(np.asarray(frame.base.cell_factor)), [7.0])
     npt.assert_array_equal(_deformation_factor(systems), [3.0])


### PR DESCRIPTION
Closes #294.

## Summary

Adds `relax_state_from_particles_and_cell()` in [`kups.application.relaxation.data`](https://github.com/cusp-ai-oss/kUPS/blob/main/src/kups/application/relaxation/data.py) so callers with existing kUPS particles and an unbatched cell can initialize `RelaxParticles` and `RelaxSystems` without going through ASE or duplicating relaxation preparation.

Array-native callers can compose `particles_from_arrays()` with the new builder, extending the source-neutral initialization pattern introduced for MD in #286 to relaxation.

`relax_state_from_ase()` now delegates to the builder after calling `particles_from_ase()`, preserving its signature and existing observable behavior.

## Implementation

* Accepts one non-empty, complete system and an unbatched `(3, 3)` cell. Structural violations and an outer `DeformedFrame` raise `ValueError`.
* Preserves particle fields and keys, the particle-to-system `Index`, the referenced `SystemId`, periodicity, and initial physical cell vectors. Inputs must already share the same coordinate frame; the builder does not transform geometry.
* Preserves the existing ASE preparation: adds the system axis before wrapping the retained reference frame in an identity `MatrixLogFrame` deformation, sets the new deformation's per-system `cell_factor` to the particle count, and initializes gradients and potential energy to zero. Any source log-frame factor remains unchanged on the reference base.
* Keys the `RelaxSystems` table by the referenced `SystemId` instead of generating a new key with `Table.arange()`. ASE outputs remain canonical because `particles_from_ase()` already supplies canonical keys.

No changes to relaxation filters, optimizers, or model backends.

## Testing

Focused tests in `test/application/relaxation/test_relaxation_data.py` cover:

* Identity and field preservation, structural validation, ASE delegation and input compatibility, and skewed-cell array/ASE parity.
* Canonical `Table.union()` with unequal particle counts and distinct cells, periodicity, and preservation of cell and reference-frame types.
* Raw log-frames, including a non-lower-triangular `MatrixLogFrame`, source-factor preservation, and the new deformation factor's value with mixed input dtypes, without prescribing its stored dtype.
* Zero gradients and energy, default exclusions, and matching cell/gradient PyTrees.

Local CPU validation passed: focused builder tests, existing Lennard-Jones regressions in both `POSITIONS_ONLY` and `FRECHET_FILTER` modes, ASE filter-parity tests, the full CPU suite, Ruff lint/format checks, and Pyrefly. Existing flat relaxation tests are unchanged.

MACE and UMA adapter integration tests were skipped locally because the optional extras were not enabled. Upstream GPU validation for the PR revision remains pending.

## Merge context

This branch is based on `main` at `cd5cd4a` (merged #286). 

Open PR [#194](https://github.com/cusp-ai-oss/kUPS/pull/194) also edits `src/kups/application/relaxation/data.py`: it adds `verlet_skin` on `RelaxState` and `RelaxRunConfig`. This PR adds the source-neutral builder and does not change those types. Landing either first is a mechanical rebase, not a semantic clash with the builder contract.

The `RelaxSystems.cell_gradients` docstring change in this PR is documentation only. 
The previous wording (“lower-triangular log-deformation entries under `cell_filter`”) described the older `LogTriclinicFrame` packing and was easy to misread against the current identity `MatrixLogFrame` deformation. Gradient storage and filter behavior are unchanged.