### PR TITLE
feat: add two-body D3(BJ) dispersion kernel

### DIFF
--- a/src/kups/potential/dispersion/__init__.py
+++ b/src/kups/potential/dispersion/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dispersion corrections for molecular potentials."""

--- a/src/kups/potential/dispersion/d3.py
+++ b/src/kups/potential/dispersion/d3.py
@@ -1,0 +1,289 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Two-body Grimme D3 dispersion with Becke-Johnson damping.
+
+$$
+E = -\frac{1}{2}\sum_{i}\sum_{j,\mathbf{T}}\left[
+    \frac{s_6\,C^{ij}_6}{r^6 + (R^{ij}_0)^6}
+  + \frac{s_8\,C^{ij}_8}{r^8 + (R^{ij}_0)^8}\right],
+$$
+
+over neighbours $j$ and lattice translations $\mathbf{T}$, with
+$C^{ij}_8 = 3\,Q_i Q_j\,C^{ij}_6$ and $R^{ij}_0 = a_1\sqrt{3\,Q_i Q_j} + a_2$,
+where $Q_i$ is the stored ``r4r2``. The coefficients follow the chemical
+environment through a fractional coordination number
+
+$$
+\mathrm{CN}_i = \sum_{j,\mathbf{T}}
+    \left[1 + e^{-k_1\left((R^\text{cov}_i + R^\text{cov}_j)/r - 1\right)}\right]^{-1},
+$$
+
+which Gaussian-weights tabulated reference environments. The joint pair weight
+factorizes, so the weights are formed and normalized per atom:
+
+$$
+C^{ij}_6 = \sum_{a,b} \hat g^a_i\, C^{ij,ab}_{6,\text{ref}}\, \hat g^b_j,
+\qquad
+\hat g^a_i \propto e^{-k_3\left(\mathrm{CN}_i - \mathrm{CN}^a_i\right)^2}.
+$$
+
+[d3_energy][kups.potential.dispersion.d3.d3_energy] is the sole boundary between
+the kUPS graph representation and the mathematics below it: it owns edge
+geometry, the atom-to-edge gathers, the per-system cutoffs and the reduction.
+Edges are directed, so each pair appears twice and the sum is halved. A pair
+contributes only while ``r < cutoff``, truncated abruptly as in
+``simple-dftd3``. Forces and stress follow by differentiating the energy. The
+Axilrod-Teller-Muto three-body term and the zero-damping variant are not
+implemented.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, Protocol, runtime_checkable
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.cell import AnyPeriodicity
+from kups.core.data import Table
+from kups.core.patch import IdPatch, WithPatch
+from kups.core.potential import Energy
+from kups.core.typing import (
+    HasAtomicNumbers,
+    HasCell,
+    HasPositionsAndSystemIndex,
+    SystemId,
+)
+from kups.core.utils.jax import dataclass, jit
+from kups.potential.common.graph import GraphPotentialInput
+
+_COORDINATION_STEEPNESS = 16.0  # k1
+_REFERENCE_WEIGHTING_FACTOR = 4.0  # k3
+
+
+@dataclass
+class D3BJParameters:
+    """Fitted Becke-Johnson damping parameters, in kUPS units."""
+
+    s6: Array  # () dimensionless
+    s8: Array  # () dimensionless
+    a1: Array  # () dimensionless
+    a2: Array  # () [Å], published in Bohr and converted by the caller
+
+
+@dataclass
+class D3ReferenceData:
+    """Element and pair reference tables, indexed directly by atomic number.
+
+    Row ``0`` is a finite neutral placeholder used by padded/unoccupied
+    entries. Its numeric data must be finite (normally zero), and
+    ``reference_mask[0]`` must be all ``False``. The preparation layer is
+    responsible for enforcing this contract.
+    """
+
+    covalent_radii: Array  # (n_elements,) [Å], Grimme's 4/3-scaled radii
+    r4r2: Array  # (n_elements,) [Å], sqrt(0.5 * sqrt(Z) * <r^4>/<r^2>)
+    reference_cn: Array  # (n_elements, n_references)
+    reference_c6: Array  # (n_elements, n_elements, n_refs, n_refs) [eV Å^6]
+    reference_mask: Array  # (n_elements, n_references), environments defined
+
+
+@dataclass
+class D3Parameters:
+    """Damping, reference tables and cutoffs, grouped into one parameter value.
+
+    ``cn_cutoff`` must not exceed ``cutoff``, so that one neighbor list built at
+    ``cutoff`` serves both sums.
+    """
+
+    damping: D3BJParameters
+    reference: D3ReferenceData
+    cutoff: Table[SystemId, Array]  # (n_systems,) [Å]
+    cn_cutoff: Table[SystemId, Array]  # (n_systems,) [Å]
+
+
+@runtime_checkable
+class IsD3Particles(HasPositionsAndSystemIndex, HasAtomicNumbers, Protocol):
+    """Particle properties D3 reads: positions, system assignment, elements."""
+
+
+type D3Input = GraphPotentialInput[
+    D3Parameters, IsD3Particles, HasCell[AnyPeriodicity], Literal[2]
+]
+
+
+def _masked_edge_distances(
+    edge_vectors: Array,  # (n_edges, 3)
+    valid: Array,  # (n_edges,)
+) -> Array:  # (n_edges,)
+    """Edge distances, with a finite stand-in on invalid/padded edges.
+
+    Padded edges would otherwise give ``r == 0``; masking the energy afterwards
+    is not enough, since a zero cotangent times an infinite partial derivative
+    still yields a NaN gradient.
+    """
+    squared_distances = jnp.sum(edge_vectors * edge_vectors, axis=-1)
+    return jnp.sqrt(jnp.where(valid, squared_distances, 1.0))
+
+
+def _reference_weights(
+    coordination_numbers: Array,  # (n_particles,)
+    reference_cn: Array,  # (n_particles, n_references)
+    reference_mask: Array,  # (n_particles, n_references)
+) -> Array:  # (n_particles, n_references)
+    """Normalized Gaussian weights over each atom's reference environments.
+
+    Subtracting the largest exponent is exact for a normalized weight and keeps
+    the sum from underflowing far from every reference.
+    """
+    exponent = (
+        -_REFERENCE_WEIGHTING_FACTOR
+        * (coordination_numbers[..., None] - reference_cn) ** 2
+    )
+    largest = jnp.max(
+        jnp.where(reference_mask, exponent, -jnp.inf), axis=-1, keepdims=True
+    )
+    largest = jnp.where(jnp.isfinite(largest), largest, 0.0)  # fully masked row
+    shifted = jnp.where(reference_mask, exponent - largest, 0.0)  # no overflow
+    weights = jnp.where(reference_mask, jnp.exp(shifted), 0.0)
+    normalizer = jnp.sum(weights, axis=-1, keepdims=True)
+    return weights / jnp.where(normalizer > 0.0, normalizer, 1.0)
+
+
+def d3_coordination_numbers(
+    distances: Array,  # (n_edges,) [Å], safe to divide by
+    covalent_radii_pairs: Array,  # (n_edges, 2) [Å]
+    central_atom_indices: Array,  # (n_edges,)
+    num_particles: int,
+    edge_mask: Array,  # (n_edges,) within cn_cutoff and not padding
+) -> Array:  # (num_particles,)
+    """Fractional D3 coordination numbers, accumulated over directed edges.
+
+    Self-image pairs contribute; the ``i == j``, ``T == 0`` pair does not,
+    because a neighbor list never emits it.
+    """
+    covalent_distance = jnp.sum(covalent_radii_pairs, axis=-1)
+    contribution = jax.nn.sigmoid(
+        _COORDINATION_STEEPNESS * (covalent_distance / distances - 1.0)
+    )
+    contribution = jnp.where(edge_mask, contribution, 0.0)
+    return jax.ops.segment_sum(
+        contribution,
+        central_atom_indices,
+        num_segments=num_particles,
+        mode="drop",
+    )
+
+
+def d3_c6_coefficients(
+    edge_reference_weights: Array,  # (n_edges, 2, n_references)
+    edge_reference_c6: Array,  # (n_edges, n_references, n_references) [eV Å^6]
+) -> Array:  # (n_edges,) [eV Å^6]
+    """Contract each endpoint's reference weights with the pair's ``C6`` matrix."""
+    return jnp.einsum(
+        "ea,eab,eb->e",
+        edge_reference_weights[:, 0],
+        edge_reference_c6,
+        edge_reference_weights[:, 1],
+    )
+
+
+def d3_c8_coefficients(
+    c6: Array,  # (n_edges,) [eV Å^6]
+    r4r2_pairs: Array,  # (n_edges, 2) [Å]
+) -> Array:  # (n_edges,) [eV Å^8]
+    """Promote ``C6`` to ``C8`` through ``C8 = 3 Q_i Q_j C6``."""
+    return 3.0 * r4r2_pairs[:, 0] * r4r2_pairs[:, 1] * c6
+
+
+def d3_bj_edge_energy(
+    distances: Array,  # (n_edges,) [Å]
+    c6: Array,  # (n_edges,) [eV Å^6]
+    c8: Array,  # (n_edges,) [eV Å^8]
+    r4r2_pairs: Array,  # (n_edges, 2) [Å], fixes the damping radius
+    damping: D3BJParameters,
+) -> Array:  # (n_edges,) [eV]
+    """Two-body D3(BJ) energy of each directed edge.
+
+    Becke-Johnson damping adds the pair radius ``R0`` to the denominators, so no
+    separate damping function appears. The caller applies the cutoff, drops
+    padded edges and halves the directed sum.
+    """
+    c8_c6_ratio = 3.0 * r4r2_pairs[:, 0] * r4r2_pairs[:, 1]
+    damping_length = damping.a1 * jnp.sqrt(c8_c6_ratio) + damping.a2
+    r2 = distances**2
+    r6 = r2**3
+    r8 = r6 * r2
+    return -(
+        damping.s6 * c6 / (r6 + damping_length**6)
+        + damping.s8 * c8 / (r8 + damping_length**8)
+    )
+
+
+@jit
+def d3_energy(inp: D3Input) -> WithPatch[Table[SystemId, Energy], IdPatch[Any]]:
+    """Total two-body D3(BJ) dispersion energy per system [eV].
+
+    The graph must carry directed pair edges out to ``cutoff``, which bounds
+    ``cn_cutoff`` and so covers both sums. That ordering is a contract on
+    [D3Parameters][kups.potential.dispersion.d3.D3Parameters], to be enforced
+    where the potential is configured rather than asserted here.
+
+    This kernel validates nothing. It assumes
+    [D3ReferenceData][kups.potential.dispersion.d3.D3ReferenceData] was checked
+    by the layer that loads and prepares it, and that every particle atomic
+    number is a valid index into those tables. A loader cannot establish the
+    second -- it never sees a particle state -- so rejecting an unsupported
+    element belongs to the state and configuration boundary that builds the
+    potential.
+    """
+    graph = inp.graph
+    parameters = inp.parameters
+    reference = parameters.reference
+    assert graph.edges.indices.shape[-1] == 2, "D3 consumes pair edges"
+
+    # edge geometry and validity
+    edge_indices = graph.edges.indices.indices
+    valid = graph.edges.indices.valid_mask.all(axis=-1)
+    distances = _masked_edge_distances(graph.edge_shifts[:, 0], valid)
+
+    # elements per atom, and per edge with padded rows sent to the masked row zero
+    atomic_numbers = graph.particles.data.atomic_numbers
+    edge_atomic_numbers = jnp.where(valid[:, None], atomic_numbers[edge_indices], 0)
+
+    # per-system cutoffs, resolved onto edges
+    edge_systems = graph.edge_batch_mask
+    cutoff = Table.broadcast_to(parameters.cutoff, graph.systems)[edge_systems]
+    cn_cutoff = Table.broadcast_to(parameters.cn_cutoff, graph.systems)[edge_systems]
+
+    # node-level quantities: coordination numbers, then reference weights
+    coordination_numbers = d3_coordination_numbers(
+        distances,
+        reference.covalent_radii[edge_atomic_numbers],
+        edge_indices[:, 0],
+        len(graph.particles),
+        valid & (distances < cn_cutoff),
+    )
+    reference_weights = _reference_weights(
+        coordination_numbers,
+        reference.reference_cn[atomic_numbers],
+        reference.reference_mask[atomic_numbers],
+    )
+
+    # gather weights onto edges, then the dispersion coefficients and pair energy
+    edge_reference_weights = jnp.where(
+        valid[:, None, None], reference_weights[edge_indices], 0.0
+    )
+    c6 = d3_c6_coefficients(
+        edge_reference_weights,
+        reference.reference_c6[edge_atomic_numbers[:, 0], edge_atomic_numbers[:, 1]],
+    )
+    r4r2_pairs = reference.r4r2[edge_atomic_numbers]
+    c8 = d3_c8_coefficients(c6, r4r2_pairs)
+    edge_energy = d3_bj_edge_energy(distances, c6, c8, r4r2_pairs, parameters.damping)
+
+    # strict cutoff, padding dropped, and each unordered pair counted twice
+    edge_energy = jnp.where(valid & (distances < cutoff), edge_energy, 0.0)
+    return WithPatch(edge_systems.sum_over(edge_energy) / 2, IdPatch[Any]())

--- a/test/potential/dispersion/test_d3.py
+++ b/test/potential/dispersion/test_d3.py
@@ -1,0 +1,393 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the two-body D3(BJ) mathematical kernel."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.testing as npt
+from jax import Array
+
+from kups.core.cell import Cell, OrthogonalFrame, VacuumCell
+from kups.core.constants import BOHR
+from kups.core.data import Index, Table
+from kups.core.neighborlist import Edges
+from kups.core.typing import ParticleId, SystemId
+from kups.core.utils.jax import dataclass
+from kups.potential.common.graph import GraphPotentialInput, HyperGraph
+from kups.potential.dispersion.d3 import (
+    D3BJParameters,
+    D3Parameters,
+    D3ReferenceData,
+    _reference_weights,
+    d3_bj_edge_energy,
+    d3_c6_coefficients,
+    d3_c8_coefficients,
+    d3_coordination_numbers,
+    d3_energy,
+)
+
+
+@dataclass
+class _Particles:
+    positions: Array
+    atomic_numbers: Array
+    system: Index[SystemId]
+
+
+@dataclass
+class _Systems:
+    cell: Cell
+
+
+def _table(*values: float) -> Table[SystemId, Array]:
+    return Table(
+        tuple(SystemId(i) for i in range(len(values))),
+        jnp.asarray(values),
+    )
+
+
+def _argon_reference() -> D3ReferenceData:
+    """Small direct-Z table containing only the published argon row."""
+    n_elements = 19
+    return D3ReferenceData(
+        covalent_radii=jnp.zeros(n_elements).at[18].set(1.28),
+        r4r2=jnp.zeros(n_elements).at[18].set(1.8239535940463758),
+        reference_cn=jnp.zeros((n_elements, 1)),
+        reference_c6=(
+            jnp.zeros((n_elements, n_elements, 1, 1))
+            .at[18, 18, 0, 0]
+            .set(38.62784329646292)
+        ),
+        reference_mask=jnp.zeros((n_elements, 1), dtype=bool).at[18, 0].set(True),
+    )
+
+
+def _parameters(
+    *cutoffs: float, cn_cutoffs: tuple[float, ...] | None = None
+) -> D3Parameters:
+    cn_cutoffs = cutoffs if cn_cutoffs is None else cn_cutoffs
+    return D3Parameters(
+        damping=D3BJParameters(
+            s6=jnp.asarray(1.0),
+            s8=jnp.asarray(0.7875),
+            a1=jnp.asarray(0.4289),
+            a2=jnp.asarray(4.4407 * BOHR),
+        ),
+        reference=_argon_reference(),
+        cutoff=_table(*cutoffs),
+        cn_cutoff=_table(*cn_cutoffs),
+    )
+
+
+def _graph(
+    positions: Array,
+    atomic_numbers: Array,
+    system_indices: Array,
+    edge_indices: Array,
+) -> HyperGraph:
+    num_systems = int(jnp.max(system_indices)) + 1
+    system_keys = tuple(SystemId(i) for i in range(num_systems))
+    particles = Table.arange(
+        _Particles(
+            positions=jnp.asarray(positions),
+            atomic_numbers=jnp.asarray(atomic_numbers),
+            system=Index(system_keys, jnp.asarray(system_indices)),
+        ),
+        label=ParticleId,
+    )
+    systems = Table.arange(
+        _Systems(
+            VacuumCell(OrthogonalFrame(jnp.full((num_systems, 3), 100.0, dtype=float)))
+        ),
+        label=SystemId,
+    )
+    edge_indices = jnp.asarray(edge_indices)
+    edges = Edges(
+        indices=Index(particles.keys, edge_indices),
+        shifts=jnp.zeros((len(edge_indices), 1, 3)),
+    )
+    return HyperGraph(particles, systems, edges)
+
+
+def _argon_dimer_graph(*, padded: bool = False) -> HyperGraph:
+    edges = [[0, 1], [1, 0]]
+    if padded:
+        edges.extend([[2, 2]] * 32)
+    return _graph(
+        positions=jnp.array([[0.0, 0.0, 0.0], [3.8, 0.0, 0.0]]),
+        atomic_numbers=jnp.array([18, 18]),
+        system_indices=jnp.array([0, 0]),
+        edge_indices=jnp.asarray(edges),
+    )
+
+
+class TestD3Math:
+    def test_coordination_numbers_reduce_directed_edges(self) -> None:
+        coordination = d3_coordination_numbers(
+            distances=jnp.ones(3),
+            covalent_radii_pairs=jnp.full((3, 2), 0.5),
+            central_atom_indices=jnp.array([0, 1, 2]),
+            num_particles=2,
+            edge_mask=jnp.array([True, True, False]),
+        )
+        npt.assert_allclose(coordination, [0.5, 0.5], rtol=1e-12)
+
+    def test_c6_contracts_endpoint_weights_with_the_pair_matrix(self) -> None:
+        weights = jnp.array([[[0.25, 0.75], [0.5, 0.5]]])
+        reference_c6 = jnp.array([[[2.0, 4.0], [6.0, 8.0]]])
+
+        actual = d3_c6_coefficients(weights, reference_c6)
+
+        expected = (
+            np.asarray(weights[0, 0])
+            @ np.asarray(reference_c6[0])
+            @ np.asarray(weights[0, 1])
+        )
+        npt.assert_allclose(actual, [expected], rtol=1e-12)
+
+    def test_reference_weights_are_normalized_per_node(self) -> None:
+        actual = _reference_weights(
+            coordination_numbers=jnp.array([0.25]),
+            reference_cn=jnp.array([[0.0, 1.0]]),
+            reference_mask=jnp.ones((1, 2), dtype=bool),
+        )
+        exponent = -4.0 * (0.25 - np.array([0.0, 1.0])) ** 2
+        expected = np.exp(exponent - exponent.max())
+        expected /= expected.sum()
+        npt.assert_allclose(actual, [expected], rtol=1e-12)
+
+    def test_reference_weights_are_stable_far_from_references(self) -> None:
+        actual = _reference_weights(
+            coordination_numbers=jnp.array([100.0]),
+            reference_cn=jnp.array([[0.0, 1.0]]),
+            reference_mask=jnp.ones((1, 2), dtype=bool),
+        )
+        npt.assert_allclose(actual, [[0.0, 1.0]], atol=1e-12)
+        assert bool(jnp.isfinite(actual).all())
+
+    def test_reference_weights_vanish_on_a_fully_masked_row(self) -> None:
+        actual = _reference_weights(
+            coordination_numbers=jnp.array([0.0]),
+            reference_cn=jnp.zeros((1, 2)),
+            reference_mask=jnp.zeros((1, 2), dtype=bool),
+        )
+        npt.assert_array_equal(actual, [[0.0, 0.0]])
+
+    def test_c8_coefficients(self) -> None:
+        c6 = jnp.array([2.0])
+        r4r2_pairs = jnp.array([[1.0, 4.0]])
+
+        actual = d3_c8_coefficients(c6, r4r2_pairs)
+
+        # C8 = 3 * Q_i * Q_j * C6
+        npt.assert_allclose(actual, [3.0 * 1.0 * 4.0 * 2.0], rtol=1e-12)
+
+    def test_bj_edge_energy(self) -> None:
+        # C6 and C8 are supplied directly, so this exercises the damped pair
+        # expression alone and not the C6 -> C8 promotion.
+        c6 = jnp.array([2.0])
+        c8 = jnp.array([24.0])
+        r4r2_pairs = jnp.array([[1.0, 4.0]])
+        damping = D3BJParameters(
+            s6=jnp.asarray(1.0),
+            s8=jnp.asarray(0.5),
+            a1=jnp.asarray(0.4),
+            a2=jnp.asarray(2.0),
+        )
+
+        actual = d3_bj_edge_energy(jnp.array([3.0]), c6, c8, r4r2_pairs, damping)
+
+        r0 = 0.4 * np.sqrt(3.0 * 1.0 * 4.0) + 2.0
+        expected = -(2.0 / (3.0**6 + r0**6) + 0.5 * 24.0 / (3.0**8 + r0**8))
+        npt.assert_allclose(actual, [expected], rtol=1e-12)
+
+
+class TestD3Energy:
+    def test_energy_uses_node_coordination_for_edge_c6(self) -> None:
+        reference_c6 = jnp.array([[2.0, 4.0], [4.0, 8.0]])
+        reference = D3ReferenceData(
+            covalent_radii=jnp.array([0.0, 0.5]),
+            r4r2=jnp.array([0.0, 1.5]),
+            reference_cn=jnp.array([[0.0, 0.0], [0.0, 1.0]]),
+            reference_c6=(jnp.zeros((2, 2, 2, 2)).at[1, 1].set(reference_c6)),
+            reference_mask=jnp.array([[False, False], [True, True]]),
+        )
+        damping = D3BJParameters(
+            s6=jnp.asarray(1.0),
+            s8=jnp.asarray(0.5),
+            a1=jnp.asarray(0.4),
+            a2=jnp.asarray(2.0),
+        )
+        parameters = D3Parameters(damping, reference, _table(10.0), _table(10.0))
+        positions = jnp.array([[0.0, 0.0, 0.0], [1.2, 0.0, 0.0], [3.5, 0.0, 0.0]])
+        graph = _graph(
+            positions=positions,
+            atomic_numbers=jnp.ones(3, dtype=int),
+            system_indices=jnp.zeros(3, dtype=int),
+            edge_indices=jnp.array([[0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1]]),
+        )
+
+        actual = float(d3_energy(GraphPotentialInput(parameters, graph)).data.data[0])
+
+        positions_np = np.asarray(positions)
+        coordination = np.zeros(3)
+        for i in range(3):
+            for j in range(3):
+                if i == j:
+                    continue
+                distance = np.linalg.norm(positions_np[j] - positions_np[i])
+                coordination[i] += 1.0 / (1.0 + np.exp(-16.0 * (1.0 / distance - 1.0)))
+        weights = np.exp(-4.0 * (coordination[:, None] - np.array([0.0, 1.0])) ** 2)
+        weights /= weights.sum(axis=-1, keepdims=True)
+        expected = 0.0
+        ratio = 3.0 * 1.5**2
+        damping_length = 0.4 * np.sqrt(ratio) + 2.0
+        for i in range(3):
+            for j in range(i + 1, 3):
+                distance = np.linalg.norm(positions_np[j] - positions_np[i])
+                c6 = weights[i] @ np.asarray(reference_c6) @ weights[j]
+                c8 = ratio * c6
+                expected -= c6 / (distance**6 + damping_length**6)
+                expected -= 0.5 * c8 / (distance**8 + damping_length**8)
+        npt.assert_allclose(actual, expected, rtol=1e-12)
+
+    def test_argon_dimer_matches_simple_dftd3(self) -> None:
+        graph = _argon_dimer_graph()
+        inp = GraphPotentialInput(_parameters(12.0), graph)
+        actual = d3_energy(inp).data.data
+        npt.assert_allclose(actual, [-0.010745634079163811], rtol=1e-12)
+
+        def energy(positions: Array) -> Array:
+            particles = Table(
+                graph.particles.keys,
+                _Particles(
+                    positions,
+                    graph.particles.data.atomic_numbers,
+                    graph.particles.data.system,
+                ),
+            )
+            moved = HyperGraph(particles, graph.systems, graph.edges)
+            return d3_energy(GraphPotentialInput(inp.parameters, moved)).data.data.sum()
+
+        gradient = jax.grad(energy)(graph.particles.data.positions)
+        expected_gradient = jnp.array(
+            [[-0.01031742754289883, 0.0, 0.0], [0.01031742754289883, 0.0, 0.0]]
+        )
+        npt.assert_allclose(gradient, expected_gradient, atol=1e-12)
+
+    def test_jit_and_padded_edges_remain_finite(self) -> None:
+        graph = _argon_dimer_graph(padded=True)
+        inp = GraphPotentialInput(_parameters(12.0), graph)
+        actual = jax.jit(d3_energy)(inp).data.data
+        npt.assert_allclose(actual, [-0.010745634079163811], rtol=1e-12)
+
+        def energy(positions: Array) -> Array:
+            particles = Table(
+                graph.particles.keys,
+                _Particles(
+                    positions,
+                    graph.particles.data.atomic_numbers,
+                    graph.particles.data.system,
+                ),
+            )
+            moved = HyperGraph(particles, graph.systems, graph.edges)
+            return d3_energy(GraphPotentialInput(inp.parameters, moved)).data.data.sum()
+
+        gradient = jax.grad(energy)(graph.particles.data.positions)
+        assert bool(jnp.isfinite(gradient).all())
+
+    def test_energy_cutoff_is_strict_and_resolved_per_system(self) -> None:
+        """System 1 sits at exactly ``r == cutoff`` and so contributes nothing.
+
+        D3 compares ``distances < cutoff`` strictly, matching every other kUPS
+        pair potential. System 0 keeps the same pair inside a wider cutoff.
+        """
+        graph = _graph(
+            positions=jnp.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [3.8, 0.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                    [3.8, 0.0, 0.0],
+                ]
+            ),
+            atomic_numbers=jnp.array([18, 18, 18, 18]),
+            system_indices=jnp.array([0, 0, 1, 1]),
+            edge_indices=jnp.array([[0, 1], [1, 0], [2, 3], [3, 2]]),
+        )
+        actual = d3_energy(GraphPotentialInput(_parameters(12.0, 3.8), graph)).data.data
+        npt.assert_allclose(actual, [-0.010745634079163811, 0.0], rtol=1e-12)
+
+    def test_cn_cutoff_bounds_the_environment_not_the_energy(self) -> None:
+        """An edge outside ``cn_cutoff`` but inside ``cutoff`` still has energy.
+
+        ``cn_cutoff`` bounds the coordination-number sum that selects C6;
+        ``cutoff`` bounds the dispersion sum. An edge between the two must be
+        paid for in the energy while leaving the environment untouched.
+        """
+        reference_c6 = jnp.array([[2.0, 4.0], [4.0, 8.0]])
+        reference = D3ReferenceData(
+            covalent_radii=jnp.array([0.0, 0.5]),
+            r4r2=jnp.array([0.0, 1.5]),
+            reference_cn=jnp.array([[0.0, 0.0], [0.0, 1.0]]),
+            reference_c6=(jnp.zeros((2, 2, 2, 2)).at[1, 1].set(reference_c6)),
+            reference_mask=jnp.array([[False, False], [True, True]]),
+        )
+        damping = D3BJParameters(
+            s6=jnp.asarray(1.0),
+            s8=jnp.asarray(0.5),
+            a1=jnp.asarray(0.4),
+            a2=jnp.asarray(2.0),
+        )
+        distance = 1.0
+        graph = _graph(
+            positions=jnp.array([[0.0, 0.0, 0.0], [distance, 0.0, 0.0]]),
+            atomic_numbers=jnp.ones(2, dtype=int),
+            system_indices=jnp.zeros(2, dtype=int),
+            edge_indices=jnp.array([[0, 1], [1, 0]]),
+        )
+
+        ratio = 3.0 * 1.5**2
+        damping_length = 0.4 * np.sqrt(ratio) + 2.0
+
+        def expected(coordination: float) -> float:
+            weights = np.exp(-4.0 * (coordination - np.array([0.0, 1.0])) ** 2)
+            weights /= weights.sum()
+            c6 = float(weights @ np.asarray(reference_c6) @ weights)
+            c8 = ratio * c6
+            return -(
+                c6 / (distance**6 + damping_length**6)
+                + 0.5 * c8 / (distance**8 + damping_length**8)
+            )
+
+        # cn_cutoff below the separation: the pair is energetic but invisible to
+        # the coordination number, so both atoms keep CN == 0.
+        outside_cn = D3Parameters(damping, reference, _table(10.0), _table(0.5))
+        without_environment = float(
+            d3_energy(GraphPotentialInput(outside_cn, graph)).data.data[0]
+        )
+        npt.assert_allclose(without_environment, expected(0.0), rtol=1e-12)
+
+        # widening cn_cutoff past the pair gives each atom
+        # CN = sigmoid(16 * (1.0 / 1.0 - 1)) = 0.5, which selects a different C6
+        inside_cn = D3Parameters(damping, reference, _table(10.0), _table(10.0))
+        with_environment = float(
+            d3_energy(GraphPotentialInput(inside_cn, graph)).data.data[0]
+        )
+        npt.assert_allclose(with_environment, expected(0.5), rtol=1e-12)
+
+        assert with_environment < without_environment
+
+    def test_isolated_atom_has_zero_energy(self) -> None:
+        graph = _graph(
+            positions=jnp.zeros((1, 3)),
+            atomic_numbers=jnp.array([18]),
+            system_indices=jnp.array([0]),
+            edge_indices=jnp.empty((0, 2), dtype=int),
+        )
+        actual = d3_energy(GraphPotentialInput(_parameters(12.0), graph)).data.data
+        npt.assert_array_equal(actual, [0.0])


### PR DESCRIPTION
First small follow-up to #287, limited to the two-body D3(BJ) mathematical kernel and graph energy function.

## Scope

* fractional D3 coordination numbers
* environment-dependent C6 interpolation
* C8 coefficients
* Becke-Johnson pair energy
* per-system energy and coordination cutoffs
* directed-edge reduction
* JAX-safe handling of padded edges

`d3_energy` is the kUPS graph boundary. The lower-level D3 functions operate on arrays.

Application integration, potential construction, parameter YAML, and reference-data loading are intentionally deferred to follow-up PRs.

## Validation

* 13 D3 tests pass
* full test suite passes
* `ruff check` passes
* `ruff format --check` passes
* `pyrefly check src/`: 0 errors

Tests include an independent NumPy evaluation of the D3 pipeline and an Ar dimer energy and gradient comparison against `simple-dftd3`.
