### PR TITLE
refactor: share typed relaxation data and masked numerical step

### DIFF
--- a/src/kups/application/relaxation/data.py
+++ b/src/kups/application/relaxation/data.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import ase
 import jax.numpy as jnp
-import optax
 from jax import Array
 from pydantic import BaseModel
 
@@ -23,8 +22,9 @@ from kups.core.data import Table
 from kups.core.data.index import Index
 from kups.core.lens import bind
 from kups.core.neighborlist import UniversalNeighborlistParameters
-from kups.core.typing import ExclusionId, ParticleId, SystemId
+from kups.core.typing import ExclusionId, IsState, ParticleId, SystemId
 from kups.core.utils.jax import dataclass, field, tree_zeros_like
+from kups.potential.common.geometry import PositionsAndCell, PositionsAndCellIndex
 from kups.relaxation.config import TransformationConfig
 
 
@@ -71,7 +71,7 @@ class RelaxSystems:
 
 
 @dataclass
-class RelaxState:
+class RelaxState[OptState]:
     """Force-field-agnostic relaxation state.
 
     The potential is built with its parameters at construction time (via the
@@ -81,8 +81,37 @@ class RelaxState:
     particles: Table[ParticleId, RelaxParticles]
     systems: Table[SystemId, RelaxSystems]
     neighborlist_params: UniversalNeighborlistParameters
-    opt_state: optax.OptState
+    opt_state: OptState
     step: Array
+
+
+type IsRelaxData = IsState[RelaxParticles, RelaxSystems]
+
+
+def relax_parameters(
+    particles: Table[ParticleId, RelaxParticles],
+    systems: Table[SystemId, RelaxSystems],
+) -> PositionsAndCell:
+    """The optimizer DOF carrier ``(positions, cell)`` of a relaxation batch."""
+    return PositionsAndCell(
+        particles.map_data(lambda p: p.positions), systems.map_data(lambda s: s.cell)
+    )
+
+
+def relax_index_prefix(
+    particles: Table[ParticleId, RelaxParticles],
+    systems: Table[SystemId, RelaxSystems],
+) -> PositionsAndCellIndex:
+    """Index prefix mapping every DOF to its system (per-particle and per-cell)."""
+    return PositionsAndCellIndex(particles.data.system, systems.index)
+
+
+def relax_gradients(state: IsRelaxData) -> PositionsAndCell:
+    """The cached DOF gradients ``∂E/∂u`` held in a relaxation state."""
+    return PositionsAndCell(
+        state.particles.map_data(lambda p: p.position_gradients),
+        state.systems.map_data(lambda s: s.cell_gradients),
+    )
 
 
 class RelaxRunConfig(BaseModel):
@@ -102,6 +131,92 @@ class RelaxRunConfig(BaseModel):
     """Whether to also relax lattice vectors."""
 
 
+def relax_cell(cell: Cell[AnyPeriodicity], n_atoms: Array) -> Cell[AnyPeriodicity]:
+    """Wrap unbatched cells in the relaxation's log-deformation frame.
+
+    ``cell_factor = n_atoms`` (ASE's ``exp_cell_factor``) balances the extensive
+    cell-virial gradient against the per-atom forces in the joint optimiser.
+
+    Args:
+        cell: Cell(s) with a plain frame; a leading batch axis is added if the
+            frame is unbatched.
+        n_atoms: Atom count per system, shape ``(n_systems,)``.
+    """
+    if cell.vectors.ndim == 2:
+        cell = cell[None]
+    # An empty system (a streaming slot without work) keeps a finite factor.
+    cell_factor = jnp.maximum(n_atoms, 1)
+    return bind(cell, lambda x: x.frame).apply(
+        lambda f: DeformedFrame.from_frame(
+            f, cell_factor=cell_factor, deformation=MatrixLogFrame
+        )
+    )
+
+
+def relax_systems(cell: Cell[AnyPeriodicity]) -> RelaxSystems:
+    """System rows with zeroed caches for a batched relaxation cell."""
+    return RelaxSystems(
+        cell=cell,
+        cell_gradients=tree_zeros_like(cell),
+        potential_energy=jnp.zeros(cell.vectors.shape[0], cell.vectors.dtype),
+    )
+
+
+def relax_particles(
+    particles: Particles,
+    *,
+    position_gradients: Array | None = None,
+    exclusion: Index[ExclusionId] | None = None,
+) -> RelaxParticles:
+    """Relaxation particle rows from plain particles, gradients zeroed by default."""
+    return RelaxParticles(
+        positions=particles.positions,
+        masses=particles.masses,
+        atomic_numbers=particles.atomic_numbers,
+        charges=particles.charges,
+        labels=particles.labels,
+        system=particles.system,
+        position_gradients=(
+            jnp.zeros_like(particles.positions)
+            if position_gradients is None
+            else position_gradients
+        ),
+        exclusion=(
+            default_exclusion(len(particles.positions))
+            if exclusion is None
+            else exclusion
+        ),
+    )
+
+
+def relax_state_from_particles(
+    particles: Table[ParticleId, Particles], cell: Cell[AnyPeriodicity]
+) -> tuple[Table[ParticleId, RelaxParticles], Table[SystemId, RelaxSystems]]:
+    """Build relaxation particle and system tables from plain particles and a cell.
+
+    Args:
+        particles: Particles of one or more systems. Keys are preserved;
+            out-of-bounds system references denote padding.
+        cell: Their cells in system-key order, unbatched for a single system.
+
+    Returns:
+        Tuple of ``(particles, systems)`` ready for relaxation propagators.
+    """
+    system = particles.data.system
+    if system.indices.shape != (len(particles),):
+        raise ValueError("Expected one system reference per particle.")
+    expected_shape = (system.num_labels, 3, 3)
+    if cell.vectors.shape != expected_shape and not (
+        system.num_labels == 1 and cell.vectors.shape == (3, 3)
+    ):
+        raise ValueError(f"Expected cell vectors with shape {expected_shape}.")
+    n_atoms = system.counts.data.astype(particles.data.positions.dtype)
+    return (
+        particles.map_data(relax_particles),
+        Table(system.keys, relax_systems(relax_cell(cell, n_atoms)), _cls=SystemId),
+    )
+
+
 def relax_state_from_ase(
     atoms: ase.Atoms | str | Path,
 ) -> tuple[Table[ParticleId, RelaxParticles], Table[SystemId, RelaxSystems]]:
@@ -115,35 +230,4 @@ def relax_state_from_ase(
         Tuple of ``(particles, systems)`` ready for relaxation propagators.
     """
     p, cell, _ = particles_from_ase(atoms)
-    particles = p.set_data(
-        RelaxParticles(
-            positions=p.data.positions,
-            masses=p.data.masses,
-            atomic_numbers=p.data.atomic_numbers,
-            charges=p.data.charges,
-            labels=p.data.labels,
-            system=p.data.system,
-            position_gradients=jnp.zeros_like(p.data.positions),
-        ),
-    )
-    # cell_factor = per-system atom count (ASE's exp_cell_factor) balances the
-    # extensive cell-virial gradient against the per-atom forces in the joint
-    # optimiser. bincount over the system index gives one count per system.
-    n_systems = p.data.system.num_labels
-    cell_factor = jnp.bincount(p.data.system.indices, length=n_systems).astype(
-        p.data.positions.dtype
-    )
-    cell = bind(cell[None], lambda x: x.frame).apply(
-        lambda f: DeformedFrame.from_frame(
-            f, cell_factor=cell_factor, deformation=MatrixLogFrame
-        )
-    )
-    systems = Table.arange(
-        RelaxSystems(
-            cell=cell,
-            cell_gradients=tree_zeros_like(cell),
-            potential_energy=jnp.zeros(n_systems),
-        ),
-        label=SystemId,
-    )
-    return particles, systems
+    return relax_state_from_particles(p, cell)

--- a/src/kups/application/relaxation/logging.py
+++ b/src/kups/application/relaxation/logging.py
@@ -5,18 +5,21 @@
 
 from __future__ import annotations
 
-import jax
-import jax.numpy as jnp
 from jax import Array
 
-from kups.application.relaxation.data import RelaxParticles, RelaxSystems
+from kups.application.relaxation.data import (
+    IsRelaxData,
+    RelaxParticles,
+    RelaxSystems,
+    relax_gradients,
+    relax_index_prefix,
+)
 from kups.core.data import Table
 from kups.core.storage import EveryNStep, Once, WriterGroupConfig
-from kups.core.typing import IsState, ParticleId, SystemId
+from kups.core.typing import ParticleId, SystemId
 from kups.core.utils.jax import dataclass
 from kups.observables.stress import stress_via_virial_theorem
-
-type HasRelaxData = IsState[RelaxParticles, RelaxSystems]
+from kups.relaxation.convergence import max_dof_per_system
 
 
 @dataclass
@@ -32,7 +35,7 @@ class RelaxInitData:
     systems: Table[SystemId, RelaxSystems]
 
     @staticmethod
-    def from_state(state: HasRelaxData) -> RelaxInitData:
+    def from_state(state: IsRelaxData) -> RelaxInitData:
         """Extract initial snapshot from a relaxation state."""
         return RelaxInitData(atoms=state.particles, systems=state.systems)
 
@@ -54,19 +57,17 @@ class RelaxStepData:
     stress_tensor: Array
 
     @staticmethod
-    def from_state(state: HasRelaxData) -> RelaxStepData:
+    def from_state(state: IsRelaxData) -> RelaxStepData:
         """Extract per-step logging data from a relaxation state."""
-        forces = state.particles.data.forces
-        force_norms = jnp.linalg.norm(forces, axis=-1)
-        max_force = jax.ops.segment_max(
-            force_norms,
-            state.particles.data.system.indices,
-            state.particles.data.system.num_labels,
+        max_force = max_dof_per_system(
+            relax_gradients(state),
+            relax_index_prefix(state.particles, state.systems),
+            include_cell=False,
         )
         return RelaxStepData(
             atoms=state.particles,
             potential_energy=state.systems.data.potential_energy,
-            max_force=max_force,
+            max_force=max_force.data,
             stress_tensor=stress_via_virial_theorem(
                 state.particles, state.systems
             ).data,
@@ -77,9 +78,9 @@ class RelaxStepData:
 class RelaxLoggedData:
     """HDF5 writer configuration for relaxation simulations."""
 
-    init: WriterGroupConfig[HasRelaxData, RelaxInitData] = WriterGroupConfig(
+    init: WriterGroupConfig[IsRelaxData, RelaxInitData] = WriterGroupConfig(
         RelaxInitData.from_state, Once()
     )
-    step: WriterGroupConfig[HasRelaxData, RelaxStepData] = WriterGroupConfig(
+    step: WriterGroupConfig[IsRelaxData, RelaxStepData] = WriterGroupConfig(
         RelaxStepData.from_state, EveryNStep(1)
     )

--- a/src/kups/application/relaxation/simulation.py
+++ b/src/kups/application/relaxation/simulation.py
@@ -3,22 +3,24 @@
 
 """Relaxation propagator construction and simulation runner."""
 
-from typing import Any, Protocol, no_type_check
+from typing import Any, Protocol
 
 import jax
 import jax.numpy as jnp
-import optax
 from jax import Array
 
 from kups.application.relaxation.data import (
     RelaxParticles,
     RelaxRunConfig,
     RelaxSystems,
+    relax_gradients,
+    relax_index_prefix,
+    relax_parameters,
 )
 from kups.application.relaxation.logging import RelaxLoggedData
 from kups.application.utils.propagate import make_cycle_function, run_simulation_cycles
 from kups.core.data import Table
-from kups.core.lens import Lens, lens
+from kups.core.lens import Lens, View, lens
 from kups.core.logging import CompositeLogger, TqdmLogger
 from kups.core.potential import (
     EMPTY,
@@ -33,112 +35,135 @@ from kups.core.propagator import (
     SequentialPropagator,
     step_counter_propagator,
 )
+from kups.core.result import as_result_function
 from kups.core.storage import HDF5StorageWriter
 from kups.core.typing import IsState, ParticleId, SystemId
 from kups.core.utils.jax import jit
 from kups.potential.common.geometry import (
     Geometry,
     PositionsAndCell,
+    PositionsAndCellIndex,
     PositionsAndSystemIndex,
+    position_and_cell_idx_view,
 )
+from kups.relaxation.convergence import converged_per_system
 from kups.relaxation.optimizer import Optimizer
-from kups.relaxation.propagator import RelaxationPropagator
+from kups.relaxation.propagator import RelaxationPropagator, UpdateMask
 
 
-class IsRelaxState(IsState[RelaxParticles, RelaxSystems], Protocol):
-    """Protocol for relaxation simulation states."""
-
+class IsRelaxState[OptState](IsState[RelaxParticles, RelaxSystems], Protocol):
     @property
-    def opt_state(self) -> optax.OptState: ...
+    def opt_state(self) -> OptState: ...
     @property
     def step(self) -> Array: ...
 
 
-class OptInit(Protocol):
-    """Protocol for initialising an Optax optimizer state from gradients."""
+class OptInit[OptState](Protocol):
+    """Initialize optimizer state from relaxation particle and system tables."""
 
     def __call__(
         self,
         particles: Table[ParticleId, RelaxParticles],
         systems: Table[SystemId, RelaxSystems],
-    ) -> optax.OptState: ...
+    ) -> OptState: ...
 
 
-def make_relax_propagator[State: IsRelaxState](
-    state_lens: Lens[State, State],
-    potential: Potential[State, Any, EmptyType, Any],
-    optimizer: Optimizer[PositionsAndCell, Any],
+class IndexPrefix(Protocol):
+    """Map the optimizer's particle and cell parameters to their owning systems."""
+
+    def __call__(
+        self,
+        particles: Table[ParticleId, RelaxParticles],
+        systems: Table[SystemId, RelaxSystems],
+    ) -> PositionsAndCellIndex: ...
+
+
+def make_relax_step[State, OptState](
+    state_lens: Lens[State, IsRelaxState[OptState]],
+    potential: Potential[State, PositionsAndCell, EmptyType, Any],
+    optimizer: Optimizer[PositionsAndCell, OptState],
     gradient: Lens[Geometry, PositionsAndCell],
-) -> tuple[Propagator[State], OptInit]:
-    """Build a relaxation propagator with step counting and error recovery.
+    *,
+    accept: View[State, Table[SystemId, Array]] | None = None,
+    index_prefix: IndexPrefix = relax_index_prefix,
+) -> tuple[Propagator[State], OptInit[OptState]]:
+    """Wire an optimizer step and initialization.
 
-    Args:
-        state_lens: Lens focusing on the relaxation sub-state.
-        potential: Potential reporting the DOF gradient ``∂E/∂u`` (built with the
-            same ``gradient`` filter).
-        optimizer: Optimizer (e.g. FIRE, Adam, L-BFGS).
-        gradient: Relaxation filter selecting the optimizer DOFs ``u`` — must be
-            the one ``potential`` was built with. The propagator optimises *these*
-            DOFs (not raw ``(positions, cell)``) so the filter's atoms-ride-the-cell
-            coupling is applied on every ``set``; using the raw property would drop
-            that coupling and diverge from ASE's cell filters.
-
-    Returns:
-        Tuple of ``(propagator, opt_init)`` where *propagator* performs one
-        optimisation step and *opt_init* initialises the optimizer state.
+    The acceptance view reads the freshly evaluated gradients. Index mappings
+    are supplied explicitly; streaming may use a fixed row-to-slot mapping.
     """
 
-    def to_geometry(x: State) -> Geometry:
+    def to_geometry(s: State) -> Geometry:
+        sub = state_lens.get(s)
         return Geometry(
-            x.particles.map_data(
+            sub.particles.map_data(
                 lambda p: PositionsAndSystemIndex(p.positions, p.system)
             ),
-            x.systems.map_data(lambda s: s.cell),
+            sub.systems.map_data(lambda x: x.cell),
         )
 
-    def cached_out(x: State) -> PotentialOut[PositionsAndCell, EmptyType]:
+    def cached_out(s: State) -> PotentialOut[PositionsAndCell, EmptyType]:
+        sub = state_lens.get(s)
         return PotentialOut(
-            x.systems.map_data(lambda s: s.potential_energy),
-            PositionsAndCell(
-                x.particles.map_data(lambda x: x.position_gradients),
-                x.systems.map_data(lambda x: x.cell_gradients),
-            ),
-            EMPTY,
-        )
-
-    @no_type_check
-    def cached_index(x: State) -> PotentialOut[PositionsAndCell, EmptyType]:
-        return PotentialOut(
-            x.systems.index,
-            PositionsAndCell(x.particles.data.system, x.systems.index),
+            sub.systems.map_data(lambda x: x.potential_energy),
+            relax_gradients(sub),
             EMPTY,
         )
 
     def opt_init(
         particles: Table[ParticleId, RelaxParticles],
         systems: Table[SystemId, RelaxSystems],
-    ) -> optax.OptState:
-        params = PositionsAndCell(
-            particles.map_data(lambda p: p.positions),
-            systems.map_data(lambda s: s.cell),
+    ) -> OptState:
+        return optimizer.init(
+            relax_parameters(particles, systems), index_prefix(particles, systems)
         )
-        # pyrefly: ignore [bad-argument-type]
-        prefix = PositionsAndCell(particles.data.system, systems.index)
-        return optimizer.init(params, prefix)
 
-    pot = CachedPotential(potential, lens(cached_out), cached_index)
-    relax_prop = RelaxationPropagator(
-        potential=pot,
+    step = RelaxationPropagator(
+        potential=CachedPotential(
+            potential,
+            lens(cached_out),
+            lambda s: position_and_cell_idx_view(to_geometry(s)),
+        ),
         property=lens(to_geometry).nest(gradient),
         opt_state=state_lens.focus(lambda x: x.opt_state),
         optimizer=optimizer,
+        mask=UpdateMask(
+            accept=accept,
+            system_index=lambda s: index_prefix(
+                state_lens.get(s).particles, state_lens.get(s).systems
+            ),
+        )
+        if accept is not None
+        else None,
     )
-    step_prop = step_counter_propagator(state_lens.focus(lambda x: x.step))
-    prop = ResetOnErrorPropagator(SequentialPropagator((relax_prop, step_prop)))
-    return prop, opt_init
+    return step, opt_init
 
 
-def run_relax[State: IsRelaxState](
+def make_relax_propagator[State, OptState](
+    state_lens: Lens[State, IsRelaxState[OptState]],
+    potential: Potential[State, PositionsAndCell, EmptyType, Any],
+    optimizer: Optimizer[PositionsAndCell, OptState],
+    gradient: Lens[Geometry, PositionsAndCell],
+) -> tuple[Propagator[State], OptInit[OptState]]:
+    """Build a relaxation step with counting and capacity-error recovery."""
+
+    step, init = make_relax_step(
+        state_lens,
+        potential,
+        optimizer,
+        gradient,
+    )
+    return ResetOnErrorPropagator(
+        SequentialPropagator(
+            (
+                step,
+                step_counter_propagator(state_lens.focus(lambda s: s.step)),
+            )
+        )
+    ), init
+
+
+def run_relax[State: IsRelaxState[object]](
     key: Array, propagator: Propagator[State], state: State, config: RelaxRunConfig
 ) -> State:
     """Run structure relaxation with early stopping on convergence.
@@ -154,16 +179,20 @@ def run_relax[State: IsRelaxState](
     """
 
     @jit
+    @as_result_function
     def converged_value(s: State) -> Array:
-        max_dof = jnp.max(jnp.linalg.norm(s.particles.data.position_gradients, axis=-1))
-        if config.optimize_cell:
-            leaves = jax.tree.leaves(s.systems.data.cell_gradients)
-            cell_dof = jnp.max(jnp.stack([jnp.max(jnp.abs(x)) for x in leaves]))
-            max_dof = jnp.maximum(max_dof, cell_dof)
-        return max_dof < config.force_tolerance
+        converged = converged_per_system(
+            relax_gradients(s),
+            relax_index_prefix(s.particles, s.systems),
+            config.force_tolerance,
+            include_cell=config.optimize_cell,
+        )
+        return jnp.all(converged.data)
 
     def converged(s: State) -> bool:
-        return bool(converged_value(s))
+        result = converged_value(s)
+        result.raise_assertion()
+        return bool(result.value)
 
     @jit
     def _postfix_jit(s: State) -> dict[str, Array]:

--- a/src/kups/application/simulations/relax.py
+++ b/src/kups/application/simulations/relax.py
@@ -44,6 +44,7 @@ from kups.core.lens import identity_lens
 from kups.core.neighborlist import UniversalNeighborlistParameters
 from kups.core.typing import ParticleId, SystemId
 from kups.relaxation.config import make_optimizer
+from kups.relaxation.optimizer import ChainOptState
 
 jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
 jax.config.update("jax_enable_x64", True)
@@ -67,7 +68,7 @@ class Config(BaseModel):
 def run(config: Config) -> None:
     """Run a structure relaxation for the configured force field."""
     key = jax.random.key(config.run.seed or time.time_ns())
-    state_lens = identity_lens(RelaxState)
+    state_lens = identity_lens(RelaxState[ChainOptState])
     optimizer = make_optimizer(config.run.optimizer)
     gradient = FRECHET_FILTER if config.run.optimize_cell else POSITIONS_ONLY
     potential, cutoff = config.potential.build(state_lens, gradient)

--- a/src/kups/potential/common/geometry.py
+++ b/src/kups/potential/common/geometry.py
@@ -37,16 +37,20 @@ class Geometry(NamedTuple):
     systems: Table[SystemId, Cell[AnyPeriodicity]]
 
 
-class PositionsAndCell(NamedTuple):
-    """Optimizer DOFs / gradient payload of the standard cell filters.
+class PositionCellTree[P, C](NamedTuple):
+    """Shared pytree structure for coordinate, gradient, and index views."""
 
-    ``positions`` is a per-particle table of DOF coordinates (``∂E/∂r`` when this
-    carries a gradient); ``cell`` is a per-system table of the cell (its frame
-    parameters carrying ``∂E/∂h`` for a gradient).
-    """
+    positions: P
+    cell: C
 
-    positions: Table[ParticleId, Array]
-    cell: Table[SystemId, Cell[AnyPeriodicity]]
+
+PositionsAndCell = PositionCellTree[
+    Table[ParticleId, Array], Table[SystemId, Cell[AnyPeriodicity]]
+]
+"""Optimizer coordinates or gradients of the standard cell filters."""
+
+PositionsAndCellIndex = PositionCellTree[Index[SystemId], Index[SystemId]]
+"""System assignment for the two branches of a positions-and-cell pytree."""
 
 
 type IsStateWithParticlesAndCell = IsState[
@@ -54,10 +58,10 @@ type IsStateWithParticlesAndCell = IsState[
 ]
 
 
-@no_type_check
+@no_type_check  # Potential caches use heterogeneous index prefixes, not value trees.
 def position_and_cell_idx_view(
     state: IsStateWithParticlesAndCell,
-) -> PotentialOut[PositionsAndCell, EmptyType]:
+) -> PotentialOut[PositionsAndCellIndex, EmptyType]:
     """Patch index structure matching the ``PositionsAndCell`` filter codomain.
 
     The per-particle system index masks the position rows and the systems index
@@ -65,6 +69,6 @@ def position_and_cell_idx_view(
     """
     return PotentialOut(
         empty_patch_idx_view(state).total_energies,
-        PositionsAndCell(state.particles.data.system, state.systems.index),
+        PositionsAndCellIndex(state.particles.data.system, state.systems.index),
         EMPTY,
     )

--- a/src/kups/relaxation/convergence.py
+++ b/src/kups/relaxation/convergence.py
@@ -1,0 +1,78 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-system convergence criteria for gradient-based relaxation.
+
+ASE's ``fmax`` criterion generalised to a batch: every system converges on its
+own, judged by the largest norm of any of its DOF gradients. The helpers take
+the optimizer's ``PositionsAndCell`` gradient payload together with the
+matching ``index_prefix`` (per-particle ``system`` index and systems index)
+that the transforms in :mod:`kups.relaxation.transforms` use, so a batched run
+judges each system exactly as a single-system run would.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from kups.core.assertion import runtime_assert
+from kups.core.data.table import Table
+from kups.core.typing import SystemId
+from kups.core.utils.segmented_tree import tree_segment_max
+from kups.potential.common.geometry import PositionsAndCell, PositionsAndCellIndex
+
+
+def dof_norm_per_row(gradients: PositionsAndCell) -> PositionsAndCell:
+    """Per-row gradient magnitudes: ``|∂E/∂r_i|`` per particle, ``|∂E/∂h|`` per cell entry."""
+    return PositionsAndCell(
+        gradients.positions.map_data(lambda g: jnp.linalg.norm(g, axis=-1)),
+        gradients.cell.map_data(lambda c: jax.tree.map(jnp.abs, c)),
+    )
+
+
+def max_dof_per_system(
+    gradients: PositionsAndCell,
+    index_prefix: PositionsAndCellIndex,
+    *,
+    include_cell: bool = True,
+) -> Table[SystemId, Array]:
+    """Largest DOF-gradient norm of each system (ASE ``fmax``).
+
+    Args:
+        gradients: DOF gradients ``∂E/∂u`` as the relaxation filter reports them.
+        index_prefix: ``PositionsAndCellIndex(particles.data.system, systems.index)``.
+        include_cell: Whether the cell DOF gradients take part in the maximum.
+
+    Returns:
+        ``Table[SystemId, Array]`` of shape ``(n_systems,)``. A system without
+        particles evaluates to ``-inf`` when cell gradients are excluded.
+    """
+    # Segment maxima can discard NaNs. Promote them to +inf before reducing,
+    # so invalid active rows cannot masquerade as convergence; OOB rows remain ignored.
+    norms = jax.tree.map(
+        lambda x: jnp.where(jnp.isfinite(x), x, jnp.inf), dof_norm_per_row(gradients)
+    )
+    result = index_prefix.positions.max_over(norms.positions.data)
+    if include_cell:
+        cell_max = tree_segment_max(norms.cell, index_prefix.cell)
+        result = result.map_data(
+            lambda positions: jnp.maximum(positions, cell_max.data)
+        )
+    return result
+
+
+def converged_per_system(
+    gradients: PositionsAndCell,
+    index_prefix: PositionsAndCellIndex,
+    tolerance: float,
+    *,
+    include_cell: bool = True,
+) -> Table[SystemId, Array]:
+    """``Table[SystemId, bool]``: systems whose :func:`max_dof_per_system` is below ``tolerance``."""
+    maximum = max_dof_per_system(gradients, index_prefix, include_cell=include_cell)
+    runtime_assert(
+        ~jnp.any(jnp.isposinf(maximum.data)), "Non-finite relaxation gradients."
+    )
+    return maximum.map_data(lambda m: m < tolerance)

--- a/src/kups/relaxation/propagator.py
+++ b/src/kups/relaxation/propagator.py
@@ -15,15 +15,30 @@ from typing import Any
 import jax.numpy as jnp
 from jax import Array
 
-from kups.core.lens import Lens
+from kups.core.data.table import Table
+from kups.core.lens import Lens, View
+from kups.core.patch import IndexLensPatch
 from kups.core.potential import Potential
 from kups.core.propagator import Propagator
+from kups.core.typing import SystemId
 from kups.core.utils.jax import dataclass, field
 from kups.relaxation.optimizer import Optimizer, apply_updates
 
 
+@dataclass(kw_only=True)
+class UpdateMask[State, Indices]:
+    """Per-system acceptance and the matching parameter-index view.
+
+    Both views read the state after the potential's patch has been applied.
+    ``system_index`` returns an index prefix of the optimized parameters.
+    """
+
+    accept: View[State, Table[SystemId, Array]] = field(static=True)
+    system_index: View[State, Indices] = field(static=True)
+
+
 @dataclass
-class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
+class RelaxationPropagator[State, Params, OptState, Indices](Propagator[State]):
     """Unified propagator for gradient-based optimization.
 
     Uses a Potential to compute energy and gradients. Supports standard optax
@@ -41,13 +56,18 @@ class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
 
     Type Parameters:
         State: The simulation state type
-        PyTree: The type of the property being optimized (must match Potential's gradient type)
+        Params: Optimized parameters (must match the potential's gradient type).
+        OptState: Optimizer state preserved through initialization and updates.
+        Indices: Index prefix returned by the optional update mask.
 
     Attributes:
-        potential: Potential that computes energy and gradients of type PyTree
+        potential: Potential that computes energy and gradients of type Params
         property: Lens to get/set the property being optimized
         opt_state: Lens to get/set the optimizer state
         optimizer: Gradient transformation
+        mask: Optional acceptance and parameter-index views, read after evaluating
+            the potential and applying its patch. Optimizer state still advances;
+            a reused slot must be reset before its next update.
 
     Example:
         ```python
@@ -80,16 +100,17 @@ class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
         ```
     """
 
-    potential: Potential[State, PyTree, Any, Any] = field(static=True)
-    property: Lens[State, PyTree] = field(static=True)
+    potential: Potential[State, Params, Any, Any] = field(static=True)
+    property: Lens[State, Params] = field(static=True)
     opt_state: Lens[State, OptState] = field(static=True)
-    optimizer: Optimizer[PyTree, OptState] = field(static=True)
+    optimizer: Optimizer[Params, OptState] = field(static=True)
+    mask: UpdateMask[State, Indices] | None = field(static=True, default=None)
 
     def __call__(self, key: Array, state: State) -> State:
         del key
         params = self.property.get(state)
 
-        def value_and_grad_fn(p: PyTree) -> tuple[Any, PyTree]:
+        def value_and_grad_fn(p: Params) -> tuple[Table[SystemId, Array], Params]:
             out = self.potential(self.property.set(state, p)).data
             return out.total_energies, out.gradients
 
@@ -116,6 +137,11 @@ class RelaxationPropagator[State, PyTree, OptState](Propagator[State]):
         )
 
         new_params = apply_updates(params, updates)
-        state = self.property.set(state, new_params)
+        if self.mask is None:
+            state = self.property.set(state, new_params)
+        else:
+            state = IndexLensPatch(
+                new_params, self.mask.system_index(state), self.property
+            )(state, self.mask.accept(state))
         state = self.opt_state.set(state, new_opt_state)
         return state

--- a/test/application/test_relax_data.py
+++ b/test/application/test_relax_data.py
@@ -1,0 +1,67 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Source-neutral relaxation builders preserve table identity and geometry."""
+
+from typing import assert_type
+
+import ase
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+import pytest
+
+from kups.application.relaxation.data import (
+    relax_index_prefix,
+    relax_state_from_particles,
+)
+from kups.application.relaxation.simulation import IndexPrefix
+from kups.application.utils.particles import particles_from_ase
+from kups.core.cell import DeformedFrame
+from kups.core.data import Index, Table
+from kups.core.lens import bind
+from kups.core.typing import ParticleId, SystemId
+from kups.potential.common.geometry import PositionsAndCellIndex
+
+
+@pytest.mark.parametrize("batched", [False, True])
+def test_builder_preserves_keys_geometry_and_system_counts(batched: bool) -> None:
+    atoms = ase.Atoms("Ar2", positions=[[0, 0, 0], [1, 2, 3]], cell=[4, 5, 6], pbc=True)
+    particles, cell, _ = particles_from_ase(atoms)
+    keys = (SystemId(12), SystemId(42)) if batched else (SystemId(42),)
+    references = jnp.array([0, 1] if batched else [0, 0])
+    particles = Table(
+        (ParticleId(7), ParticleId(19)),
+        bind(particles.data).focus(lambda p: p.system).set(Index(keys, references)),
+    )
+    if batched:
+        cell = jax.tree.map(lambda x: jnp.repeat(x[None], 2, axis=0), cell)
+    relaxed, systems = relax_state_from_particles(particles, cell)
+    index_prefix: IndexPrefix = relax_index_prefix
+    prefix = index_prefix(particles=relaxed, systems=systems)
+    assert_type(prefix, PositionsAndCellIndex)
+    npt.assert_array_equal(prefix.positions.indices, relaxed.data.system.indices)
+    npt.assert_array_equal(prefix.cell.indices, systems.index.indices)
+    assert relaxed.keys == particles.keys
+    assert systems.keys == keys
+    npt.assert_array_equal(
+        systems[relaxed.data.system].cell.vectors,
+        cell.vectors if batched else jnp.repeat(cell.vectors[None], 2, axis=0),
+    )
+    npt.assert_array_equal(relaxed.data.positions, particles.data.positions)
+    npt.assert_array_equal(relaxed.data.position_gradients, 0)
+    npt.assert_array_equal(relaxed.data.system.counts.data, [1, 1] if batched else [2])
+    frame = systems.data.cell.frame
+    assert isinstance(frame, DeformedFrame)
+    npt.assert_array_equal(
+        frame.vectors, cell.vectors if batched else cell.vectors[None]
+    )
+
+
+def test_builder_rejects_mismatched_cell_count() -> None:
+    atoms = ase.Atoms("Ar", cell=[4, 5, 6], pbc=True)
+    particles, cell, _ = particles_from_ase(atoms)
+    with pytest.raises(ValueError, match="cell vectors"):
+        relax_state_from_particles(
+            particles, jax.tree.map(lambda x: jnp.repeat(x[None], 2, axis=0), cell)
+        )

--- a/test/application/test_relax_lj.py
+++ b/test/application/test_relax_lj.py
@@ -22,14 +22,15 @@ from kups.application.relaxation.data import (
     RelaxState,
     relax_state_from_ase,
 )
-from kups.application.relaxation.simulation import make_relax_propagator
+from kups.application.relaxation.simulation import make_relax_propagator, run_relax
 from kups.application.simulations.potentials import LjPotentialConfig
 from kups.application.simulations.relax import Config, run
-from kups.core.lens import identity_lens
+from kups.core.lens import bind, identity_lens
 from kups.core.neighborlist import UniversalNeighborlistParameters
 from kups.observables.stress import stress_via_virial_theorem, total_lattice_gradient
 from kups.potential.classical.lennard_jones import LennardJonesParameters
 from kups.relaxation.config import make_optimizer
+from kups.relaxation.optimizer import ChainOptState
 
 
 def _ar_cif(rattle: float) -> str:
@@ -123,7 +124,7 @@ def _build_propagator(optimize_cell: bool):
         parameters=config.potential.parameters,
         mixing_rule=config.potential.mixing_rule,
     )
-    state_lens = identity_lens(RelaxState)
+    state_lens = identity_lens(RelaxState[ChainOptState])
     optimizer = make_optimizer(config.run.optimizer)
     gradient = FRECHET_FILTER if optimize_cell else POSITIONS_ONLY
     potential = make_lennard_jones_from_state(
@@ -139,6 +140,18 @@ def _build_propagator(optimize_cell: bool):
     opt_state = opt_init(particles, systems)
     state = RelaxState(particles, systems, nlp, opt_state, jnp.array([0]))
     return propagator, state
+
+
+def test_nonfinite_gradients_abort_run() -> None:
+    _, state = _build_propagator(optimize_cell=False)
+    state = (
+        bind(state)
+        .focus(lambda s: s.particles.data.position_gradients)
+        .apply(lambda gradients: jnp.full_like(gradients, jnp.nan))
+    )
+    config = _config(_tmp_h5(), "unused").run
+    with pytest.raises(AssertionError, match="Non-finite relaxation gradients"):
+        run_relax(jax.random.key(0), lambda key, s: s, state, config)
 
 
 class TestCellRelaxation:

--- a/test/relaxation/test_convergence.py
+++ b/test/relaxation/test_convergence.py
@@ -1,0 +1,98 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy.testing as npt
+import pytest
+
+from kups.core.cell import PeriodicCell, TriclinicFrame
+from kups.core.data import Index, Table
+from kups.core.result import as_result_function
+from kups.core.typing import ParticleId, SystemId
+from kups.potential.common.geometry import PositionsAndCell, PositionsAndCellIndex
+from kups.relaxation.convergence import converged_per_system, max_dof_per_system
+
+
+def _cubic(diagonal: jnp.ndarray) -> PeriodicCell:
+    return PeriodicCell(
+        TriclinicFrame.from_matrix(diagonal[:, None, None] * jnp.eye(3)[None])
+    )
+
+
+def _gradients(
+    n_systems: int, rows: jnp.ndarray, system: list[int], cell_grad: jnp.ndarray
+) -> tuple[PositionsAndCell, PositionsAndCellIndex]:
+    system_index = Index.integer(jnp.array(system), n=n_systems, label=SystemId)
+    positions = Table.arange(rows, label=ParticleId)
+    cells = Table.arange(_cubic(cell_grad), label=SystemId)
+    prefix = PositionsAndCellIndex(system_index, cells.index)
+    return PositionsAndCell(positions, cells), prefix
+
+
+class TestMaxDofPerSystem:
+    def test_per_system_maximum_of_row_norms(self):
+        rows = jnp.array([[3.0, 4.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.5]])
+        grads, prefix = _gradients(2, rows, [0, 0, 1], jnp.zeros(2))
+        npt.assert_allclose(
+            max_dof_per_system(grads, prefix, include_cell=False).data, [5.0, 0.5]
+        )
+
+    def test_cell_gradients_take_part(self):
+        rows = jnp.array([[0.1, 0.0, 0.0], [0.0, 0.0, 0.2]])
+        grads, prefix = _gradients(2, rows, [0, 1], jnp.array([-7.0, 0.05]))
+        with_cell = max_dof_per_system(grads, prefix).data
+        without = max_dof_per_system(grads, prefix, include_cell=False).data
+        npt.assert_allclose(with_cell, [7.0, 0.2])
+        npt.assert_allclose(without, [0.1, 0.2])
+
+    def test_padded_rows_and_empty_systems(self):
+        # Row 2 is padding (OOB system); system 1 has no particles.
+        rows = jnp.array([[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [9.0, 0.0, 0.0]])
+        grads, prefix = _gradients(2, rows, [0, 0, 2], jnp.zeros(2))
+        result = max_dof_per_system(grads, prefix, include_cell=False).data
+        npt.assert_allclose(result[0], 2.0)
+        assert result[1] == -jnp.inf
+
+    def test_converged_matches_global_criterion_for_one_system(self):
+        rows = jnp.array([[0.01, 0.0, 0.0], [0.0, 0.02, 0.0]])
+        grads, prefix = _gradients(1, rows, [0, 0], jnp.zeros(1))
+        assert bool(converged_per_system(grads, prefix, 0.05).data[0])
+        assert not bool(converged_per_system(grads, prefix, 0.015).data[0])
+
+    @pytest.mark.parametrize("bad", [jnp.nan, jnp.inf])
+    def test_nonfinite_active_gradients_fail_under_jit(self, bad: float) -> None:
+        grads, prefix = _gradients(1, jnp.array([[bad, 0.0, 0.0]]), [0], jnp.zeros(1))
+        evaluate = jax.jit(
+            as_result_function(
+                lambda g: converged_per_system(g, prefix, 0.1, include_cell=False)
+            )
+        )
+        result = evaluate(grads)
+        assert not bool(result.value.data[0])
+        with pytest.raises(AssertionError, match="Non-finite relaxation gradients"):
+            result.raise_assertion()
+
+    def test_nonfinite_padding_is_ignored(self) -> None:
+        grads, prefix = _gradients(
+            1, jnp.array([[0.0, 0.0, 0.0], [jnp.nan, 0.0, 0.0]]), [0, 1], jnp.zeros(1)
+        )
+        evaluate = jax.jit(
+            as_result_function(
+                lambda g: converged_per_system(g, prefix, 0.1, include_cell=False)
+            )
+        )
+        result = evaluate(grads)
+        result.raise_assertion()
+        assert bool(result.value.data[0])
+
+    def test_nonfinite_cell_gradient_fails_when_included(self) -> None:
+        grads, prefix = _gradients(1, jnp.zeros((1, 3)), [0], jnp.array([jnp.nan]))
+        evaluate = jax.jit(
+            as_result_function(lambda g: converged_per_system(g, prefix, 0.1))
+        )
+        result = evaluate(grads)
+        with pytest.raises(AssertionError, match="Non-finite relaxation gradients"):
+            result.raise_assertion()

--- a/test/relaxation/test_propagator.py
+++ b/test/relaxation/test_propagator.py
@@ -3,21 +3,27 @@
 
 """Tests for relaxation propagators."""
 
-from typing import Any
+from typing import Literal, assert_type, overload
 
 import jax
 import jax.numpy as jnp
 import numpy.testing as npt
 import optax
 
-from kups.core.data import Table
-from kups.core.lens import lens
-from kups.core.patch import ExplicitPatch, IdPatch, WithPatch
-from kups.core.potential import PotentialOut
+from kups.core.data import Index, Table
+from kups.core.lens import bind, lens
+from kups.core.patch import IdPatch, Patch, WithPatch
+from kups.core.potential import (
+    CompensatedPotentialResult,
+    Potential,
+    PotentialOut,
+    PotentialResult,
+)
 from kups.core.typing import SystemId
-from kups.core.utils.jax import dataclass
-from kups.relaxation.optimizer import Optimizer, chain
-from kups.relaxation.propagator import RelaxationPropagator
+from kups.core.utils.jax import dataclass, field
+from kups.core.utils.kahan import KahanSummand
+from kups.relaxation.optimizer import ChainOptimizer, ChainOptState, chain
+from kups.relaxation.propagator import RelaxationPropagator, UpdateMask
 from kups.relaxation.transforms import (
     ScaleByAseLbfgs,
     ScaleByBacktrackingLinesearch,
@@ -30,59 +36,68 @@ class PotentialState:
     """State for potential-based propagator tests."""
 
     positions: jax.Array
-    opt_state: optax.OptState
+    opt_state: ChainOptState
 
 
 @dataclass
-class PotentialStateWithCounter:
+class PotentialStateWithCounter(PotentialState):
     """State with a counter to track patch applications."""
 
-    positions: jax.Array
-    opt_state: optax.OptState
     patch_count: jax.Array
 
 
-class QuadraticPotential:
+@dataclass
+class QuadraticPotential[State: PotentialState](
+    Potential[State, jax.Array, tuple[()], Patch[State]]
+):
     """Mock potential: E = 0.5 * ||x||^2, grad = x."""
 
-    def __call__(self, state: PotentialState, patch=None):
+    cache_patch: Patch[State] = field(static=True, default_factory=IdPatch)
+
+    @overload
+    def __call__(
+        self,
+        state: State,
+        patch: Patch[State] | None = None,
+        *,
+        include_compensate: Literal[False] = False,
+    ) -> PotentialResult[State, jax.Array, tuple[()]]: ...
+    @overload
+    def __call__(
+        self,
+        state: State,
+        patch: Patch[State] | None = None,
+        *,
+        include_compensate: Literal[True],
+    ) -> CompensatedPotentialResult[State, jax.Array, tuple[()]]: ...
+    def __call__(
+        self,
+        state: State,
+        patch: Patch[State] | None = None,
+        *,
+        include_compensate: bool = False,
+    ) -> (
+        PotentialResult[State, jax.Array, tuple[()]]
+        | CompensatedPotentialResult[State, jax.Array, tuple[()]]
+    ):
         del patch
         energy = 0.5 * jnp.sum(state.positions**2)
-        gradients = state.positions
-        return WithPatch(
-            PotentialOut(
-                total_energies=Table.arange(jnp.array([energy]), label=SystemId),
-                gradients=gradients,
-                hessians=(),
-            ),
-            IdPatch(),
+        out = PotentialOut(
+            total_energies=Table.arange(jnp.array([energy]), label=SystemId),
+            gradients=state.positions,
+            hessians=(),
         )
+        if include_compensate:
+            return WithPatch(KahanSummand.init(out), self.cache_patch)
+        return WithPatch(out, self.cache_patch)
 
 
-class QuadraticPotentialWithPatch:
-    """Mock potential that increments a counter via patch."""
-
-    def __call__(self, state: PotentialStateWithCounter, patch=None):
-        del patch
-        energy = 0.5 * jnp.sum(state.positions**2)
-        gradients = state.positions
-
-        def apply_fn(state, payload, accept):
-            del accept
-            return PotentialStateWithCounter(
-                positions=state.positions,
-                opt_state=state.opt_state,
-                patch_count=state.patch_count + payload,
-            )
-
-        return WithPatch(
-            PotentialOut(
-                total_energies=Table.arange(jnp.array([energy]), label=SystemId),
-                gradients=gradients,
-                hessians=(),
-            ),
-            ExplicitPatch(payload=jnp.array(1), apply_fn=apply_fn),
+def _counted_quadratic() -> QuadraticPotential[PotentialStateWithCounter]:
+    return QuadraticPotential(
+        cache_patch=lambda s, accept: (
+            bind(s).focus(lambda x: x.patch_count).apply(lambda count: count + 1)
         )
+    )
 
 
 class TestRelaxationPropagator:
@@ -90,8 +105,8 @@ class TestRelaxationPropagator:
 
     def test_sgd_single_step(self):
         """SGD should take a single gradient step."""
-        optimizer = optax.sgd(learning_rate=0.1)
-        potential = QuadraticPotential()
+        optimizer: ChainOptimizer[jax.Array] = chain(optax.sgd(learning_rate=0.1))
+        potential = QuadraticPotential[PotentialState]()
 
         initial_pos = jnp.array([1.0, 2.0, 3.0])
         state = PotentialState(
@@ -114,8 +129,8 @@ class TestRelaxationPropagator:
 
     def test_applies_patch_each_step(self):
         """Potential's patch should be applied after each relaxation step."""
-        optimizer = optax.sgd(learning_rate=0.1)
-        potential = QuadraticPotentialWithPatch()
+        optimizer: ChainOptimizer[jax.Array] = chain(optax.sgd(learning_rate=0.1))
+        potential = _counted_quadratic()
 
         initial_pos = jnp.array([1.0, 2.0, 3.0])
         state = PotentialStateWithCounter(
@@ -137,9 +152,39 @@ class TestRelaxationPropagator:
 
         assert state.patch_count == 1
 
+    def test_mask_reads_patched_state_and_preserves_rejected_rows(self) -> None:
+        optimizer: ChainOptimizer[jax.Array] = chain(optax.sgd(learning_rate=0.1))
+        positions = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+        state = PotentialStateWithCounter(
+            positions=positions,
+            opt_state=optimizer.init(positions),
+            patch_count=jnp.array(0),
+        )
+        system_index = Index.integer(jnp.array([0, 1]), n=2, label=SystemId)
+        mask: UpdateMask[PotentialStateWithCounter, Index[SystemId]] = UpdateMask(
+            accept=lambda s: Table(
+                system_index.keys, jnp.array([s.patch_count > 0, False])
+            ),
+            system_index=lambda s: system_index,
+        )
+        assert_type(mask.system_index(state), Index[SystemId])
+        step = jax.jit(
+            RelaxationPropagator(
+                potential=_counted_quadratic(),
+                property=lens(lambda s: s.positions, cls=PotentialStateWithCounter),
+                opt_state=lens(lambda s: s.opt_state),
+                optimizer=optimizer,
+                mask=mask,
+            )
+        )
+        updated = step(jax.random.key(0), state)
+        npt.assert_allclose(updated.positions[0], 0.9 * positions[0])
+        npt.assert_array_equal(updated.positions[1], positions[1])
+        assert updated.patch_count == 1
+
     def test_kups_more_thuente_linesearch_converges(self):
         """The per-system More-Thuente search drives the quadratic to its minimum."""
-        optimizer: Optimizer[Any, Any] = chain(
+        optimizer: ChainOptimizer[jax.Array] = chain(
             optax.scale(-1.0), ScaleByMoreThuenteLinesearch()
         )
         state = PotentialState(
@@ -148,7 +193,7 @@ class TestRelaxationPropagator:
         )
         propagator = jax.jit(
             RelaxationPropagator(
-                potential=QuadraticPotential(),
+                potential=QuadraticPotential[PotentialState](),
                 property=lens(lambda s: s.positions, cls=PotentialState),
                 opt_state=lens(lambda s: s.opt_state),
                 optimizer=optimizer,
@@ -161,7 +206,7 @@ class TestRelaxationPropagator:
 
     def test_kups_lbfgs_with_backtracking_converges(self):
         """L-BFGS direction + per-system backtracking (the documented chain)."""
-        optimizer: Optimizer[Any, Any] = chain(
+        optimizer: ChainOptimizer[jax.Array] = chain(
             ScaleByAseLbfgs(memory_size=10, alpha=1.0),
             optax.scale(-1.0),
             ScaleByBacktrackingLinesearch(),
@@ -172,7 +217,7 @@ class TestRelaxationPropagator:
         )
         propagator = jax.jit(
             RelaxationPropagator(
-                potential=QuadraticPotential(),
+                potential=QuadraticPotential[PotentialState](),
                 property=lens(lambda s: s.positions, cls=PotentialState),
                 opt_state=lens(lambda s: s.opt_state),
                 optimizer=optimizer,


### PR DESCRIPTION
## Scope

Share relaxation data builders, convergence reduction and numerical-step wiring
with the downstream streaming application.

- Preserve particle/system keys and validate cell counts in the source-neutral builder.
- Preserve concrete optimizer-state types through the state and initializer.
- Describe initializer and index callbacks with named `OptInit` and `IndexPrefix`
  protocols, retaining keyword-call typing for ordinary functions.
- Bundle acceptance and parameter-index views into `UpdateMask[State, Indices]`,
  a named dataclass preserving the concrete index-prefix type;
  the existing indexed patch applies the mask after fresh gradients are cached.
- Report non-finite gradients as infinity in observables and raise through the
  assertion-aware convergence path, including ordinary relaxation.

The shared step returns only a propagator and initializer. It neither discovers
reset support nor returns a potentially unsupported reset closure. The fixed-batch
factory keeps its existing interface; refill and reset wiring remain downstream.

## Validation

Data-builder, convergence and ordinary LJ relaxation regressions pass, including
non-default system IDs and non-finite-gradient failure. Whole-source strict typing
passes independently at this layer. The typed propagator fixtures also check
that the mask reads patched state and leaves rejected rows unchanged under JIT.
