### PR TITLE
bench: measure streaming relaxation throughput against fixed batches

### DIFF
--- a/benchmarks/bench_relax_streaming.py
+++ b/benchmarks/bench_relax_streaming.py
@@ -1,0 +1,348 @@
+# Copyright 2024-2026 Cusp AI
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixed batches versus streaming on identical heterogeneous LJ relaxations.
+
+Run from the repository root, for example:
+    CUDA_VISIBLE_DEVICES=0 JAX_PLATFORMS=cuda,cpu JAX_ENABLE_X64=false \
+        .venv/bin/python benchmarks/bench_relax_streaming.py --slots 128
+
+JSONL output separates warmup from synchronized timed trials. Inputs are packed
+once on CPU; both policies receive the same shuffled stream of 32 template
+structures. Timings include refill, device transfers, and result snapshots, but
+exclude initial packing and the final NumPy comparison. No file I/O is timed.
+The heterogeneous mix deliberately includes already-converged structures;
+--homogeneous is the equal-work control. All jobs must return finite results
+and either meet the common force tolerance or reach the reported step budget.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from dataclasses import dataclass
+
+import ase.build
+import jax
+import jax.numpy as jnp
+import numpy as np
+import numpy.typing as npt
+import optax
+from jax import Array
+
+from kups.application.potential.classical.lennard_jones import (
+    make_lennard_jones_from_state,
+)
+from kups.application.potential.filter import POSITIONS_ONLY
+from kups.application.relaxation.streaming import (
+    RelaxPayload,
+    StreamingRelaxState,
+    Structure,
+    estimate_stream_neighborlist,
+    idle_payload,
+    make_streaming_relax_propagator,
+    make_streaming_relax_state,
+    payload_from_structures,
+    replace_slots,
+    slot_payload_lens,
+)
+from kups.application.utils.particles import particles_from_ase
+from kups.application.utils.propagate import make_cycle_function
+from kups.core.data import Table
+from kups.core.data.slots import SlotLayout
+from kups.core.lens import bind, identity_lens
+from kups.core.propagator import LoopPropagator, SequentialPropagator, propagate_and_fix
+from kups.core.stream import RefillPropagator
+from kups.core.typing import Label, SystemId
+from kups.core.utils.jax import dataclass as state_dataclass
+from kups.core.utils.jax import tree_concat
+from kups.potential.classical.lennard_jones import LennardJonesParameters
+from kups.relaxation.optimizer import chain
+from kups.relaxation.transforms import MaxStepSize, ScaleByFire
+
+
+@state_dataclass
+class State:
+    batch: StreamingRelaxState
+    evaluations: Array
+
+
+@dataclass
+class Measurement:
+    steps: npt.NDArray[np.int64]
+    energy: npt.NDArray[np.float32 | np.float64]
+    positions: npt.NDArray[np.float32 | np.float64]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--slots", type=int, default=32)
+    parser.add_argument("--mult", type=int, default=3)
+    parser.add_argument("--waves", type=int, default=8)
+    parser.add_argument("--trials", type=int, default=2)
+    parser.add_argument("--modes", default="fixed:8,stream:1,stream:8")
+    parser.add_argument("--max-steps", type=int, default=400)
+    parser.add_argument("--tolerance", type=float, default=0.01)
+    parser.add_argument("--minimum-rattle", type=float, default=0.002)
+    parser.add_argument("--homogeneous", action="store_true")
+    args = parser.parse_args()
+    if args.waves < 1 or args.trials < 0:
+        parser.error("waves must be positive and trials non-negative")
+    x64 = bool(jax.config.read("jax_enable_x64"))
+    slots, count = args.slots, args.slots * args.waves
+    capacity = 4 * args.mult**3
+    layout = SlotLayout(slots, capacity)
+    species = (Label("Ar"),)
+    rng = np.random.default_rng(20260908)
+    # The same shuffled job order in every policy. Pool reuse bounds preparation.
+    choices = rng.permutation(np.arange(count) % 32)
+    t0 = time.perf_counter()
+    structures: list[Structure] = []
+    with jax.default_device(jax.devices("cpu")[0]):
+        for i in range(32):
+            amplitude = (
+                0.15
+                if args.homogeneous
+                else (0.002 if i < 16 else 0.03 if i < 24 else 0.15 if i < 30 else 0.35)
+            )
+            amplitude = max(amplitude, args.minimum_rattle)
+            atoms = ase.build.bulk("Ar", "fcc", a=5.3, cubic=True) * args.mult
+            atoms.rattle(amplitude, seed=0 if args.homogeneous else i)
+            p, cell, _ = particles_from_ase(atoms)
+            structures.append((p, cell))
+        idle = idle_payload(layout, species, (True, True, True), 5.0)
+        pool = jax.device_get(
+            tree_concat(
+                payload_from_structures(structures, layout, species, range(32)),
+                idle,
+            )
+        )
+        lj = LennardJonesParameters.from_dict(
+            cutoff=5.0,
+            parameters={"Ar": (3.405, 0.010326)},
+            mixing_rule="lorentz_berthelot",
+        )
+        nlp = estimate_stream_neighborlist(
+            structures, layout, species, lj.cutoff, multiplier=2.0
+        )
+    lj = jax.device_put(lj)
+    state_lens = identity_lens(State).focus(lambda s: s.batch)
+    potential = make_lennard_jones_from_state(
+        state_lens, parameters=lj, gradient=POSITIONS_ONLY
+    )
+    step, init, reset = make_streaming_relax_propagator(
+        state_lens,
+        potential,
+        chain(optax.scale(-1.0), ScaleByFire(dt_start=0.1), MaxStepSize(0.2)),
+        POSITIONS_ONLY,
+        layout,
+        force_tolerance=args.tolerance,
+        max_steps=args.max_steps,
+        include_cell=False,
+    )
+    with jax.default_device(jax.devices("cpu")[0]):
+        template = jax.device_get(
+            State(
+                make_streaming_relax_state(layout, idle, init, nlp),
+                jnp.array(0),
+            )
+        )
+    print(
+        json.dumps(
+            dict(
+                kind="setup",
+                slots=slots,
+                atoms=capacity,
+                total_atoms=slots * capacity,
+                jobs=count,
+                x64=x64,
+                device=str(jax.devices()[0]),
+                homogeneous=args.homogeneous,
+                minimum_rattle=args.minimum_rattle,
+                neighborlist_capacities=dict(
+                    candidates=nlp.avg_candidates,
+                    image_candidates=nlp.avg_image_candidates,
+                    edges=nlp.avg_edges,
+                ),
+                packing_seconds=time.perf_counter() - t0,
+            )
+        ),
+        flush=True,
+    )
+    payload_lens = slot_payload_lens(layout)
+
+    @jax.jit
+    def snapshot(s: State) -> RelaxPayload:
+        return payload_lens.get(s.batch)
+
+    @jax.jit
+    def install(s: State, payload: RelaxPayload, mask: Table[SystemId, Array]) -> State:
+        return state_lens.set(
+            s, replace_slots(s.batch, payload, mask, layout=layout, reset=reset)
+        )
+
+    def counted(key: Array, s: State) -> State:
+        return bind(step(key, s)).focus(lambda x: x.evaluations).apply(lambda n: n + 1)
+
+    reference: Measurement | None = None
+    for mode in args.modes.split(","):
+        policy, block_text = mode.split(":")
+        block = int(block_text)
+        if policy not in {"fixed", "stream"} or block < 1:
+            parser.error("modes must be fixed:N or stream:N with positive N")
+        next_job = 0
+        outputs: list[RelaxPayload] = []
+        callback_seconds = 0.0
+
+        def requested(s: State) -> Table[SystemId, Array]:
+            done = s.batch.finished
+            if policy == "fixed":
+                ready = jnp.all(done.data | (s.batch.slot_ordinal < 0))
+                return done.map_data(lambda m: m & ready)
+            return done
+
+        def refill(s: State, mask: Table[SystemId, Array]) -> State:
+            nonlocal next_job, callback_seconds
+            start = time.perf_counter()
+            mask_host, old = jax.device_get((mask.data, snapshot(s)))
+            output_rows = np.flatnonzero(mask_host & (old.ordinal >= 0))
+            if len(output_rows):
+                outputs.append(jax.tree.map(lambda x: x[output_rows].copy(), old))
+            slots_to_fill = np.flatnonzero(mask_host)
+            amount = min(len(slots_to_fill), count - next_job)
+            selection = np.full(slots, 32, dtype=np.int64)
+            ordinal = np.full(slots, -1, dtype=np.asarray(pool.ordinal).dtype)
+            selection[slots_to_fill[:amount]] = choices[next_job : next_job + amount]
+            ordinal[slots_to_fill[:amount]] = np.arange(next_job, next_job + amount)
+            payload = (
+                bind(jax.tree.map(lambda x: x[selection], pool))
+                .focus(lambda p: p.ordinal)
+                .set(ordinal)
+            )
+            next_job += amount
+            s = install(s, payload, mask)
+            jax.block_until_ready(s)
+            callback_seconds += time.perf_counter() - start
+            return s
+
+        def repetitions(s: State) -> Array:
+            # A repair-only attempt does not evaluate the potential; EOS does not either.
+            run = ~requested(s).data.any() & (s.batch.slot_ordinal >= 0).any()
+            return jnp.where(run, block, 0)
+
+        cycle = make_cycle_function(
+            SequentialPropagator(
+                (
+                    RefillPropagator(requested, refill),
+                    LoopPropagator(counted, repetitions),
+                )
+            )
+        )
+        finished = jax.jit(lambda s: jnp.all(s.batch.slot_ordinal < 0))
+        for trial in range(args.trials + 1):
+            next_job, callback_seconds = 0, 0.0
+            outputs = []
+            s = jax.device_put(jax.tree.map(np.copy, template))
+            jax.block_until_ready(s)
+            start = time.perf_counter()
+            cycles = 0
+            while True:
+                s = propagate_and_fix(cycle, jax.random.key(42), s)
+                cycles += 1
+                if bool(finished(s)):
+                    break
+                if cycles > count * (args.max_steps + 2):
+                    raise RuntimeError("Stream did not drain")
+            jax.block_until_ready(s)
+            elapsed = time.perf_counter() - start
+            # numpy-only collection after synchronization; no GPU operation per result row.
+            ordinals = np.concatenate([np.asarray(p.ordinal) for p in outputs])
+            order = np.argsort(ordinals)
+            np.testing.assert_array_equal(ordinals[order], np.arange(count))
+            steps = np.concatenate([np.asarray(p.step) for p in outputs])[order].astype(
+                np.int64
+            )
+            energy = np.concatenate(
+                [np.asarray(p.systems.potential_energy) for p in outputs]
+            )[order]
+            forces = np.concatenate(
+                [np.asarray(p.position_gradients) for p in outputs]
+            )[order]
+            positions = np.concatenate(
+                [np.asarray(p.particles.positions) for p in outputs]
+            )[order]
+            finite = (
+                np.isfinite(positions).all(axis=(1, 2))
+                & np.isfinite(energy)
+                & np.isfinite(forces).all(axis=(1, 2))
+            )
+            if not finite.all():
+                bad = np.flatnonzero(~finite)
+                print(
+                    json.dumps(
+                        dict(
+                            kind="invalid_results",
+                            mode=mode,
+                            ordinals=bad.tolist(),
+                            templates=choices[bad].tolist(),
+                            steps=steps[bad].tolist(),
+                        )
+                    ),
+                    flush=True,
+                )
+                raise AssertionError("Non-finite relaxation results")
+            fmax = np.linalg.norm(forces, axis=-1).max(axis=-1)
+            assert np.all((fmax < args.tolerance) | (steps == args.max_steps))
+            result = Measurement(steps, energy, positions)
+            if reference is None:
+                reference = result
+            position_error = float(np.max(np.abs(positions - reference.positions)))
+            energy_error = float(np.max(np.abs(energy - reference.energy)))
+            # Tolerate floating point reduction-order changes, not dropped or unfinished jobs.
+            if x64:
+                np.testing.assert_allclose(
+                    energy, reference.energy, rtol=1e-8, atol=1e-8
+                )
+                np.testing.assert_allclose(
+                    positions, reference.positions, rtol=1e-7, atol=1e-7
+                )
+            else:
+                np.testing.assert_allclose(
+                    energy, reference.energy, rtol=1e-4, atol=1e-4
+                )
+                np.testing.assert_allclose(
+                    positions, reference.positions, rtol=1e-3, atol=1e-3
+                )
+            print(
+                json.dumps(
+                    dict(
+                        kind="warmup" if trial == 0 else "measurement",
+                        mode=mode,
+                        trial=trial,
+                        seconds=elapsed,
+                        jobs_per_second=count / elapsed,
+                        callback_seconds=callback_seconds,
+                        host_cycles=cycles,
+                        evaluations=int(s.evaluations),
+                        useful_fraction=float(
+                            (steps + 1).sum() / (int(s.evaluations) * slots)
+                        ),
+                        step_quantiles=np.quantile(
+                            steps, [0, 0.5, 0.9, 0.99, 1]
+                        ).tolist(),
+                        capped=int((steps == args.max_steps).sum()),
+                        max_position_difference=position_error,
+                        max_energy_difference=energy_error,
+                        max_step_difference=int(
+                            np.max(np.abs(steps - reference.steps))
+                        ),
+                        memory=jax.devices()[0].memory_stats(),
+                    )
+                ),
+                flush=True,
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/relax_streaming.md
+++ b/benchmarks/results/relax_streaming.md
@@ -1,0 +1,150 @@
+# Streaming relaxation throughput — L4, 2026-09-08
+
+Streaming helps when convergence times differ, not merely because input is
+called a stream. This benchmark compares two refill policies over the same
+numerical propagator, optimizer, and shuffled inputs:
+
+- **Fixed:** retain a batch until every occupied slot completes.
+- **Streaming:** replace completed slots at the next host boundary.
+
+Both use JIT-compiled slot replacement, batched host snapshots, and bounded
+`LoopPropagator` blocks. No device queue, threads, or alternate numerical kernel.
+Thus the comparison isolates scheduling, rather than comparing against an
+intentionally slow fixed-batch implementation or against the full logging CLI.
+
+## Workload and validation
+
+NVIDIA L4; JAX 0.10.0; FP32; 108-atom periodic FCC argon structures;
+Lennard–Jones cutoff 5 Å; FIRE with a 0.2 Å `MaxStepSize`; force tolerance
+0.01 eV/Å; maximum 400 updates. Seed 20260908 shuffles repeated copies of 32
+templates. Their rattle amplitudes are 16 × 0.002, 8 × 0.03, 6 × 0.15, and
+2 × 0.35 Å. This deliberately broad mix includes initially converged structures.
+
+Each stream contains eight batches' worth of jobs. Every job must appear exactly
+once, return finite outputs, and meet the common force tolerance or the reported
+budget limit. In the measurements below **none hit the budget**, and energies,
+positions, and update counts matched the fixed-batch reference exactly. The
+update-count quantiles (min/median/p90/p99/max) were 0 / 7.5 / 42 / 123 / 123.
+
+Timings synchronize GPU completion and include refill, host/device transfers,
+and result snapshots. Initial CPU packing (~8–9 seconds), full-stream JIT warmup,
+and final NumPy result comparison are excluded. No file I/O or ML potential is
+timed. Template reuse is a controlled scheduling experiment, not a measurement
+of loading thousands of unique structures.
+
+## Follow-up: remove unnecessary image replication
+
+The capacity estimator rounded and applied its safety multiplier to candidate
+counts **before** weighting them by periodic images, then applied that multiplier
+again to the final image estimate. With this fixture's multiplier of 2, that
+produced 256 candidate rows but 512 image-candidate rows per particle, despite
+every system needing only one image. Unequal capacities selected the general
+replication pipeline instead of the existing minimum-image fast path.
+
+The fix accumulates the unrounded `candidates * images` estimate, then applies
+headroom and rounding once. Both capacities are now 256. This changes one
+production expression, adds no streaming-specific optimization, and retains
+runtime capacity assertions and repair for underestimated buffers.
+
+Same fixture and two post-warmup trials; fixed uses 32-step blocks and streaming
+uses eight-step blocks. "Before" is the initial measurement below, not a new
+fixed-batch baseline:
+
+| Slots | Streaming before (structures/s) | Streaming now (structures/s) | Improvement | Fixed now (structures/s) |
+| ---: | ---: | ---: | ---: | ---: |
+| 32 | 89.0 | 190.1 | 2.14× | 83.4 |
+| 128 | 68.5 | 340.2 | 4.97× | 125.5 |
+| 512 | 66.7 | 430.1 | 6.45× | 142.0 |
+
+At 512 slots (55,296 atoms; 4,096 completed jobs), streaming now takes 9.52
+seconds instead of 61.41. It remains 3.03× faster than the **also corrected**
+fixed-batch path. Peak live JAX allocation fell from about 2.16 GB to 0.55 GB.
+
+All jobs converged without hitting the budget. Within each rerun, fixed and
+streaming positions, energies, and iteration counts matched exactly; the
+iteration quantiles and evaluation counts also stayed the same as before.
+
+At 128 slots, four-step streaming reached 298.8 structures/s and 16-step
+streaming reached 348.0, versus 340.2 with eight steps. The small 16-step gain
+is not enough evidence for a universal default; the measured tradeoff has
+shifted as numerical work became cheaper. No scheduling defaults were changed.
+
+Regression tests cover minimum-image capacity equality with heterogeneous
+systems and safety multipliers both below and above one, plus single application
+of headroom when multiple images are needed. The neighbor-list and streaming
+tests also exercise periodic images, skewed cells, and capacity repair:
+428 neighbor-list/streaming tests and 28 ASE comparison tests passed. Strict
+Pyrefly checking passed for all changed Python files and the benchmark, without
+new suppressions.
+
+## Initial heterogeneous throughput (before capacity correction)
+
+Two measured trials after warmup. Rates use the mean elapsed time. Fixed batches
+use 32-step blocks; streaming uses eight-step blocks.
+
+| Slots | Atoms in batch | Jobs | Fixed structures/s | Streaming structures/s | Speedup |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 32 | 3,456 | 256 | 30.1 | 89.0 | 2.96× |
+| 128 | 13,824 | 1,024 | 20.8 | 68.5 | 3.30× |
+| 512 | 55,296 | 4,096 | 19.7 | 66.7 | 3.39× |
+
+At 128 slots, fixed batching performed 1,024 batch evaluations versus 296 for
+streaming. Useful slot-evaluations rose from 15.6% to 53.9%; the remaining waste
+includes within-block waiting and the final partially occupied tail. This is
+the intended benefit, not a change in the convergence criterion.
+
+More slots did not automatically improve absolute throughput for this particular
+LJ/neighbor-list pipeline. GPU utilization was around 99–100% during numerical
+work at 128 and 512 slots. The 512-slot process peaked at about 2.16 GB of live
+JAX allocations (about 3.26 GB in its allocator pool). Utilization alone does not identify the limiting
+kernel or establish an optimal batch size for another potential.
+
+## Initial block-size and equal-work controls
+
+At 32 slots, one-step streaming achieved 64.6 structures/s versus 89.0 with
+eight-step blocks. Host refill time fell from about 0.815 to 0.257 seconds per
+stream. At 128 slots, increasing streaming blocks from eight to 32 steps reduced
+throughput from 68.5 to 46.6 structures/s: the saved host calls did not compensate
+for keeping completed slots occupied longer. Eight is a useful measured setting
+for this fixture, not a hard-coded optimum.
+
+In the **equal-work control**, every structure was identical and needed 41
+updates. Fixed and streaming policies both used eight-step blocks and both
+performed 384 batch evaluations for 256 jobs: approximately 70.8 versus 70.6
+structures/s. There was no meaningful streaming advantage without a long tail.
+
+In an **all-inputs-need-work control** (`--minimum-rattle 0.03`), every structure
+needed 15–123 updates. At 32 slots, fixed batching achieved 30.1 structures/s
+versus 78.4 for streaming, a 2.61× gain. Results and iteration counts again
+matched exactly, with no capped jobs. The speedup therefore does not depend on
+including already-converged inputs.
+
+## Implementation and correctness follow-up
+
+The documented composition now uses bounded device blocks, skips numerical work
+on repair-only attempts and after exhaustion, JIT-compiles pure replacement, and
+transfers masks/snapshots in batches. These are existing kUPS abstractions.
+
+Hard inputs exposed two important correctness checks: use appropriate step
+control, and never count non-finite gradients as convergence. The convergence
+helper now promotes non-finite row norms before segment reduction and raises a
+runtime assertion for invalid active gradients. Padding stays excluded.
+Tests cover this, blocked refill/exhaustion, and preserving committed progress
+when a capacity repair occurs partway through a device block.
+
+## Reproduction
+
+From the repository root:
+
+```sh
+CUDA_VISIBLE_DEVICES=0 XLA_PYTHON_CLIENT_PREALLOCATE=false JAX_PLATFORMS=cuda,cpu JAX_ENABLE_X64=false .venv/bin/python benchmarks/bench_relax_streaming.py --slots 128 --waves 8 --trials 2 --modes fixed:32,stream:8,stream:32
+CUDA_VISIBLE_DEVICES=0 XLA_PYTHON_CLIENT_PREALLOCATE=false JAX_PLATFORMS=cuda,cpu JAX_ENABLE_X64=false .venv/bin/python benchmarks/bench_relax_streaming.py --slots 128 --waves 8 --trials 2 --modes fixed:32,stream:8,stream:4,stream:16
+CUDA_VISIBLE_DEVICES=0 XLA_PYTHON_CLIENT_PREALLOCATE=false JAX_PLATFORMS=cuda,cpu JAX_ENABLE_X64=false .venv/bin/python benchmarks/bench_relax_streaming.py --slots 512 --waves 8 --trials 2 --modes fixed:32,stream:8
+CUDA_VISIBLE_DEVICES=0 XLA_PYTHON_CLIENT_PREALLOCATE=false JAX_PLATFORMS=cuda,cpu JAX_ENABLE_X64=false .venv/bin/python benchmarks/bench_relax_streaming.py --slots 32 --waves 8 --trials 2 --modes fixed:8,stream:8 --homogeneous
+CUDA_VISIBLE_DEVICES=0 XLA_PYTHON_CLIENT_PREALLOCATE=false JAX_PLATFORMS=cuda,cpu JAX_ENABLE_X64=false .venv/bin/python benchmarks/bench_relax_streaming.py --slots 32 --waves 8 --trials 2 --modes fixed:32,stream:8 --minimum-rattle 0.03
+```
+
+The script emits JSONL containing timing, actual batch evaluations, useful-work
+fraction, convergence counts, result differences, and device memory statistics.
+For a real workflow, repeat with its potential, atom-count distribution, input
+adapter, and output requirements; do not extrapolate these rates to MLFFs.

--- a/docs/simulations.md
+++ b/docs/simulations.md
@@ -128,6 +128,9 @@ convergence. As in fixed-batch relaxation, choose appropriate optimizer controls
 
 The [streaming integration test](https://github.com/cusp-ai-oss/kUPS/blob/main/test/application/test_relax_streaming.py)
 shows a complete source, collector, and refill callback.
+`benchmarks/bench_relax_streaming.py` compares fixed batches and streaming on the
+same heterogeneous-convergence workload, with an equal-work control. Measure
+completed structures per second, not just latency of a fixed number of updates.
 
 ## Grand-Canonical Monte Carlo (GCMC)
 


### PR DESCRIPTION
> 🤖 *Auto-generated by Claude. Review and edit as needed.*

Added benchmark comparing streaming vs. fixed-batch relaxation policies on heterogeneous workloads to measure throughput when convergence times differ. Includes reference results on L4 GPU and documentation pointer.