### PR TITLE
feat: expose per-system optimizer reset lenses

### DIFF
--- a/src/kups/core/utils/segmented_tree.py
+++ b/src/kups/core/utils/segmented_tree.py
@@ -1,7 +1,7 @@
 # Copyright 2024-2026 Cusp AI
 # SPDX-License-Identifier: Apache-2.0
 
-"""Per-segment tree operations for system-aware Optax transforms.
+"""Per-segment tree operations over pytrees partitioned by an ``Index``.
 
 When several independent systems are flattened into one
 [Table[ParticleId, ...]][kups.core.data.table.Table], the tree-global
@@ -13,14 +13,14 @@ This module provides three system-aware helpers that the kUPS-native
 transforms need to operate per-segment instead, all built directly on
 existing relational primitives:
 
-* [tree_vdot][kups.relaxation.transforms._segmented_tree.tree_vdot] —
+* [tree_vdot][kups.core.utils.segmented_tree.tree_vdot] —
   per-segment inner product, summed across pytree leaves.
-* [tree_segment_max][kups.relaxation.transforms._segmented_tree.tree_segment_max]
+* [tree_segment_max][kups.core.utils.segmented_tree.tree_segment_max]
   — per-segment row-wise maximum, taken across pytree leaves.
-* [tree_segment_norm][kups.relaxation.transforms._segmented_tree.tree_segment_norm]
+* [tree_segment_norm][kups.core.utils.segmented_tree.tree_segment_norm]
   — per-segment L2 norm across pytree leaves (sqrt of the per-segment
   inner product with itself).
-* [tree_scale_per_row][kups.relaxation.transforms._segmented_tree.tree_scale_per_row]
+* [tree_scale_per_row][kups.core.utils.segmented_tree.tree_scale_per_row]
   — multiply each row of every leaf by its segment's entry in a
   ``Table[K, Array]``.
 
@@ -39,7 +39,6 @@ how each leaf's leading axis partitions into segments.
 from __future__ import annotations
 
 import functools
-from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -52,7 +51,7 @@ from kups.core.typing import PyTree
 from kups.core.utils.jax import tree_structure
 
 
-def _is_index(x: Any) -> bool:
+def _is_index(x: object) -> bool:
     return isinstance(x, Index)
 
 

--- a/src/kups/relaxation/optimizer.py
+++ b/src/kups/relaxation/optimizer.py
@@ -9,12 +9,40 @@ factory out of here avoids a circular import with
 :mod:`kups.relaxation.transforms`.
 """
 
-from typing import Any, Protocol, no_type_check, override
+from typing import Any, Callable, Protocol, no_type_check, override
 
 import optax
+from jax import Array
 
+from kups.core.data.index import SupportsSorting
+from kups.core.data.table import Table
+from kups.core.lens import Lens, View
 from kups.core.typing import PyTree
-from kups.core.utils.jax import dataclass
+from kups.core.utils.jax import dataclass, field
+
+
+@dataclass(kw_only=True)
+class ResetLayout[OptState, Data, Indices]:
+    """Describe which optimizer fields to reset and which systems own their rows.
+
+    Fresh values come from ``Optimizer.init``; this layout only describes how to
+    select and mask them. Fields outside the lens, such as a shared history
+    cursor, survive replacement.
+
+    ``Data`` and ``Indices`` retain the concrete value and index-prefix types.
+    Their pytree alignment is checked by ``IndexLensPatch`` when applied.
+
+    Attributes:
+        fields: Lens reading and writing the resettable part of optimizer state.
+        system_index: View returning a matching pytree prefix of ``Index`` objects.
+            Each index maps selected data rows to systems so ``IndexLensPatch``
+            can apply the refill mask. Include reserved particle rows even when
+            unoccupied. For FIRE, velocity uses particle-to-system indices;
+            dt, alpha and counters use system indices.
+    """
+
+    fields: Lens[OptState, Data] = field(static=True)
+    system_index: View[OptState, Indices] = field(static=True)
 
 
 class Optimizer[Params, OptState](Protocol):
@@ -26,8 +54,23 @@ class Optimizer[Params, OptState](Protocol):
         updates: Params,
         state: OptState,
         params: Params | None = None,
+        *,
+        grad: Params | None = None,
+        energies: Table[SupportsSorting, Array] | None = None,
+        value_and_grad_fn: Callable[
+            [Params], tuple[Table[SupportsSorting, Array], Params]
+        ]
+        | None = None,
         **kwargs: Any,
-    ) -> tuple[Params, OptState]: ...
+    ) -> tuple[Params, OptState]:
+        """One optimisation step.
+
+        Besides the optax arguments, :class:`kups.relaxation.propagator.RelaxationPropagator`
+        passes the raw gradient ``grad``, the per-system ``energies`` and a
+        ``value_and_grad_fn`` evaluating trial points; line searches consume
+        them, plain transforms ignore them.
+        """
+        ...
 
 
 def apply_updates[Params](parameters: Params, updates: Params) -> Params:

--- a/src/kups/relaxation/transforms/clip_by_global_norm.py
+++ b/src/kups/relaxation/transforms/clip_by_global_norm.py
@@ -25,11 +25,11 @@ import jax.numpy as jnp
 from kups.core.data.index import Index
 from kups.core.typing import PyTree
 from kups.core.utils.jax import dataclass, field, tree_copy
-from kups.relaxation.optimizer import Optimizer
-from kups.relaxation.transforms._segmented_tree import (
+from kups.core.utils.segmented_tree import (
     tree_scale_per_row,
     tree_segment_norm,
 )
+from kups.relaxation.optimizer import Optimizer
 
 
 @dataclass

--- a/src/kups/relaxation/transforms/fire.py
+++ b/src/kups/relaxation/transforms/fire.py
@@ -50,14 +50,15 @@ from jax import Array
 
 from kups.core.data.index import Index, SupportsSorting
 from kups.core.data.table import Table
+from kups.core.lens import lens
 from kups.core.typing import PyTree
 from kups.core.utils.jax import dataclass, field, tree_copy
-from kups.relaxation.optimizer import Optimizer
-from kups.relaxation.transforms._segmented_tree import (
+from kups.core.utils.segmented_tree import (
     tree_scale_per_row,
     tree_segment_norm,
     tree_vdot,
 )
+from kups.relaxation.optimizer import Optimizer, ResetLayout
 
 
 @dataclass
@@ -78,6 +79,39 @@ class ScaleByFireState:
     alpha: Table[SupportsSorting, Array]
     n_pos: Table[SupportsSorting, Array]
     index_prefix: PyTree
+
+
+@dataclass(kw_only=True)
+class FireReset[Velocity, PerSystem]:
+    """Resettable FIRE fields, carrying either values or their index prefix.
+
+    ``Velocity`` follows the parameter tree; ``PerSystem`` is a table of values
+    or an index mapping those values to systems. Field meanings match
+    :class:`ScaleByFireState`.
+    """
+
+    velocity: Velocity
+    dt: PerSystem
+    alpha: PerSystem
+    n_pos: PerSystem
+
+
+def fire_reset_layout() -> ResetLayout[
+    ScaleByFireState,
+    FireReset[PyTree, Table[SupportsSorting, Array]],
+    FireReset[PyTree, Index[SupportsSorting]],
+]:
+    """Mutable FIRE fields; initialization supplies the configured dt and alpha."""
+    return ResetLayout(
+        fields=lens(
+            lambda s: FireReset(
+                velocity=s.velocity, dt=s.dt, alpha=s.alpha, n_pos=s.n_pos
+            )
+        ),
+        system_index=lambda s: FireReset(
+            velocity=s.index_prefix, dt=s.dt.index, alpha=s.dt.index, n_pos=s.dt.index
+        ),
+    )
 
 
 @dataclass

--- a/src/kups/relaxation/transforms/fire2.py
+++ b/src/kups/relaxation/transforms/fire2.py
@@ -51,16 +51,18 @@ from jax import Array
 
 from kups.core.data.index import Index, SupportsSorting
 from kups.core.data.table import Table
+from kups.core.lens import lens
 from kups.core.typing import PyTree
 from kups.core.utils.jax import dataclass, field, tree_copy
-from kups.relaxation.optimizer import Optimizer
-from kups.relaxation.transforms._segmented_tree import (
+from kups.core.utils.segmented_tree import (
     tree_clip_per_row,
     tree_scale_per_row,
     tree_segment_max,
     tree_vdot,
     tree_where_per_row,
 )
+from kups.relaxation.optimizer import Optimizer, ResetLayout
+from kups.relaxation.transforms.fire import FireReset
 
 
 @dataclass
@@ -74,8 +76,8 @@ class ScaleByFire2State:
         n_pos: Per-system count of consecutive positive-power steps
             (LAMMPS ``ntimestep - last_negative``; also the ABC-FIRE bias
             exponent).
-        n_total: Scalar — total update steps taken so far (drives
-            ``delaystep_start``).
+        n_total: Per-system count of update steps taken so far (drives
+            ``delaystep_start``); restarts when a system is reset.
         index_prefix: Tree prefix of the parameter pytree whose leaves are
             ``Index[K]`` objects, captured at init time.
     """
@@ -84,8 +86,41 @@ class ScaleByFire2State:
     dt: Table[SupportsSorting, Array]
     alpha: Table[SupportsSorting, Array]
     n_pos: Table[SupportsSorting, Array]
-    n_total: Array
+    n_total: Table[SupportsSorting, Array]
     index_prefix: PyTree
+
+
+@dataclass(kw_only=True)
+class Fire2Reset[Velocity, PerSystem](FireReset[Velocity, PerSystem]):
+    """FIRE reset fields plus the per-system warmup counter ``n_total``."""
+
+    n_total: PerSystem
+
+
+def fire2_reset_layout() -> ResetLayout[
+    ScaleByFire2State,
+    Fire2Reset[PyTree, Table[SupportsSorting, Array]],
+    Fire2Reset[PyTree, Index[SupportsSorting]],
+]:
+    """Mutable FIRE2 fields, including the per-system warmup counter."""
+    return ResetLayout(
+        fields=lens(
+            lambda s: Fire2Reset(
+                velocity=s.velocity,
+                dt=s.dt,
+                alpha=s.alpha,
+                n_pos=s.n_pos,
+                n_total=s.n_total,
+            )
+        ),
+        system_index=lambda s: Fire2Reset(
+            velocity=s.index_prefix,
+            dt=s.dt.index,
+            alpha=s.dt.index,
+            n_pos=s.dt.index,
+            n_total=s.dt.index,
+        ),
+    )
 
 
 @dataclass
@@ -168,7 +203,7 @@ class ScaleByFire2[Params](Optimizer[Params, ScaleByFire2State]):
             dt=Table(keys, jnp.full((n,), self.dt_start)),
             alpha=Table(keys, jnp.full((n,), self.alpha_start)),
             n_pos=Table(keys, jnp.zeros((n,), dtype=jnp.int32)),
-            n_total=jnp.asarray(0, dtype=jnp.int32),
+            n_total=Table(keys, jnp.zeros((n,), dtype=jnp.int32)),
             index_prefix=tree_copy(index_prefix),
         )
 
@@ -186,7 +221,7 @@ class ScaleByFire2[Params](Optimizer[Params, ScaleByFire2State]):
         dt_data = state.dt.data
         alpha_data = state.alpha.data
         float_dtype = dt_data.dtype
-        n_total = state.n_total + 1
+        n_total = state.n_total.data + 1
 
         # ``updates`` IS the force F = -∇L (optax convention); see module
         # docstring. P = v_old · F per system (LAMMPS: vdotfall).
@@ -318,6 +353,6 @@ class ScaleByFire2[Params](Optimizer[Params, ScaleByFire2State]):
             dt=state.dt.set_data(new_dt),
             alpha=state.alpha.set_data(new_alpha),
             n_pos=state.n_pos.set_data(new_n_pos),
-            n_total=n_total,
+            n_total=state.n_total.set_data(n_total),
             index_prefix=idx,
         )

--- a/src/kups/relaxation/transforms/lbfgs.py
+++ b/src/kups/relaxation/transforms/lbfgs.py
@@ -24,6 +24,7 @@ from jax import Array
 
 from kups.core.data.index import Index, SupportsSorting
 from kups.core.data.table import Table
+from kups.core.lens import lens
 from kups.core.typing import PyTree
 from kups.core.utils.jax import (
     PyTreeDef,
@@ -32,12 +33,13 @@ from kups.core.utils.jax import (
     tree_copy,
     tree_structure,
 )
-from kups.relaxation.optimizer import Optimizer
-from kups.relaxation.transforms._segmented_tree import (
+from kups.core.utils.segmented_tree import (
     _layout_and_leaves,
     tree_scale_per_row,
     tree_vdot,
+    tree_where_per_row,
 )
+from kups.relaxation.optimizer import Optimizer, ResetLayout
 
 
 @dataclass
@@ -50,7 +52,11 @@ class ScaleByAseLbfgsState[Params]:
     ``Table`` validation. ``treedef`` reconstructs the parameter pytree on exit.
 
     Attributes:
-        count: Total update steps taken so far (scalar int32).
+        count: Total update steps taken so far (scalar int32); selects the ring
+            slot written on each update.
+        steps: Per-system number of updates since that system was (re)initialised,
+            ``Table[K, Array]`` of shape ``(n_systems,)``; a system's first update
+            after a reset contributes an inert ``(0, 0, rho=0)`` pair.
         params: Last seen parameter leaves (flat list of arrays).
         updates: Last seen gradient/update leaves (flat list of arrays).
         diff_params_memory: Per leaf, stacked past parameter differences of
@@ -67,6 +73,7 @@ class ScaleByAseLbfgsState[Params]:
     """
 
     count: Array
+    steps: Table[SupportsSorting, Array]
     params: list[Array]
     updates: list[Array]
     diff_params_memory: list[Array]
@@ -74,6 +81,66 @@ class ScaleByAseLbfgsState[Params]:
     weights_memory: Table[SupportsSorting, Array]
     index_prefix: PyTree
     treedef: PyTreeDef[Params] = field(static=True)
+
+
+@dataclass(kw_only=True)
+class LbfgsReset[PerSystem, PerLeaf]:
+    """Resettable L-BFGS fields, carrying either values or their index prefix.
+
+    ``PerSystem`` is a table or system index; ``PerLeaf`` is a list of arrays or
+    matching indices. History indices broadcast over the leading memory axis.
+    Field meanings match :class:`ScaleByAseLbfgsState`; the shared ring cursor
+    ``count`` is deliberately excluded.
+    """
+
+    steps: PerSystem
+    weights_memory: PerSystem
+    params: PerLeaf
+    updates: PerLeaf
+    diff_params_memory: PerLeaf
+    diff_updates_memory: PerLeaf
+
+
+type LbfgsResetIndices = LbfgsReset[
+    Index[SupportsSorting], list[Index[SupportsSorting]]
+]
+
+
+def lbfgs_reset_layout[Params]() -> ResetLayout[
+    ScaleByAseLbfgsState[Params],
+    LbfgsReset[Table[SupportsSorting, Array], list[Array]],
+    LbfgsResetIndices,
+]:
+    """Mutable history fields and their row indices; preserve the shared ring cursor.
+
+    Copying initialization blanks the selected history. The first update after
+    reset contributes an inert pair, independently of the preserved ring phase.
+    """
+    fields = lens(
+        lambda s: LbfgsReset(
+            steps=s.steps,
+            weights_memory=s.weights_memory,
+            params=s.params,
+            updates=s.updates,
+            diff_params_memory=s.diff_params_memory,
+            diff_updates_memory=s.diff_updates_memory,
+        ),
+        cls=ScaleByAseLbfgsState[Params],
+    )
+
+    def indices(s: ScaleByAseLbfgsState[Params]) -> LbfgsResetIndices:
+        idx, _ = _layout_and_leaves(s.index_prefix, s.treedef.unflatten(s.params))
+        history_idx = [i[None] for i in idx]  # Broadcast over the history axis.
+        return LbfgsReset(
+            steps=s.steps.index,
+            weights_memory=s.steps.index,
+            params=idx,
+            updates=idx,
+            diff_params_memory=history_idx,
+            diff_updates_memory=history_idx,
+        )
+
+    return ResetLayout(fields=fields, system_index=indices)
 
 
 @dataclass
@@ -125,6 +192,7 @@ class ScaleByAseLbfgs[Params](Optimizer[Params, ScaleByAseLbfgsState[Params]]):
         ]
         return ScaleByAseLbfgsState(
             count=jnp.asarray(0, dtype=jnp.int32),
+            steps=Table(keys, jnp.zeros((n_systems,), dtype=jnp.int32)),
             params=zeros,
             updates=[jnp.zeros_like(x) for x in param_leaves],
             diff_params_memory=stacked,
@@ -162,7 +230,9 @@ class ScaleByAseLbfgs[Params](Optimizer[Params, ScaleByAseLbfgsState[Params]]):
         sy = tree_vdot(diff_updates, diff_params, idx).data  # (s·y) per system
         weight = jnp.where(sy == 0.0, 0.0, 1.0 / sy)
 
-        is_first = state.count == 0
+        # Per system: is this the first update since (re)initialisation?
+        is_first = state.steps.data == 0
+        first = Table(keys, is_first)
 
         # Per-system initial inverse-Hessian scale γ.
         if self.adaptive_scale:
@@ -175,9 +245,10 @@ class ScaleByAseLbfgs[Params](Optimizer[Params, ScaleByAseLbfgsState[Params]]):
             )
         gamma = Table(keys, gamma_data)
 
-        # Differences are undefined at the very first iteration; stay zero.
-        diff_params = [jnp.where(is_first, jnp.zeros_like(x), x) for x in diff_params]
-        diff_updates = [jnp.where(is_first, jnp.zeros_like(x), x) for x in diff_updates]
+        # Differences are undefined at a system's first iteration; stay zero.
+        zeros = [jnp.zeros_like(x) for x in diff_params]
+        diff_params = tree_where_per_row(first, zeros, diff_params, idx)
+        diff_updates = tree_where_per_row(first, zeros, diff_updates, idx)
         weight = jnp.where(is_first, jnp.zeros_like(weight), weight)
 
         diff_params_memory = [
@@ -204,6 +275,7 @@ class ScaleByAseLbfgs[Params](Optimizer[Params, ScaleByAseLbfgsState[Params]]):
         precond = state.treedef.unflatten(precond_leaves)
         return precond, ScaleByAseLbfgsState(
             count=state.count + 1,
+            steps=state.steps.set_data(state.steps.data + 1),
             params=param_leaves,
             updates=update_leaves,
             diff_params_memory=diff_params_memory,

--- a/src/kups/relaxation/transforms/linesearch.py
+++ b/src/kups/relaxation/transforms/linesearch.py
@@ -66,10 +66,11 @@ from jax import Array
 
 from kups.core.data.index import Index, SupportsSorting
 from kups.core.data.table import Table
+from kups.core.lens import lens
 from kups.core.typing import PyTree
 from kups.core.utils.jax import dataclass, field, tree_copy
-from kups.relaxation.optimizer import Optimizer
-from kups.relaxation.transforms._segmented_tree import tree_scale_per_row, tree_vdot
+from kups.core.utils.segmented_tree import tree_scale_per_row, tree_vdot
+from kups.relaxation.optimizer import Optimizer, ResetLayout
 
 type ValueAndGradFn = Callable[[PyTree], tuple[Table[SupportsSorting, Array], PyTree]]
 """Maps trial params to ``(per-system energies, gradient pytree)``."""
@@ -100,6 +101,21 @@ def _init_state(parameters: PyTree, index_prefix: PyTree | None) -> LineSearchSt
     return LineSearchState(
         index_prefix=tree_copy(index_prefix), prev_phi0=jnp.full(len(keys), jnp.nan)
     )
+
+
+def linesearch_reset_layout() -> ResetLayout[
+    LineSearchState, Array, Index[SupportsSorting]
+]:
+    """Previous energies, indexed by system; shared by both line searches."""
+
+    def indices(state: LineSearchState) -> Index[SupportsSorting]:
+        leaves = jax.tree.leaves(
+            state.index_prefix, is_leaf=lambda x: isinstance(x, Index)
+        )
+        keys = next(leaf for leaf in leaves if isinstance(leaf, Index)).keys
+        return Table(keys, state.prev_phi0).index
+
+    return ResetLayout(fields=lens(lambda s: s.prev_phi0), system_index=indices)
 
 
 def _setup(

--- a/src/kups/relaxation/transforms/max_step_size.py
+++ b/src/kups/relaxation/transforms/max_step_size.py
@@ -21,11 +21,11 @@ import jax.numpy as jnp
 from kups.core.data.index import Index
 from kups.core.typing import PyTree
 from kups.core.utils.jax import dataclass, field, tree_copy
-from kups.relaxation.optimizer import Optimizer
-from kups.relaxation.transforms._segmented_tree import (
+from kups.core.utils.segmented_tree import (
     tree_scale_per_row,
     tree_segment_max,
 )
+from kups.relaxation.optimizer import Optimizer
 
 
 @dataclass

--- a/test/relaxation/transforms/test_fire2.py
+++ b/test/relaxation/transforms/test_fire2.py
@@ -62,7 +62,7 @@ def _single_sys_state(
         dt=Table(keys, jnp.asarray([dt], dtype=jnp.float32)),
         alpha=Table(keys, jnp.asarray([alpha], dtype=jnp.float32)),
         n_pos=Table(keys, jnp.asarray([n_pos], dtype=jnp.int32)),
-        n_total=jnp.asarray(n_total, dtype=jnp.int32),
+        n_total=Table(keys, jnp.asarray([n_total], dtype=jnp.int32)),
         index_prefix=_system_index([0] * velocity.shape[0], 1),
     )
 
@@ -79,7 +79,7 @@ class TestScaleByFire2GlobalFallback:
         npt.assert_allclose(state.dt.data, jnp.array([0.1]))
         npt.assert_allclose(state.alpha.data, jnp.array([0.25]))
         assert int(state.n_pos.data[0]) == 0
-        assert int(state.n_total) == 0
+        assert int(state.n_total.data[0]) == 0
 
     def test_init_pytree(self):
         opt = ScaleByFire2()
@@ -96,7 +96,7 @@ class TestScaleByFire2GlobalFallback:
         force = jnp.array([1.0])  # F = -∇L for ∇L = -1.0
         for i in range(4):
             _, state = opt.update(force, state, params)
-            assert int(state.n_total) == i + 1
+            assert int(state.n_total.data[0]) == i + 1
 
     def test_positive_power_increases_n_pos(self):
         opt = ScaleByFire2(dt_start=0.1, n_min=2, delaystep_start=False)
@@ -149,7 +149,7 @@ class TestScaleByFire2GlobalFallback:
                 dt=float(state.dt.data[0]),
                 alpha=float(state.alpha.data[0]),
                 n_pos=int(state.n_pos.data[0]),
-                n_total=int(state.n_total),
+                n_total=int(state.n_total.data[0]),
             )
         assert float(state.dt.data[0]) >= 0.01 - 1e-6
 
@@ -403,7 +403,7 @@ class TestScaleByFire2PerSystem:
             dt=Table(keys, jnp.array([1.0, 1.0])),
             alpha=Table(keys, jnp.array([0.25, 0.25])),
             n_pos=Table(keys, jnp.array([10, 10], dtype=jnp.int32)),
-            n_total=jnp.asarray(20, dtype=jnp.int32),
+            n_total=Table(keys, jnp.array([20, 20], dtype=jnp.int32)),
             index_prefix=idx,
         )
         params = jnp.array([0.0, 0.0, 0.0, 0.0])

--- a/test/relaxation/transforms/test_reset.py
+++ b/test/relaxation/transforms/test_reset.py
@@ -1,0 +1,300 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Indexed state lenses: a reset system continues identically to a fresh run."""
+
+from __future__ import annotations
+
+from typing import Callable, assert_type
+
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+import optax
+import pytest
+
+from kups.core.data import Index, Table
+from kups.core.data.index import SupportsSorting
+from kups.core.lens import lens
+from kups.core.patch import IndexLensPatch
+from kups.core.typing import SystemId
+from kups.relaxation.optimizer import (
+    ChainOptimizer,
+    ChainOptState,
+    Optimizer,
+    ResetLayout,
+    chain,
+)
+from kups.relaxation.transforms import (
+    ClipByGlobalNorm,
+    MaxStepSize,
+    ScaleByAseLbfgs,
+    ScaleByBacktrackingLinesearch,
+    ScaleByFire,
+    ScaleByFire2,
+    ScaleByMoreThuenteLinesearch,
+)
+from kups.relaxation.transforms.fire import FireReset, fire_reset_layout
+from kups.relaxation.transforms.fire2 import fire2_reset_layout
+from kups.relaxation.transforms.lbfgs import LbfgsResetIndices, lbfgs_reset_layout
+from kups.relaxation.transforms.linesearch import linesearch_reset_layout
+
+# Two systems: rows 0-2 belong to system 0, rows 3-4 to system 1.
+PREFIX = Index.integer(jnp.array([0, 0, 0, 1, 1]), n=2, label=SystemId)
+SINGLE = Index.integer(jnp.array([0, 0]), n=1, label=SystemId)
+X0 = jnp.array(
+    [
+        [1.0, 0.0, 0.0],
+        [0.0, 2.0, 0.0],
+        [0.0, 0.0, 3.0],
+        [1.0, 1.0, 0.0],
+        [0.0, 1.0, 1.0],
+    ]
+)
+STIFFNESS = jnp.array([1.0, 1.0, 1.0, 2.0, 2.0])[:, None]
+
+
+def _objective(prefix: Index[SystemId], x0: jax.Array, k: jax.Array):
+    """Per-system harmonic wells ``E_s = sum_i k_i |x_i - x0_i|^2 / 2``."""
+
+    def value_and_grad(x: jax.Array):
+        grad = k * (x - x0)
+        energies = prefix.sum_over(0.5 * jnp.sum(grad * (x - x0), axis=-1))
+        return energies, grad
+
+    return value_and_grad
+
+
+def _run[OptState](
+    opt: Optimizer[jax.Array, OptState],
+    params: jax.Array,
+    state: OptState,
+    prefix: Index[SystemId],
+    x0: jax.Array,
+    k: jax.Array,
+    steps: int,
+) -> tuple[jax.Array, OptState]:
+    vg = _objective(prefix, x0, k)
+    for _ in range(steps):
+        energies, grad = vg(params)
+        updates, state = opt.update(
+            grad, state, params, grad=grad, energies=energies, value_and_grad_fn=vg
+        )
+        params = params + updates
+    return params, state
+
+
+OPTIMIZERS: dict[str, Callable[[], ChainOptimizer[jax.Array]]] = {
+    "fire": lambda: chain(optax.scale(-1.0), ScaleByFire[jax.Array](dt_start=0.1)),
+    "fire2": lambda: chain(
+        optax.scale(-1.0), ScaleByFire2[jax.Array](dt_start=0.1, n_min=3)
+    ),
+    "fire2_abc": lambda: chain(
+        optax.scale(-1.0), ScaleByFire2[jax.Array](dt_start=0.1, use_abc=True)
+    ),
+    "lbfgs": lambda: chain(
+        ScaleByAseLbfgs[jax.Array](memory_size=3), optax.scale(-1.0)
+    ),
+    "lbfgs_adaptive": lambda: chain(
+        ScaleByAseLbfgs[jax.Array](memory_size=3, adaptive_scale=True),
+        optax.scale(-1.0),
+    ),
+    "lbfgs_more_thuente": lambda: chain(
+        ScaleByAseLbfgs[jax.Array](memory_size=3),
+        optax.scale(-1.0),
+        ScaleByMoreThuenteLinesearch[jax.Array](),
+    ),
+    "lbfgs_backtracking": lambda: chain(
+        ScaleByAseLbfgs[jax.Array](memory_size=3),
+        optax.scale(-1.0),
+        ScaleByBacktrackingLinesearch[jax.Array](),
+    ),
+    "fire_clipped": lambda: chain(
+        optax.scale(-1.0),
+        ScaleByFire[jax.Array](dt_start=0.1),
+        ClipByGlobalNorm[jax.Array](max_norm=0.5),
+        MaxStepSize[jax.Array](max_step_size=0.2),
+    ),
+}
+
+
+type ResetIndices = (
+    FireReset[Index[SupportsSorting], Index[SupportsSorting]]
+    | LbfgsResetIndices
+    | tuple[LbfgsResetIndices, Index[SupportsSorting]]
+)
+
+
+def _layout(name: str) -> ResetLayout[ChainOptState, object, ResetIndices]:
+    if name.startswith("fire"):
+        fire = fire2_reset_layout() if name.startswith("fire2") else fire_reset_layout()
+        return ResetLayout(
+            fields=lens(lambda s: s[1]).nest(fire.fields),
+            system_index=lambda s: fire.system_index(s[1]),
+        )
+    lbfgs = lbfgs_reset_layout()
+    outer = lens(lambda s: s[0], cls=tuple).nest(lbfgs.fields)
+    if name in ("lbfgs_more_thuente", "lbfgs_backtracking"):
+        search = linesearch_reset_layout()
+        return ResetLayout(
+            fields=outer.merge(lens(lambda s: s[2]).nest(search.fields)),
+            system_index=lambda s: (
+                lbfgs.system_index(s[0]),
+                search.system_index(s[2]),
+            ),
+        )
+    return ResetLayout(fields=outer, system_index=lambda s: lbfgs.system_index(s[0]))
+
+
+def _replace[State, Data, Indices](
+    state: State,
+    fresh: State,
+    layout: ResetLayout[State, Data, Indices],
+    mask: Table[SystemId, jax.Array],
+) -> State:
+    return IndexLensPatch(
+        layout.fields.get(fresh), layout.system_index(state), layout.fields
+    )(state, mask)
+
+
+@pytest.mark.parametrize("name", sorted(OPTIMIZERS))
+@pytest.mark.parametrize("k_before", [1, 5])
+def test_reset_system_matches_fresh_run(name: str, k_before: int):
+    opt = OPTIMIZERS[name]()
+    start = X0 + 0.7
+    state = opt.init(start, PREFIX)
+    params, state = _run(opt, start, state, PREFIX, X0, STIFFNESS, k_before)
+
+    # System 1 receives a new structure; system 0 keeps relaxing.
+    new_rows = jnp.array([[3.0, 0.0, 1.0], [0.5, 2.0, 0.0]])
+    params_reset = params.at[3:].set(new_rows)
+    mask = Table((SystemId(0), SystemId(1)), jnp.array([False, True]))
+    state_reset = _replace(state, opt.init(params_reset, PREFIX), _layout(name), mask)
+    after, _ = _run(opt, params_reset, state_reset, PREFIX, X0, STIFFNESS, 4)
+
+    # Fresh single-system run of the new structure.
+    fresh_state = opt.init(new_rows, SINGLE)
+    fresh, _ = _run(opt, new_rows, fresh_state, SINGLE, X0[3:], STIFFNESS[3:], 4)
+    npt.assert_array_equal(after[3:], fresh)
+
+    # System 0 is untouched by the reset.
+    continued, _ = _run(opt, params, state, PREFIX, X0, STIFFNESS, 4)
+    npt.assert_array_equal(after[:3], continued[:3])
+
+
+def test_fire2_n_total_is_per_system():
+    opt = ScaleByFire2[jax.Array](dt_start=0.1, n_min=3)
+    state = opt.init(X0, PREFIX)
+    for _ in range(4):
+        _, state = opt.update(-STIFFNESS * (X0 + 0.5 - X0), state, X0 + 0.5)
+    npt.assert_array_equal(state.n_total.data, [4, 4])
+    mask = Table((SystemId(0), SystemId(1)), jnp.array([False, True]))
+    reset = _replace(state, opt.init(X0, PREFIX), fire2_reset_layout(), mask)
+    npt.assert_array_equal(reset.n_total.data, [4, 0])
+    npt.assert_array_equal(reset.n_pos.data[0], state.n_pos.data[0])
+    npt.assert_array_equal(reset.velocity[3:], 0.0)
+    npt.assert_array_equal(reset.velocity[:3], state.velocity[:3])
+
+
+def test_lbfgs_reset_blanks_history_rows_only():
+    opt = ScaleByAseLbfgs[jax.Array](memory_size=3)
+    state = opt.init(X0, PREFIX)
+    params = X0 + 0.5
+    params, state = _run(
+        chain(opt, optax.scale(-1.0)),
+        params,
+        (state, optax.EmptyState()),
+        PREFIX,
+        X0,
+        STIFFNESS,
+        4,
+    )
+    lbfgs_state = state[0]
+    mask = Table((SystemId(0), SystemId(1)), jnp.array([False, True]))
+    reset = _replace(lbfgs_state, opt.init(params, PREFIX), lbfgs_reset_layout(), mask)
+    assert int(reset.count) == int(lbfgs_state.count)
+    npt.assert_array_equal(reset.steps.data, [4, 0])
+    for mem in reset.diff_params_memory + reset.diff_updates_memory:
+        npt.assert_array_equal(mem[:, 3:], 0.0)
+    npt.assert_array_equal(
+        reset.diff_params_memory[0][:, :3], lbfgs_state.diff_params_memory[0][:, :3]
+    )
+    npt.assert_array_equal(reset.weights_memory.data[1], 0.0)
+    npt.assert_array_equal(
+        reset.weights_memory.data[0], lbfgs_state.weights_memory.data[0]
+    )
+    npt.assert_array_equal(reset.params[0][3:], 0.0)
+    npt.assert_array_equal(reset.updates[0][3:], 0.0)
+
+
+def test_ordinary_chain_does_not_require_reset_support() -> None:
+    opt = chain(optax.adam(0.1))
+    state = opt.init(X0, PREFIX)
+    updates, _ = opt.update(X0, state, X0)
+    assert updates.shape == X0.shape
+
+
+@pytest.mark.parametrize("name", sorted(OPTIMIZERS))
+def test_reset_is_jittable(name: str) -> None:
+    opt = OPTIMIZERS[name]()
+    state = opt.init(X0, PREFIX)
+    _, state = _run(opt, X0 + 0.5, state, PREFIX, X0, STIFFNESS, 4)
+    mask = Table((SystemId(0), SystemId(1)), jnp.array([False, True]))
+    layout = _layout(name)
+
+    def replace(s: ChainOptState) -> ChainOptState:
+        return _replace(s, opt.init(X0, PREFIX), layout, mask)
+
+    reset = jax.jit(replace)(state)
+    assert jax.tree.structure(reset) == jax.tree.structure(state)
+    for eager, compiled in zip(
+        jax.tree.leaves(replace(state)), jax.tree.leaves(reset), strict=True
+    ):
+        npt.assert_array_equal(eager, compiled)
+
+
+@pytest.mark.parametrize("name", sorted(OPTIMIZERS))
+def test_reset_lens_round_trip(name: str) -> None:
+    opt = OPTIMIZERS[name]()
+    state = opt.init(X0, PREFIX)
+    _, state = _run(opt, X0 + 0.5, state, PREFIX, X0, STIFFNESS, 4)
+    fields = _layout(name).fields
+    restored = fields.set(state, fields.get(state))
+    for before, after in zip(
+        jax.tree.leaves(state), jax.tree.leaves(restored), strict=True
+    ):
+        npt.assert_array_equal(before, after)
+
+
+def test_reset_projection_field_types() -> None:
+    fire_state = ScaleByFire[jax.Array]().init(X0, PREFIX)
+    fire = fire_reset_layout()
+    assert_type(fire.fields.get(fire_state).dt, Table[SupportsSorting, jax.Array])
+    assert_type(fire.system_index(fire_state).dt, Index[SupportsSorting])
+
+    fire2_state = ScaleByFire2[jax.Array]().init(X0, PREFIX)
+    fire2 = fire2_reset_layout()
+    assert_type(
+        fire2.fields.get(fire2_state).n_total, Table[SupportsSorting, jax.Array]
+    )
+    assert_type(fire2.system_index(fire2_state).n_total, Index[SupportsSorting])
+
+    lbfgs_state = ScaleByAseLbfgs[jax.Array](memory_size=3).init(X0, PREFIX)
+    lbfgs = lbfgs_reset_layout()
+    assert_type(lbfgs.fields.get(lbfgs_state).diff_params_memory, list[jax.Array])
+    assert_type(lbfgs.system_index(lbfgs_state), LbfgsResetIndices)
+    assert_type(
+        lbfgs.system_index(lbfgs_state).diff_params_memory, list[Index[SupportsSorting]]
+    )
+
+
+def test_reset_layout_preserves_concrete_index_type() -> None:
+    layout: ResetLayout[
+        tuple[Index[SystemId], jax.Array], jax.Array, Index[SystemId]
+    ] = ResetLayout(
+        fields=lens(lambda s: s[1], cls=tuple[Index[SystemId], jax.Array]),
+        system_index=lambda s: s[0],
+    )
+    indices = layout.system_index((PREFIX, X0))
+    assert_type(indices, Index[SystemId])
+    npt.assert_array_equal(indices.indices, PREFIX.indices)

--- a/test/relaxation/transforms/test_segmented_tree.py
+++ b/test/relaxation/transforms/test_segmented_tree.py
@@ -7,11 +7,12 @@ import jax
 import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
+from jax.typing import ArrayLike
 
 from kups.core.data.index import Index
 from kups.core.data.table import Table
 from kups.core.typing import SystemId
-from kups.relaxation.transforms._segmented_tree import (
+from kups.core.utils.segmented_tree import (
     tree_clip_per_row,
     tree_scale_per_row,
     tree_segment_max,
@@ -26,7 +27,9 @@ def _system_index(system_ids: list[int], num_systems: int) -> Index[SystemId]:
     return Index(keys, jnp.array(system_ids), _cls=SystemId)
 
 
-def _system_table(values, num_systems: int) -> Table[SystemId, jax.Array]:
+def _system_table(
+    values: ArrayLike | list[float] | list[bool], num_systems: int
+) -> Table[SystemId, jax.Array]:
     keys = tuple(SystemId(i) for i in range(num_systems))
     return Table(keys, jnp.asarray(values), _cls=SystemId)
 


### PR DESCRIPTION
## Scope

Expose resettable optimizer fields through ordinary lenses and matching
system-index views. `ResetLayout` is a frozen, keyword-only dataclass: `fields`
selects the resettable data through a lens, and `system_index` maps its rows to
systems for masking. Both fields are documented and static. Fresh values come
from `init`; the existing `IndexLensPatch` handles masked replacement. Chains
compose layouts explicitly with `nest` and `merge`; no capability discovery or
new reset behavior is introduced.

`ResetLayout[OptState, Data, Indices]` preserves the selected data and index-prefix
types. L-BFGS and line searches declare concrete index types; FIRE/FIRE2 retain
their existing parameter-shaped `PyTree` boundary.

Native projections are named generic dataclasses (`FireReset`, `Fire2Reset`,
`LbfgsReset`), used for both values and their matching index prefixes. FIRE2
extends the FIRE fields with its warmup counter. Ordinary lenses derive the
setters directly; there is no reset-state conversion layer or custom setter.

FIRE/FIRE2 restart their per-system adaptation and warmup state. L-BFGS clears
selected history while preserving its shared ring cursor; its index prefix
broadcasts over the history axis. Both line searches share one layout.
Stateless transforms need no reset method. Ordinary optimizers remain init/update
only, including stateful Optax transforms.

Move the existing segmented-tree helpers to core for reuse. No streaming
application or driver is introduced.

## Validation

Reset tests compare reused systems against fresh independent runs, including
FIRE/FIRE2, L-BFGS and line searches, and verify untouched systems, lens round
trips and eager/JIT reset parity for each combination. Static assertions check
named field types. Optimizer regressions and whole-source strict typing pass.
